### PR TITLE
fix(search): reset query and results state on modal close

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -195,6 +195,12 @@ const SearchBar = () => {
     [navigate]
   )
 
+  const handleCloseModal = () => {
+    setIsModalOpen(false)
+    setQuery('')
+    setResults([])
+  }
+
   // Handle Keyboard Shortcuts
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -221,7 +227,7 @@ const SearchBar = () => {
           handleSelect(results[selectedIndex].item.route)
         }
       } else if (e.key === 'Escape') {
-        setIsModalOpen(false)
+        handleCloseModal()
       }
     }
 
@@ -279,7 +285,7 @@ const SearchBar = () => {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              onClick={() => setIsModalOpen(false)}
+              onClick={handleCloseModal}
               className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm"
             />
 
@@ -316,7 +322,7 @@ const SearchBar = () => {
                 />
                 {/* Close Button */}
                 <button
-                  onClick={() => setIsModalOpen(false)}
+                  onClick={handleCloseModal}
                   className="absolute right-4 top-1/2 -translate-y-1/2 p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/10 transition-all duration-200"
                   aria-label="Close search"
                 >


### PR DESCRIPTION
Closes #185 

There was a state persistence/caching bug inside the `SearchBar` component. When a user typed a search query, closed the modal (via the `Escape` key, clicking the background backdrop overlay, or clicking the close button), and reopened it and then typing a new character would append it to the uncleared test (e.g., typing "Mo", closing, and reopening to type "m" resulted in "Mom").

Solution Implemented:

Consolidated the modal closing logic into a unified helper function `handleCloseModal` inside `src/components/SearchBar.jsx` to simultaneously reset all relevant search states:

```javascript
const handleCloseModal = () => {
  setIsModalOpen(false)
  setQuery('')
  setResults([])
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SearchBar modal closing behavior to consistently clear search state across all closing methods (Escape key, backdrop click, close button).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->