### PR TITLE
fix: add JavaScript heap sort implementation to CodeDisplay

### DIFF
--- a/src/components/sortingAlgo/CodeDisplay.jsx
+++ b/src/components/sortingAlgo/CodeDisplay.jsx
@@ -492,7 +492,39 @@ int main() {
 }`,
   },
   heap: {
-    javascript: `
+    javascript: `function heapSort(arr) {
+  let n = arr.length;
+  for (let i = Math.floor(n / 2) - 1; i >= 0; i--) {
+    heapify(arr, n, i);
+  }
+  for (let i = n - 1; i > 0; i--) {
+    [arr[0], arr[i]] = [arr[i], arr[0]];
+    swapVisuals(0, i);
+    heapify(arr, i, 0);
+  }
+}
+function heapify(arr, n, i) {
+  let largest = i;
+  let left = 2 * i + 1;
+  let right = 2 * i + 2;
+  highlightPivot(i);
+  if (left < n && arr[left] > arr[largest]) {
+    largest = left;
+  }
+  if (right < n && arr[right] > arr[largest]) {
+    largest = right;
+  }
+  if (largest !== i) {
+    highlightActive(largest);
+    [arr[i], arr[largest]] = [arr[largest], arr[i]];
+    swapVisuals(i, largest);
+    dehighlightActive(largest);
+    dehighlightPivot(i);
+    heapify(arr, n, largest);
+  } else {
+    dehighlightPivot(i);
+  }
+}
 `,
     python: `def heap_sort(arr):
     n = len(arr)


### PR DESCRIPTION
## Summary
Adds the missing JavaScript implementation for Heap Sort in the Sorting Visualizer's CodeDisplay component.
## Changes
- Added `heapSort` and `heapify` functions to `codeSnippets.heap.javascript`
- Follows existing JS code style (camelCase helpers, destructuring swaps)
- Matches logic of existing Python/Java/C++ implementations
## Verification
- [x] `npm run lint` passes (0 errors/warnings)
- [x] `npm run build` succeeds
- [x] `npm run format:check` passes

Closes #3 