### PR TITLE
feat: dynamically display Ctrl/Enter or ⌘/Return based on user OS

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -143,6 +143,15 @@ const SearchBar = () => {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState([])
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [isMac] = useState(() => {
+    if (typeof window === 'undefined') return false
+    const platform =
+      navigator.userAgentData?.platform || navigator.platform || ''
+    return (
+      platform.toLowerCase().includes('mac') ||
+      navigator.userAgent.toLowerCase().includes('macintosh')
+    )
+  })
 
   const inputRef = useRef(null)
   const navigate = useNavigate()
@@ -250,7 +259,7 @@ const SearchBar = () => {
           Search...
         </span>
         <div className="ml-auto hidden lg:flex items-center gap-1 opacity-40 group-hover:opacity-100 transition-opacity">
-          <kbd className="text-[10px] font-sans">⌘</kbd>
+          <kbd className="text-[10px] font-sans">{isMac ? '⌘' : 'Ctrl'}</kbd>
           <kbd className="text-[10px] font-sans">K</kbd>
         </div>
       </button>
@@ -347,7 +356,7 @@ const SearchBar = () => {
                         <div className="flex items-center gap-2">
                           {index === selectedIndex && (
                             <span className="text-[10px] text-slate-500 border border-slate-700 px-1 rounded bg-slate-800">
-                              Enter
+                              {isMac ? 'Return' : 'Enter'}
                             </span>
                           )}
                           <svg
@@ -393,7 +402,7 @@ const SearchBar = () => {
                   </span>
                   <span className="flex items-center gap-1">
                     <kbd className="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-800">
-                      Enter
+                      {isMac ? 'Return' : 'Enter'}
                     </kbd>{' '}
                     Select
                   </span>


### PR DESCRIPTION
### Description
Closes #175

This PR resolves the issue where `⌘` and `Enter` were hardcoded for all users. The shortcut hints now adapt dynamically to match the user's operating system environment.

### Changes
- Shows `⌘ K` and `Return` for macOS users.
- Shows `Ctrl K` and `Enter` for Windows and Linux users.

### Additionals
Tested on both MacOS and Windows. I am a GSSoC contributor. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SearchBar now displays platform-appropriate keyboard shortcuts. macOS users will see the Command symbol (⌘) and Return key, while other platforms display Ctrl and Enter labels, ensuring accurate keyboard hints for each operating system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->