### PR TITLE
fix: reset source and target dropdowns in pathfinding module

### DIFF
--- a/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
+++ b/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
@@ -1,12 +1,25 @@
-import React from 'react'
+import React, { useState } from 'react'
 
-export const MenuSelectNodesShortestPath = ({ setSource, setTarget }) => {
-  const handleChangeSource = (e) => setSource(e.target.value)
-  const handleChangeTarget = (e) => setTarget(e.target.value)
+export const MenuSelectNodesShortestPath = ({ setSource, setTarget, onReset }) => {
+  const [sourceValue, setSourceValue] = useState('')
+  const [targetValue, setTargetValue] = useState('')
+
+  const handleChangeSource = (e) => {
+    setSourceValue(e.target.value)
+    setSource(e.target.value)
+  }
+
+  const handleChangeTarget = (e) => {
+    setTargetValue(e.target.value)
+    setTarget(e.target.value)
+  }
 
   const handleReset = () => {
+    setSourceValue('')   
+    setTargetValue('')   
     setSource(null)
     setTarget(null)
+    if (onReset) onReset()
   }
 
   return (
@@ -18,29 +31,17 @@ export const MenuSelectNodesShortestPath = ({ setSource, setTarget }) => {
         <div className="w-full max-w-sm min-w-[200px]">
           <div className="relative">
             <select
+              value={sourceValue}
               onChange={handleChangeSource}
               className="w-full bg-slate-800 placeholder:text-slate-500 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm focus:shadow-md appearance-none cursor-pointer"
             >
               <option value="">Choose Source</option>
               {Array.from({ length: 9 }, (_, i) => i + 1).map((element) => (
-                <option key={element} value={element}>
-                  {element}
-                </option>
+                <option key={element} value={element}>{element}</option>
               ))}
             </select>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.2"
-              stroke="currentColor"
-              className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
-              />
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.2" stroke="currentColor" className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
             </svg>
           </div>
         </div>
@@ -48,29 +49,17 @@ export const MenuSelectNodesShortestPath = ({ setSource, setTarget }) => {
         <div className="w-full max-w-sm min-w-[200px]">
           <div className="relative">
             <select
+              value={targetValue}
               onChange={handleChangeTarget}
               className="w-full bg-slate-800 placeholder:text-slate-500 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm focus:shadow-md appearance-none cursor-pointer"
             >
               <option value="">Choose Target</option>
               {Array.from({ length: 9 }, (_, i) => i + 1).map((element) => (
-                <option key={element} value={element}>
-                  {element}
-                </option>
+                <option key={element} value={element}>{element}</option>
               ))}
             </select>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="1.2"
-              stroke="currentColor"
-              className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
-              />
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.2" stroke="currentColor" className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
             </svg>
           </div>
         </div>

--- a/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
+++ b/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react'
 
-export const MenuSelectNodesShortestPath = ({ setSource, setTarget, onReset }) => {
+export const MenuSelectNodesShortestPath = ({
+  setSource,
+  setTarget,
+  onReset,
+}) => {
   const [sourceValue, setSourceValue] = useState('')
   const [targetValue, setTargetValue] = useState('')
 
@@ -15,8 +19,8 @@ export const MenuSelectNodesShortestPath = ({ setSource, setTarget, onReset }) =
   }
 
   const handleReset = () => {
-    setSourceValue('')   
-    setTargetValue('')   
+    setSourceValue('')
+    setTargetValue('')
     setSource(null)
     setTarget(null)
     if (onReset) onReset()
@@ -37,11 +41,24 @@ export const MenuSelectNodesShortestPath = ({ setSource, setTarget, onReset }) =
             >
               <option value="">Choose Source</option>
               {Array.from({ length: 9 }, (_, i) => i + 1).map((element) => (
-                <option key={element} value={element}>{element}</option>
+                <option key={element} value={element}>
+                  {element}
+                </option>
               ))}
             </select>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.2" stroke="currentColor" className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.2"
+              stroke="currentColor"
+              className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+              />
             </svg>
           </div>
         </div>
@@ -55,11 +72,24 @@ export const MenuSelectNodesShortestPath = ({ setSource, setTarget, onReset }) =
             >
               <option value="">Choose Target</option>
               {Array.from({ length: 9 }, (_, i) => i + 1).map((element) => (
-                <option key={element} value={element}>{element}</option>
+                <option key={element} value={element}>
+                  {element}
+                </option>
               ))}
             </select>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.2" stroke="currentColor" className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.2"
+              stroke="currentColor"
+              className="h-5 w-5 ml-1 absolute top-3.5 right-4 text-slate-400 pointer-events-none"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+              />
             </svg>
           </div>
         </div>

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -19,10 +19,9 @@ export const ShortestPathPage = () => {
     setSpeed(newValue)
   }
 
-
   const handleResetNodes = () => {
-  setSource(null)
-  setTarget(null)
+    setSource(null)
+    setTarget(null)
   }
 
   const currentSource = useMemo(() => {

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -19,6 +19,12 @@ export const ShortestPathPage = () => {
     setSpeed(newValue)
   }
 
+
+  const handleResetNodes = () => {
+  setSource(null)
+  setTarget(null)
+  }
+
   const currentSource = useMemo(() => {
     if (!algorithm || !shortestPathSources[algorithm]) return null
     return shortestPathSources[algorithm][language]?.code ?? ''
@@ -49,6 +55,7 @@ export const ShortestPathPage = () => {
         <MenuSelectNodesShortestPath
           setSource={setSource}
           setTarget={setTarget}
+          onReset={handleResetNodes}
         />
         <div className="m-auto w-full">
           <SpeedSlider value={speed} onChange={handleSpeedChange} />


### PR DESCRIPTION
## Changes Made
- Added controlled state (`sourceValue`, `targetValue`) to 
  `MenuSelectNodesShortestPath.jsx` so dropdowns can be 
  programmatically reset
- Added `onReset` prop to the component
- Added `handleResetNodes` in `ShortestPathPage.jsx` and 
  passed it as `onReset` prop


## Fix
Reset button now correctly clears both Source & Target 
dropdowns back to "Choose Source" / "Choose Target"
[Dijkstra Shortest Path _ AlgoScope - Google Chrome 2026-05-15 16-35-29.zip](https://github.com/user-attachments/files/27798740/Dijkstra.Shortest.Path._.AlgoScope.-.Google.Chrome.2026-05-15.16-35-29.zip)
(video)
Fixes #79