### PR TITLE
style: add custom scrollbar styling for dark theme consistency

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -289,7 +289,6 @@
     var(--tw-gradient-from), var(--tw-gradient-via-stops), var(--tw-gradient-to) !important;
 }
 
-
 /* Custom scrollbar - Issue #170 */
 * {
   scrollbar-width: thin;

--- a/src/input.css
+++ b/src/input.css
@@ -288,3 +288,28 @@
   --tw-gradient-stops:
     var(--tw-gradient-from), var(--tw-gradient-via-stops), var(--tw-gradient-to) !important;
 }
+
+
+/* Custom scrollbar - Issue #170 */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #8b5cf6 #0f172a;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: #0f172a;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #8b5cf6;
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: #7c3aed;
+}


### PR DESCRIPTION
## Pull Request Summary

style: add custom scrollbar styling for dark theme consistency

### What changed?

Added custom scrollbar styles to `src/input.css`. The scrollbar is now 6px wide with a rounded thumb (`border-radius: 3px`), purple accent color (`#8b5cf6`) matching the app's existing theme, a dark track (`#0f172a`), and a subtle hover state. Includes `scrollbar-width: thin` and `scrollbar-color` for Firefox compatibility.

### Why is this needed?

The default browser scrollbar did not match the app's dark theme aesthetic. A styled scrollbar improves visual consistency and makes the interface look more polished and aligned with the application's branding.

Closes #170

## Type of Change
- [ ] `feat` - New user-facing feature or algorithm capability
- [ ] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [x] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes
Release note category:
- [ ] Added
- [x] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:
- Styled the scrollbar to match the dark theme with a thin purple thumb and dark track

## Testing and Verification
- [x] `npm ci` or `npm install`
- [ ] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [ ] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:
Skipped npm run format:check — script does not exist in this project. Skipped responsive testing — change is a global CSS rule with no layout impact.

## UI Evidence
Before:
<img width="1440" height="771" alt="Screenshot 2026-05-22 at 3 15 10 PM" src="https://github.com/user-attachments/assets/30ba1a02-b80b-47c8-93ed-81f30db5f857" />

After: 
<img width="1440" height="770" alt="Screenshot 2026-05-22 at 3 11 22 PM" src="https://github.com/user-attachments/assets/553ead4a-19df-49d2-b018-fc236990aaca" />


## CI/CD and Deployment Impact
- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:
N/A

## Reviewer Checklist
- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [x] CI checks are expected to pass: format, lint, and build
- [x] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Applied global custom scrollbar styling across the app: thin scrollbars with consistent themed colors, fixed thumb size and rounded corners, hover state with a darker thumb, and cross‑browser support for modern Firefox and WebKit browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->