### PR TITLE
fix: align search bar vertically in Navbar with items-center

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -100,7 +100,7 @@ export const Navbar = () => {
           </Link>
 
           {/* Desktop Search */}
-          <div className="hidden md:flex flex-1 justify-center max-w-xs mx-4">
+          <div className="hidden md:flex flex-1 items-center justify-center max-w-xs mx-4">
             <SearchBar />
           </div>
 


### PR DESCRIPTION
Summary:
Fixes the horizontal positioning of the search bar in the Navbar by adding items-center to the desktop search bar container div, ensuring it aligns vertically with the logo, links, and buttons.
Changes:

Added items-center class to the desktop search bar wrapper in src/components/Navbar.jsx