### PR TITLE
feat: move Practice button from Navbar to hero CTA

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -113,7 +113,7 @@ export const Home = () => {
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ delay: 0.5, duration: 0.5 }}
-            className="pt-8"
+            className="pt-8 flex flex-wrap items-center justify-center gap-4"
           >
             <a
               href="#explore"
@@ -126,6 +126,12 @@ export const Home = () => {
               className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-white transition-all duration-200 bg-white/5 border border-white/10 rounded-lg hover:bg-white/10 hover:scale-105 hover:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-cyan-500"
             >
               Start Exploring
+            </a>
+            <a
+              href="/practice"
+              className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-white transition-all duration-200 bg-emerald-600/80 border border-emerald-500/40 rounded-lg hover:bg-emerald-500 hover:scale-105 hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+            >
+              Practice
             </a>
           </motion.div>
         </motion.div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -78,9 +78,8 @@ export const Navbar = () => {
     { name: 'Search', href: '/search' },
     { name: 'Shortest Path', href: '/spath' },
     { name: 'Sort', href: '/sort' },
+    { name: 'About', href: '/about' },
   ]
-
-  const navLinks = [{ name: 'Practice', href: '/practice' }]
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-slate-950/50 backdrop-blur supports-[backdrop-filter]:bg-slate-950/40 rounded-xl shadow-2xl">
@@ -115,31 +114,17 @@ export const Navbar = () => {
                     <Link
                       key={link.name}
                       to={link.href}
-                      className={`block rounded-lg px-4 py-2 text-sm transition-all ${
-                        pathname === link.href
-                          ? 'bg-indigo-500/20 text-indigo-300'
-                          : 'text-slate-300 hover:bg-white/5 hover:text-white'
-                      }`}
+                      className={`block rounded-lg px-4 py-2 text-sm transition-all ${pathname === link.href
+                        ? 'bg-indigo-500/20 text-indigo-300'
+                        : 'text-slate-300 hover:bg-white/5 hover:text-white'
+                        }`}
                     >
                       {link.name}
                     </Link>
                   ))}
                 </div>
               </li>
-              {navLinks.map((link) => (
-                <li key={link.name}>
-                  <Link
-                    to={link.href}
-                    className={`block rounded-lg px-4 py-2 text-sm font-medium transition-all duration-200 ${
-                      pathname === link.href
-                        ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40 font-semibold'
-                        : 'text-slate-400 hover:text-white hover:bg-white/5'
-                    }`}
-                  >
-                    {link.name}
-                  </Link>
-                </li>
-              ))}
+
             </ul>
             <Link
               to="https://github.com/algoscope-hq/AlgoScope"
@@ -223,17 +208,16 @@ export const Navbar = () => {
                 <SearchBar />
               </div>
               <ul className="space-y-2">
-                {[...algorithmLinks, ...navLinks].map((link) => (
+                {algorithmLinks.map((link) => (
                   // Animate each link
                   <motion.li key={link.name} variants={menuItemVariants}>
                     <Link
                       to={link.href}
                       onClick={() => setOpen(false)}
-                      className={`block rounded-xl px-4 py-3 text-base font-medium transition-all ${
-                        pathname === link.href
-                          ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40 font-semibold'
-                          : 'text-slate-400 hover:text-white hover:bg-white/5'
-                      }`}
+                      className={`block rounded-xl px-4 py-3 text-base font-medium transition-all ${pathname === link.href
+                        ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/40 font-semibold'
+                        : 'text-slate-400 hover:text-white hover:bg-white/5'
+                        }`}
                     >
                       {link.name}
                     </Link>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,14 +1,18 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { ClerkProvider } from '@clerk/clerk-react'
 import './input.css'
 import App from './App.jsx'
-import { ClerkProvider } from '@clerk/clerk-react'
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
+if (!PUBLISHABLE_KEY) {
+  throw new Error('Missing Publishable Key')
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
+    <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/">
       <App />
     </ClerkProvider>
   </StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,18 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { ClerkProvider } from '@clerk/clerk-react'
 import './input.css'
 import App from './App.jsx'
+import { ClerkProvider } from '@clerk/clerk-react'
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
 
-if (!PUBLISHABLE_KEY) {
-  throw new Error('Missing Publishable Key')
-}
-
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/">
+    <ClerkProvider publishableKey={PUBLISHABLE_KEY}>
       <App />
     </ClerkProvider>
   </StrictMode>


### PR DESCRIPTION
What & Why
Moves the Practice button out of the Navbar and into the landing page 
hero section as a primary CTA, next to Start Exploring.

Closes #60 

Changes
- Navbar.jsx: removed `navLinks` array and Practice link from desktop nav and mobile menu
- Home.jsx: wrapped CTA in flex gap-4, added emerald Practice button

<img width="1506" height="727" alt="Screenshot 2026-05-16 173041" src="https://github.com/user-attachments/assets/30267884-bfeb-4f2a-bc15-b60fe4c312ad" />

