### PR TITLE
feat: add +/- precision buttons to speed control slider

### DIFF
--- a/src/components/SpeedSlider.jsx
+++ b/src/components/SpeedSlider.jsx
@@ -20,6 +20,52 @@ const SpeedSlider = memo(function SpeedSlider({
     audio.play().catch(() => {})
     onChange(event, newValue)
   }
+
+  const handleDecrease = () => {
+    const newValue = Number((value - 0.1).toFixed(1))
+    if (newValue >= min) {
+      audio.currentTime = 0
+      audio.play().catch(() => {})
+      onChange(null, newValue)
+    }
+  }
+
+  const handleIncrease = () => {
+    const newValue = Number((value + 0.1).toFixed(1))
+    if (newValue <= max) {
+      audio.currentTime = 0
+      audio.play().catch(() => {})
+      onChange(null, newValue)
+    }
+  }
+
+  const buttonSx = {
+    width: 32,
+    height: 32,
+    flexShrink: 0,
+    borderRadius: '8px',
+    border: '1px solid #22d3ee',
+    background: 'rgba(34, 211, 238, 0.1)',
+    color: '#22d3ee',
+    fontSize: '18px',
+    fontWeight: 'bold',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: 'all 0.15s ease',
+    '&:hover:not(:disabled)': {
+      background: 'rgba(34, 211, 238, 0.25)',
+      boxShadow: '0 0 8px rgba(34, 211, 238, 0.4)',
+    },
+    '&:disabled': {
+      opacity: 0.3,
+      cursor: 'not-allowed',
+      borderColor: '#94a3b8',
+      color: '#94a3b8',
+    },
+  }
+
   return (
     <Box
       sx={{
@@ -33,53 +79,75 @@ const SpeedSlider = memo(function SpeedSlider({
         width: '100%',
       }}
     >
-      <Slider
-        value={value}
-        onChange={handleChange}
-        valueLabelDisplay="auto"
-        step={step}
-        marks
-        min={min}
-        max={max}
-        // 2. Custom styling for the slider itself
-        sx={{
-          height: 8,
-          '& .MuiSlider-track': {
-            border: 'none',
-            // 3. The sexy gradient track
-            background: sliderGradient,
-          },
-          '& .MuiSlider-thumb': {
-            height: 24,
-            width: 24,
-            backgroundColor: '#0f172a', // slate-900
-            border: '2px solid #22d3ee', // cyan-400
-            // 4. The "glow" effect on hover/focus
-            '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
-              boxShadow: '0 0 0 8px rgba(34, 211, 238, 0.15)', // cyan-400 with 15% opacity
-            },
-            '&:before': {
-              display: 'none', // Removes default Mui ripple
-            },
-          },
-          '& .MuiSlider-valueLabel': {
-            // 5. Styled tooltip
-            background: '#0f172a', // slate-900
-            border: '1px solid #334155', // slate-700
-            borderRadius: '8px',
-            padding: '4px 8px',
-            color: '#22d3ee', // cyan-400
-          },
-          '& .MuiSlider-rail': {
-            opacity: 0.3,
-            backgroundColor: '#94a3b8', // slate-400
-          },
-          '& .MuiSlider-mark': {
-            backgroundColor: '#94a3b8',
-            opacity: 0.5,
-          },
-        }}
-      />
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <Box
+          component="button"
+          onClick={handleDecrease}
+          disabled={value <= min}
+          sx={buttonSx}
+          aria-label="Decrease speed"
+        >
+          −
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Slider
+            value={value}
+            onChange={handleChange}
+            valueLabelDisplay="auto"
+            step={step}
+            marks
+            min={min}
+            max={max}
+            // 2. Custom styling for the slider itself
+            sx={{
+              height: 8,
+              '& .MuiSlider-track': {
+                border: 'none',
+                // 3. The sexy gradient track
+                background: sliderGradient,
+              },
+              '& .MuiSlider-thumb': {
+                height: 24,
+                width: 24,
+                backgroundColor: '#0f172a', // slate-900
+                border: '2px solid #22d3ee', // cyan-400
+                // 4. The "glow" effect on hover/focus
+                '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+                  boxShadow: '0 0 0 8px rgba(34, 211, 238, 0.15)', // cyan-400 with 15% opacity
+                },
+                '&:before': {
+                  display: 'none', // Removes default Mui ripple
+                },
+              },
+              '& .MuiSlider-valueLabel': {
+                // 5. Styled tooltip
+                background: '#0f172a', // slate-900
+                border: '1px solid #334155', // slate-700
+                borderRadius: '8px',
+                padding: '4px 8px',
+                color: '#22d3ee', // cyan-400
+              },
+              '& .MuiSlider-rail': {
+                opacity: 0.3,
+                backgroundColor: '#94a3b8', // slate-400
+              },
+              '& .MuiSlider-mark': {
+                backgroundColor: '#94a3b8',
+                opacity: 0.5,
+              },
+            }}
+          />
+        </Box>
+        <Box
+          component="button"
+          onClick={handleIncrease}
+          disabled={value >= max}
+          sx={buttonSx}
+          aria-label="Increase speed"
+        >
+          +
+        </Box>
+      </Box>
       {/* 6. Styled text below */}
       <p className="text-center text-cyan-400 font-mono text-sm mt-2 font-bold tracking-wide">
         SPEED: {value.toFixed(1)}x


### PR DESCRIPTION
- Add '-' button left of slider and '+' button right of slider
- Clicking '+' increases speed by 0.1, '-' decreases by 0.1
- Buttons disabled at min/max boundaries (no out-of-range values)
- Used Number((value +/- 0.1).toFixed(1)) to fix JS floating point issues
- Buttons styled consistently with existing glassmorphism/cyan-400 UI

Closes #87