### PR TITLE
fix: reset starting node dropdown in search module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Created `CHANGELOG.md` to track project updates.
 - Added URL state persistence for all algorithm visualizers.
 - Integrated `useSearchParams` so users can share links to specific algorithms.
 
 ### Fixed
+
 - Fixed the double-rendering bug in the sorting visualizer components.
 - Fixed linting errors caused by unescaped characters in selection menus.
 - Improved rendering performance across the main dashboard.
 
 ## [1.2.0] - 2026-05-15
+
 ### Added
+
 - Core logic for Sorting and Searching visualizers.
 - Dark mode support with Tailwind CSS.
 - Playback controls for speed and step-by-step execution.
 
 ## [1.0.0] - 2026-01-15
+
 ### Added
+
 - Initial repository setup and project structure.

--- a/src/components/searchAlgo/MenuSelectNodeSearch.jsx
+++ b/src/components/searchAlgo/MenuSelectNodeSearch.jsx
@@ -1,11 +1,15 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 export const MenuSelectNodeSearch = ({ setNode }) => {
+  const [nodeValue, setNodeValue] = useState('')
+
   const handleChange = (e) => {
+    setNodeValue(e.target.value)
     setNode(e.target.value)
   }
 
   const handleReset = () => {
+    setNodeValue('')
     setNode(null)
   }
 
@@ -18,6 +22,7 @@ export const MenuSelectNodeSearch = ({ setNode }) => {
         <div className="w-full ma-w-sm min-w-[200px]">
           <div className="relative">
             <select
+              value={nodeValue}
               onChange={handleChange}
               className="w-full bg-slate-800 placeholder:text-slate-500 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm focus:shadow-md appearance-none cursor-pointer"
             >


### PR DESCRIPTION
## Changes Made
- Added controlled state (`nodeValue`) to `MenuSelectNodeSearch.jsx` 
  so the dropdown can be programmatically reset
- Added `value={nodeValue}` to make it a controlled component

## Fix
Reset button now correctly clears the Starting Node dropdown 
back to "Choose a Starting Node"

## Related
- Follows same fix pattern as #84 (Pathfinding module)
- Requested by @Bimbok in PR #84 review

Fixes #86