### PR TITLE
fix: Canvas reload fix

### DIFF
--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -130,7 +130,7 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1 }) => {
     return () => {
       network.destroy()
     }
-  }, [])
+  })
 
   useEffect(() => {
     if (networkRef.current) {

--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -130,7 +130,7 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1 }) => {
     return () => {
       network.destroy()
     }
-  }, [physics])
+  }, [])
 
   useEffect(() => {
     if (networkRef.current) {

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -129,7 +129,7 @@ export const CanvasShortestPath = ({
     return () => {
       network.destroy()
     }
-  }, [])
+  })
 
   useEffect(() => {
     if (networkRef.current) {

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -129,7 +129,7 @@ export const CanvasShortestPath = ({
     return () => {
       network.destroy()
     }
-  }, [physics])
+  }, [])
 
   useEffect(() => {
     if (networkRef.current) {


### PR DESCRIPTION
The canvas was reloading when physics was turned on as there the 'physics' state present in the dependency array