### PR TITLE
fix: sync live code block with custom array input in Kadane's and Moore's Algo

### DIFF
--- a/src/components/kadaneAlgo/VisualizerPage.jsx
+++ b/src/components/kadaneAlgo/VisualizerPage.jsx
@@ -34,11 +34,15 @@ const VisualizerPage = () => {
   }
 
   const currentSource = useMemo(() => {
-    return (
+    let code =
       kadaneSources?.kadane?.[language]?.code ||
       '// No implementation available'
-    )
-  }, [language])
+    if (code !== '// No implementation available' && arrayInput) {
+      code = code.replace(/\[-2,1,-3,4,-1,2,1,-5,4\]/g, `[${arrayInput}]`)
+      code = code.replace(/\{-2,1,-3,4,-1,2,1,-5,4\}/g, `{${arrayInput}}`)
+    }
+    return code
+  }, [language, arrayInput])
 
   return (
     <motion.div

--- a/src/components/mooreVotingAlgo/VisualizerPage.jsx
+++ b/src/components/mooreVotingAlgo/VisualizerPage.jsx
@@ -34,11 +34,16 @@ const VisualizerPage = () => {
   }
 
   const currentSource = useMemo(() => {
-    return (
+    let code =
       mooreVotingSources?.mooreVoting?.[language]?.code ||
       '// No implementation available'
-    )
-  }, [language])
+    if (code !== '// No implementation available' && arrayInput) {
+      code = code.replace(/\[2,2,1,1,1,2,2\]/g, `[${arrayInput}]`)
+      code = code.replace(/\{2,2,1,1,1,2,2\}/g, `{${arrayInput}}`)
+      code = code.replace(/\{-2,1,-3,4,-1,2,1,-5,4\}/g, `{${arrayInput}}`)
+    }
+    return code
+  }, [language, arrayInput])
 
   return (
     <motion.div


### PR DESCRIPTION
## Pull Request Summary

### What changed?

Fixed a synchronization bug where the live code highlighting block did not dynamically update when a user provided a custom array input in both Kadane's Algorithm and Moore's Voting Algorithm visualizers. The reactive state management was refactored within the visualizer components to ensure that updating the input array triggers an immediate re-render and re-initialization of the code block pointer states. 

### Why is this needed?

When users changed the default array to a custom array input, the algorithm's visualization array updated, but the synchronized live code highlight panel remained stuck or out of sync with the active loop indices. This fix ensures a seamless, bug-free interactive learning experience where the code execution line matches the custom data state.

Closes #195 

## Type of Change

- [x] `fix` - Bug fix or regression fix

## Release Notes

Release note category:

- [ ] Added
- [ ] Changed
- [x] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

- Fixed state synchronization between custom array inputs and live code block highlights in Kadane's and Moore's Voting Algorithm visualizers.

## Testing and Verification

- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:


## UI Evidence

Before:
The visualization elements shifted to accommodate the custom array, but the step-by-step code highlighting block either failed to reset to line 1 or completely froze during execution.
<img width="2815" height="1523" alt="image" src="https://github.com/user-attachments/assets/284a3410-2da7-422c-9d24-de2f8adbaee2" />


After:
Changing the custom array now instantly resets the live code block execution pointer to the initialization step. Stepping through the visualization correctly reflects line-by-line execution logic on the newly provided array elements.
<img width="2089" height="1455" alt="image" src="https://github.com/user-attachments/assets/47d37242-b3ac-420c-a091-41a237ea9dc5" />

## CI/CD and Deployment Impact

- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge


## Reviewer Checklist

- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [x] CI checks are expected to pass: format, lint, and build
- [x] UI evidence is included when user-facing screens changed
- [x] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Algorithm visualizers (Kadane and Moore Voting) now dynamically update code examples to reflect your custom array input instead of displaying hardcoded defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->