### PR TITLE
fix: open external GitHub links in a new tab

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -91,6 +91,8 @@ const Footer = () => {
               <div className="flex items-center space-x-3">
                 <motion.a
                   href="https://github.com/algoscope-hq/AlgoScope.git"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="w-9 h-9 bg-white/5 border border-white/10 rounded-lg flex items-center justify-center hover:bg-white/10 hover:border-white/20 transition-all"
                   whileHover={{ scale: 1.1 }}
                 >

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -186,8 +186,10 @@ export const Navbar = () => {
               </li>
             </ul>
 
-            <Link
-              to="https://github.com/algoscope-hq/AlgoScope"
+            <a
+              href="https://github.com/algoscope-hq/AlgoScope"
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center rounded-xl bg-white px-5 py-2 text-sm font-bold text-black shadow-lg hover:bg-slate-200 transition-all duration-200 active:scale-95"
             >
               <img
@@ -197,7 +199,7 @@ export const Navbar = () => {
               />
 
               <span>Github</span>
-            </Link>
+            </a>
 
             <div className="flex items-center gap-4 border-l border-white/10 pl-6">
               <SignedOut>
@@ -299,13 +301,15 @@ export const Navbar = () => {
                   </SignInButton>
                 </SignedOut>
 
-                <Link
-                  to="https://github.com/algoscope-hq/AlgoScope"
+                <a
+                  href="https://github.com/algoscope-hq/AlgoScope"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   onClick={() => setOpen(false)}
                   className="block w-full text-center rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-base font-bold text-white shadow-lg hover:bg-white/10 transition-all active:scale-95"
                 >
                   Github
-                </Link>
+                </a>
               </motion.div>
             </div>
           </motion.div>


### PR DESCRIPTION
## Pull Request Summary

### What changed?

Updated the external GitHub repository links in `src/components/Navbar.jsx` and `src/components/Footer.jsx` so they open in a new tab using `target="_blank"` and include `rel="noopener noreferrer"`.

### Why is this needed?

This keeps the GitHub links consistent with other external social links, such as Discord, and prevents users from being navigated away from AlgoScope in the current tab.

Closes #

## Type of Change

- [x] `fix` - Bug fix or regression fix

## Release Notes

Release note category:

- [x] Fixed

Release note entry:

- Fixed external GitHub links so they open in a new tab.

## Testing and Verification

- [x] `npm ci` or `npm install`
- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [ ] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:

- Ran the project locally with `npm run dev` and verified the updated GitHub links open in a new tab.
- Format check, lint, build, and responsive testing were not run.

## UI Evidence

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9b081b1b-b4bb-4f55-9c7f-f93c61aaa4e2" />

After:
<img width="1343" height="422" alt="image" src="https://github.com/user-attachments/assets/aa8cf25d-dd26-4142-8b2b-9f174ac1332c" />


## CI/CD and Deployment Impact

- [x] No deployment impact expected

Deployment notes:

- None.

## Reviewer Checklist

- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub links now open in new browser tabs instead of navigating away from the application, allowing you to continue browsing while visiting the repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->