### PR TITLE
Fixed Brightness Saturation Level of Practice Button

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -129,7 +129,7 @@ export const Home = () => {
             </a>
             <a
               href="/practice"
-              className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-white transition-all duration-200 bg-emerald-600/80 border border-emerald-500/40 rounded-lg hover:bg-emerald-500 hover:scale-105 hover:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+             className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-emerald-300 transition-all duration-200 bg-emerald-500/[0.06] border border-emerald-400/30 rounded-lg backdrop-blur-md hover:text-emerald-100 hover:bg-emerald-500/10 hover:border-emerald-400/60 hover:scale-105 hover:shadow-[0_0_20px_rgba(52,211,153,0.15)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
             >
               Practice
             </a>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -129,7 +129,7 @@ export const Home = () => {
             </a>
             <a
               href="/practice"
-             className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-emerald-300 transition-all duration-200 bg-emerald-500/[0.06] border border-emerald-400/30 rounded-lg backdrop-blur-md hover:text-emerald-100 hover:bg-emerald-500/10 hover:border-emerald-400/60 hover:scale-105 hover:shadow-[0_0_20px_rgba(52,211,153,0.15)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+              className="inline-flex items-center justify-center px-8 py-4 text-base font-bold text-emerald-300 transition-all duration-200 bg-emerald-500/[0.06] border border-emerald-400/30 rounded-lg backdrop-blur-md hover:text-emerald-100 hover:bg-emerald-500/10 hover:border-emerald-400/60 hover:scale-105 hover:shadow-[0_0_20px_rgba(52,211,153,0.15)] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
             >
               Practice
             </a>


### PR DESCRIPTION
## fix: Restyle `Practice` button to match AlgoScope's glassmorphism aesthetic

### Summary
The `Practice` button in the hero CTA section of `Home.jsx` was visually inconsistent with the rest of AlgoScope's cyber/dark neon design system. It used a heavy solid `emerald-600` fill that made it feel disconnected from the glassmorphism aesthetic used throughout the platform — particularly when placed alongside the `Start Exploring` button.

This PR replaces the solid background with a glassmorphism treatment that brings the button in line with the existing design language.

---

### Changes
**File modified:** `src/components/Home.jsx`

| Property | Before | After |
|---|---|---|
| Background | `bg-emerald-600/80` (heavy solid fill) | `bg-emerald-500/[0.06]` (subtle tint) |
| Text color | `text-white` | `text-emerald-300` (neon accent) |
| Border | `border-emerald-500/40` | `border-emerald-400/30` |
| Hover background | `hover:bg-emerald-500` (full solid) | `hover:bg-emerald-500/10` (glass brighten) |
| Hover border | `hover:border-emerald-400` (full opacity) | `hover:border-emerald-400/60` (glow) |
| Hover shadow | none | `hover:shadow-[0_0_20px_rgba(52,211,153,0.15)]` (neon glow) |
| Backdrop blur | none | `backdrop-blur-md` (glassmorphism depth) |

---

### Before & After
- **Before:** Solid green button, visually dominant, breaks the cyber aesthetic
- **After:** Glassmorphism border-glow button, cohesive with `Start Exploring` and AlgoScope's neon dark theme

---

### Testing
- [ ] Hero section renders correctly on mobile and desktop
- [ ] `Practice` button hover state shows neon glow
- [ ] Both CTA buttons feel visually balanced side by side
- [ ] No regressions in routing or functionality (`href="/practice"` unchanged)
Before:- <img width="947" height="508" alt="Screenshot 2026-05-17 152927" src="https://github.com/user-attachments/assets/74902b80-f0d9-4e40-aea7-6a75a75d1863" />

After:- <img width="947" height="509" alt="Screenshot 2026-05-17 153558" src="https://github.com/user-attachments/assets/66004a24-65ec-42fc-85c7-bc85ab011d4f" />
