### PR TITLE
 implemented URL state persistence across all visualizers

### DIFF
--- a/src/components/arraySearch/Visualizer.jsx
+++ b/src/components/arraySearch/Visualizer.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
 
-// Step Generators and Source Resolvers
 import * as linear from '../../algorithms/searching/linearSearchSteps'
 import * as binary from '../../algorithms/searching/binarySearchSteps'
 
@@ -20,13 +20,26 @@ const createArray = (type) => {
 }
 
 export default function Visualizer({ algorithm }) {
-  // Use a key on this component in the parent to handle resets on algorithm change
+  const [searchParams, setSearchParams] = useSearchParams()
+  
   const [baseArray, setBaseArray] = useState(() => createArray(algorithm))
-  const [target, setTarget] = useState(() =>
-    algorithm === 'binarySearch' ? 37 : 30
-  )
+  const [target, setTarget] = useState(() => {
+    const urlTarget = searchParams.get('target')
+    if (urlTarget) return urlTarget
+    return algorithm === 'binarySearch' ? 37 : 30
+  })
   const [speed, setSpeed] = useState(1)
-  const [language, setLanguage] = useState('javascript')
+  const [language, setLanguage] = useState(() => {
+    return searchParams.get('lang') || 'javascript'
+  })
+
+  useEffect(() => {
+    const params = {}
+    if (target) params.target = target
+    if (language) params.lang = language
+    if (algorithm) params.algo = algorithm
+    setSearchParams(params, { replace: true })
+  }, [target, language, algorithm, setSearchParams])
 
   const {
     currentStep,

--- a/src/components/dataStructures/DSLayout.jsx
+++ b/src/components/dataStructures/DSLayout.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import StackIV from './stackIV'
 import QueueIV from './queueIV'
@@ -12,11 +13,21 @@ const tabs = [
 ]
 
 export const DSLayout = () => {
-  const [activeTab, setActiveTab] = useState('stack')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = searchParams.get('type') || 'stack'
+
+  const setActiveTab = (tabId) => {
+    setSearchParams({ type: tabId })
+  }
+
+  useEffect(() => {
+    if (!searchParams.get('type')) {
+      setSearchParams({ type: 'stack' }, { replace: true })
+    }
+  }, [searchParams, setSearchParams])
 
   return (
     <div className="w-full max-w-7xl mx-auto flex flex-col gap-6 text-slate-200">
-      {/* Internal Navigation Tabs */}
       <div className="flex flex-wrap gap-2 justify-center p-2 bg-slate-900/50 rounded-xl border border-white/5 backdrop-blur-sm">
         {tabs.map((tab) => (
           <button
@@ -41,7 +52,6 @@ export const DSLayout = () => {
         ))}
       </div>
 
-      {/* Main Visualization Canvas */}
       <div className="relative min-h-[600px] w-full bg-slate-950/80 rounded-2xl border border-slate-800 p-6 overflow-hidden shadow-2xl">
         <div className="absolute inset-0 bg-[linear-gradient(to_right,#1e293b_1px,transparent_1px),linear-gradient(to_bottom,#1e293b_1px,transparent_1px)] bg-[size:40px_40px] opacity-10 pointer-events-none"></div>
 

--- a/src/components/searchAlgo/MenuSelectAlgorithm.jsx
+++ b/src/components/searchAlgo/MenuSelectAlgorithm.jsx
@@ -1,8 +1,23 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 export const MenuSelectAlgorithm = ({ algorithm, setAlgorithm }) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  useEffect(() => {
+    const algoFromUrl = searchParams.get('algo')
+    const validAlgos = ['bfs', 'dfs']
+    
+    if (algoFromUrl && validAlgos.includes(algoFromUrl)) {
+      setAlgorithm(algoFromUrl)
+    }
+  }, [searchParams, setAlgorithm])
+
   const handleSelect = (algo) => {
     setAlgorithm(algo)
+    if (algo) {
+      setSearchParams({ algo: algo })
+    }
   }
 
   const getButtonClass = (algo) => {

--- a/src/components/shortestPathAlgo/MenuSetAlgoShortestPath.jsx
+++ b/src/components/shortestPathAlgo/MenuSetAlgoShortestPath.jsx
@@ -1,12 +1,31 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 export const MenuSetAlgoShortestPath = ({ setAlgorithm }) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  useEffect(() => {
+    const algoFromUrl = searchParams.get('algo')
+    const validAlgos = ['dijkstra', 'bellmanford', 'floydwarshall']
+    
+    if (algoFromUrl && validAlgos.includes(algoFromUrl)) {
+      setAlgorithm(algoFromUrl)
+    }
+  }, [searchParams, setAlgorithm])
+
   const handleChange = (e) => {
-    setAlgorithm(e.target.value)
+    const selected = e.target.value
+    setAlgorithm(selected)
+    if (selected) {
+      setSearchParams({ algo: selected })
+    } else {
+      setSearchParams({})
+    }
   }
 
   const handleReset = () => {
     setAlgorithm(null)
+    setSearchParams({})
   }
 
   return (
@@ -18,6 +37,7 @@ export const MenuSetAlgoShortestPath = ({ setAlgorithm }) => {
         <div className="w-full max-w-sm min-w-[200px]">
           <div className="relative">
             <select
+              value={searchParams.get('algo') || ''}
               onChange={handleChange}
               className="w-full bg-slate-800 placeholder:text-slate-500 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm focus:shadow-md appearance-none cursor-pointer"
             >

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
 
-// Step Generators and Source Resolvers
 import * as bubble from '../../algorithms/sorting/bubbleSortSteps'
 import * as selection from '../../algorithms/sorting/selectionSortSteps'
 import * as insertion from '../../algorithms/sorting/insertionSortSteps'
@@ -32,6 +32,7 @@ export default function Visualizer({ algorithmType }) {
   const [selectedAlgorithm, setSelectedAlgorithm] = useState('')
   const [speed, setSpeed] = useState(1)
   const [language, setLanguage] = useState('javascript')
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const {
     currentStep,
@@ -47,6 +48,13 @@ export default function Visualizer({ algorithmType }) {
     replay: replayPlayback,
     stepForward,
   } = useStepPlayback({ speed })
+
+  useEffect(() => {
+    const algoFromUrl = searchParams.get('algo')
+    if (algoFromUrl && algoMap[algoFromUrl]) {
+      setSelectedAlgorithm(algoFromUrl)
+    }
+  }, [])
 
   const algorithmOptions = {
     simple: ['bubble', 'selection', 'insertion'],
@@ -70,6 +78,7 @@ export default function Visualizer({ algorithmType }) {
   const handleReset = () => {
     clearPlayback()
     setSelectedAlgorithm('')
+    setSearchParams({})
     setBaseArray(createRandomArray())
   }
 
@@ -234,8 +243,14 @@ export default function Visualizer({ algorithmType }) {
   }
 
   const handleAlgorithmChange = (event) => {
+    const newAlgo = event.target.value
     clearPlayback()
-    setSelectedAlgorithm(event.target.value)
+    setSelectedAlgorithm(newAlgo)
+    if (newAlgo) {
+      setSearchParams({ algo: newAlgo })
+    } else {
+      setSearchParams({})
+    }
   }
 
   return (


### PR DESCRIPTION
### **Overview**
Closes #72. This PR implements URL state persistence across all main visualizer modules. By using `useSearchParams`, the app now synchronizes the user's selection (algorithms, target values, and tabs) with the URL query parameters.

### **Key Features**
* **Persistence on Refresh:** Selected algorithms and values stay active even after reloading the page.
* **Deep Linking:** users can now share direct links to specific algorithm states (e.g., a specific search target or a specific sorting method).
* **Global Coverage:** Applied to Sorting, Searching (Graph & Array), Shortest Path, and Data Structures (ADT).

### **Evidence & Screenshots**

**1. Sorting Visualizer (`?algo=bubble`)**
<img width="1600" height="797" alt="buublesort" src="https://github.com/user-attachments/assets/2a6070d7-a4c7-4f39-af0f-67a78124c9b8" />

**2. Graph Search (`?algo=bfs`)**
<img width="1600" height="803" alt="breadthfirstsearch" src="https://github.com/user-attachments/assets/03ccaaa4-778a-4844-ac8a-50bf24c359f9" />

**3. Array Search (`?target=99&lang=javascript`)**
<img width="1600" height="785" alt="arraysearch" src="https://github.com/user-attachments/assets/af316d8b-3f5e-4e0f-8912-618758fd6053" />

**4. Shortest Path (`?algo=dijkstra`)**
<img width="1600" height="768" alt="shortestpath" src="https://github.com/user-attachments/assets/3b1084b5-c52b-4dd5-9ed2-c546be37ea33" />

**5. Data Structures / ADT (`?type=tree`)**
<img width="1600" height="640" alt="binarytree" src="https://github.com/user-attachments/assets/59e9291b-8fe7-48a8-970d-8ab69577e69f" />

**Verification**
I have manually verified that navigating to these URLs directly loads the correct component state and that the browser back/forward buttons work as expected with the new search params.