### PR TITLE
Search Bar not includes Kadane's algo (#132)

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -67,6 +67,13 @@ const ALGORITHMS = [
     category: 'Array Search',
     route: '/ldssearch',
   },
+  {
+    id: 'kadane',
+    name: "Kadane's Algorithm",
+    category: 'Dynamic Programming',
+    route: '/kadane',
+    keywords: ['kadane', 'maximum subarray', 'max subarray', 'dynamic programming'],
+  },
   // ADTs
   { id: 'stack', name: 'Stack', category: 'Data Structures', route: '/adt' },
   { id: 'queue', name: 'Queue', category: 'Data Structures', route: '/adt' },
@@ -97,7 +104,7 @@ const SearchBar = () => {
   // Initialize Fuse.js
   const fuse = useMemo(() => {
     return new Fuse(ALGORITHMS, {
-      keys: ['name', 'category'],
+      keys: ['name', 'category','keywords'],
       threshold: 0.4,
       includeMatches: true,
     })


### PR DESCRIPTION
Fixes #132

Changes
- Added Kadane's Algorithm to the `ALGORITHMS` array in `SearchBar.jsx` with route `/kadane`
- Added `keywords` field with aliases (`kadane`, `maximum subarray`, `max subarray`, `dynamic programming`)
- Updated Fuse.js config to also search the `keywords` field for better discoverability

Testing
- Searching "kadane" now returns Kadane's Algorithm
- Searching "maximum subarray" also returns the result
- Clicking the result navigates correctly to `/kadane`