### PR TITLE
fix(ui): adjust vertical spacing for status display banner

### DIFF
--- a/src/components/kadaneAlgo/CanvasKadane.jsx
+++ b/src/components/kadaneAlgo/CanvasKadane.jsx
@@ -116,9 +116,9 @@ export const CanvasKadane = ({ numbers, speed }) => {
         </div>
       </div>
 
-<div className="mt-8 mb-2">
-  <StatusDisplay message={displayStatus} />
-</div>
+      <div className="mt-8 mb-2">
+        <StatusDisplay message={displayStatus} />
+      </div>
     </div>
   )
 }

--- a/src/components/kadaneAlgo/CanvasKadane.jsx
+++ b/src/components/kadaneAlgo/CanvasKadane.jsx
@@ -116,9 +116,9 @@ export const CanvasKadane = ({ numbers, speed }) => {
         </div>
       </div>
 
-      <div className="mt-4">
-        <StatusDisplay message={displayStatus} />
-      </div>
+<div className="mt-8 mb-2">
+  <StatusDisplay message={displayStatus} />
+</div>
     </div>
   )
 }

--- a/src/components/mooreVotingAlgo/CanvasMooreVoting.jsx
+++ b/src/components/mooreVotingAlgo/CanvasMooreVoting.jsx
@@ -100,9 +100,9 @@ export const CanvasMooreVoting = ({ numbers, speed }) => {
         </div>
       </div>
 
-<div className="mt-8 mb-2">
-  <StatusDisplay message={displayStatus} />
-</div>
+      <div className="mt-8 mb-2">
+        <StatusDisplay message={displayStatus} />
+      </div>
     </div>
   )
 }

--- a/src/components/mooreVotingAlgo/CanvasMooreVoting.jsx
+++ b/src/components/mooreVotingAlgo/CanvasMooreVoting.jsx
@@ -100,9 +100,9 @@ export const CanvasMooreVoting = ({ numbers, speed }) => {
         </div>
       </div>
 
-      <div className="mt-4">
-        <StatusDisplay message={displayStatus} />
-      </div>
+<div className="mt-8 mb-2">
+  <StatusDisplay message={displayStatus} />
+</div>
     </div>
   )
 }


### PR DESCRIPTION
### Overview
Balances the vertical layout spacing for the informational text banner (`"Enter array and start visualization."`) across the algorithm visualizer pages. 

Closes #165 

### Files Changed
- `src/components/kadaneAlgo/CanvasKadane.jsx`
- `src/components/mooreVotingAlgo/CanvasMooreVoting.jsx`

### Verification
<img width="538" height="217" alt="Screenshot 2026-05-18 at 7 39 18 AM" src="https://github.com/user-attachments/assets/e188a756-564f-4372-90fa-633732dfd4f7" />
