### PR TITLE
docs: add initial CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Created `CHANGELOG.md` to track project updates.
+- Added URL state persistence for all algorithm visualizers.
+- Integrated `useSearchParams` so users can share links to specific algorithms.
+
+### Fixed
+- Fixed the double-rendering bug in the sorting visualizer components.
+- Fixed linting errors caused by unescaped characters in selection menus.
+- Improved rendering performance across the main dashboard.
+
+## [1.2.0] - 2026-05-15
+### Added
+- Core logic for Sorting and Searching visualizers.
+- Dark mode support with Tailwind CSS.
+- Playback controls for speed and step-by-step execution.
+
+## [1.0.0] - 2026-01-15
+### Added
+- Initial repository setup and project structure.


### PR DESCRIPTION
I have added the CHANGELOG.md file to the project root as discussed in the issue. This file follows the "Keep a Changelog" format to help contributors and users track version history and new feature additions.

The initial content includes recent updates regarding URL state persistence and general bug fixes for the visualizers.

Issue #74 