### PR TITLE
feat: add close (X) button to search modal

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -243,9 +243,19 @@ const SearchBar = () => {
                   type="text"
                   value={query}
                   onChange={handleSearch}
-                  className="w-full bg-transparent text-slate-200 text-lg block pl-12 pr-4 py-2 outline-none"
+                  className="w-full bg-transparent text-slate-200 text-lg block pl-12 pr-12 py-2 outline-none"
                   placeholder="Search algorithms..."
                 />
+                {/* Close Button */}
+                <button
+                  onClick={() => setIsModalOpen(false)}
+                  className="absolute right-4 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/10 transition-all duration-200"
+                  aria-label="Close search"
+                >
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
               </div>
 
               {/* Results */}


### PR DESCRIPTION
Added a visible close button (X icon) to the top-right corner of the search modal for better UX. Users can now close the search section by clicking the X button, in addition to the existing Escape key and backdrop click methods.