### PR TITLE
feat: add code export/download support to practice sandbox

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -30,6 +30,36 @@ const CodeEditor = ({
     }
   }
 
+  // NEW: Download functionality
+  const handleDownload = () => {
+    const extensions = {
+      javascript: 'js',
+      python: 'py',
+      cpp: 'cpp',
+      java: 'java',
+      c: 'c',
+    }
+
+    const extension = extensions[language] || 'txt'
+
+    const blob = new Blob([value], {
+      type: 'text/plain',
+    })
+
+    const url = window.URL.createObjectURL(blob)
+
+    const a = document.createElement('a')
+
+    a.href = url
+    a.download = `solution.${extension}`
+
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+
+    window.URL.revokeObjectURL(url)
+  }
+
   const handleEditorChange = (newValue) => {
     setValue(newValue)
     if (onCodeChange) {
@@ -105,6 +135,14 @@ const CodeEditor = ({
                 <span>Copy</span>
               </>
             )}
+          </button>
+
+          {/* NEW: Download Button */}
+          <button
+            onClick={handleDownload}
+            className="px-4 py-2 text-sm font-bold bg-slate-800 text-slate-300 hover:bg-slate-700 hover:text-white border border-slate-700/50 rounded-xl transition-all duration-300"
+          >
+            Download
           </button>
 
           <button

--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -42,7 +42,8 @@ const CodeEditor = ({
 
     const extension = extensions[language] || 'txt'
 
-    const blob = new Blob([value], {
+    const safeValue = value ?? ''
+    const blob = new Blob([safeValue], {
       type: 'text/plain',
     })
 


### PR DESCRIPTION
## Summary
Added a Download button to the Monaco editor sandbox that allows users to export their current code locally.

## Changes Made
- Added download/export functionality
- Added dynamic file extension handling
- Implemented browser-based file generation and download
- Integrated feature into existing editor toolbar

## Supported Languages
- JavaScript (.js)
- Python (.py)
- C++ (.cpp)
- Java (.java)
- C (.c)

## Result
Users can now quickly save and export their practice code for offline use.

Fixes #231 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Download button to the code editor toolbar, letting users download their current code as a file named like solution.<ext>, where the extension is chosen to match the selected language.
  * Client-side download is triggered directly from the editor without navigating away.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->