### PR TITLE
feat(graph): add interactive graph canvas builder for BFS, DFS, and s…

### DIFF
--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -1,88 +1,98 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import StatusDisplay from '../StatusDisplay'
+import { GraphBuilderToolbar } from '../shared/GraphBuilderToolbar'
 
-export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
+// ── Preset graph data (also used by Reset button in toolbar) ──────────────────
+const PRESET_NODES = [
+  { id: 1, label: '1' },
+  { id: 2, label: '2' },
+  { id: 3, label: '3' },
+  { id: 4, label: '4' },
+  { id: 5, label: '5' },
+  { id: 6, label: '6' },
+  { id: 7, label: '7' },
+  { id: 8, label: '8' },
+  { id: 9, label: '9' },
+  { id: 10, label: '10' },
+  { id: 11, label: '11' },
+  { id: 12, label: '12' },
+  { id: 13, label: '13' },
+  { id: 14, label: '14' },
+  { id: 15, label: '15' },
+]
+
+const PRESET_EDGES = [
+  // Main chain
+  { id: 1, from: 1, to: 2 },
+  { id: 2, from: 2, to: 3 },
+  { id: 3, from: 3, to: 4 },
+  { id: 4, from: 4, to: 5 },
+  { id: 5, from: 5, to: 6 },
+  { id: 6, from: 6, to: 7 },
+  // Branches
+  { id: 7, from: 2, to: 8 },
+  { id: 8, from: 3, to: 9 },
+  { id: 9, from: 5, to: 10 },
+  { id: 10, from: 6, to: 11 },
+  { id: 11, from: 4, to: 12 },
+  // Sub-branches
+  { id: 12, from: 8, to: 13 },
+  { id: 13, from: 9, to: 14 },
+  { id: 14, from: 10, to: 15 },
+  // Cross-connections
+  { id: 15, from: 7, to: 11 },
+  { id: 16, from: 9, to: 5 },
+  { id: 17, from: 10, to: 6 },
+  { id: 18, from: 8, to: 4 },
+  { id: 19, from: 3, to: 12 },
+  { id: 20, from: 2, to: 1 },
+]
+
+export const CanvasSearching = ({
+  algorithm,
+  vertex,
+  speed = 1,
+  runKey,
+  onGraphChange,
+}) => {
   const containerRef = useRef(null)
   const networkRef = useRef(null)
   const nodesRef = useRef(null)
   const edgesRef = useRef(null)
   const [status, setStatus] = useState('')
   const [physics, setPhysics] = useState(false)
+  const [networkReady, setNetworkReady] = useState(false)
 
-  // initialize network
+  // Notify parent of node list
+  const notifyGraphChange = useCallback(() => {
+    if (!nodesRef.current || !onGraphChange) return
+    onGraphChange(nodesRef.current.getIds())
+  }, [onGraphChange])
+
+  // ── Initialize vis-network ─────────────────────────────────────────────────
   useEffect(() => {
     if (!window.vis || !containerRef.current) return
-    const someNodes = [
-      { id: 1, label: '1' },
-      { id: 2, label: '2' },
-      { id: 3, label: '3' },
-      { id: 4, label: '4' },
-      { id: 5, label: '5' },
-      { id: 6, label: '6' },
-      { id: 7, label: '7' },
-      { id: 8, label: '8' },
-      { id: 9, label: '9' },
-      { id: 10, label: '10' },
-      { id: 11, label: '11' },
-      { id: 12, label: '12' },
-      { id: 13, label: '13' },
-      { id: 14, label: '14' },
-      { id: 15, label: '15' },
-    ]
-    const nodes = new window.vis.DataSet(someNodes)
-    // const length = someNodes.length
-    const edges = new window.vis.DataSet([
-      // Main chain (like a backbone)
-      { id: 1, from: 1, to: 2 },
-      { id: 2, from: 2, to: 3 },
-      { id: 3, from: 3, to: 4 },
-      { id: 4, from: 4, to: 5 },
-      { id: 5, from: 5, to: 6 },
-      { id: 6, from: 6, to: 7 },
 
-      // Branches from the main chain
-      { id: 7, from: 2, to: 8 },
-      { id: 8, from: 3, to: 9 },
-      { id: 9, from: 5, to: 10 },
-      { id: 10, from: 6, to: 11 },
-      { id: 11, from: 4, to: 12 },
-
-      // Sub-branches
-      { id: 12, from: 8, to: 13 },
-      { id: 13, from: 9, to: 14 },
-      { id: 14, from: 10, to: 15 },
-
-      // Light cross-connections (for reachability, not clutter)
-      { id: 15, from: 7, to: 11 },
-      { id: 16, from: 9, to: 5 },
-      { id: 17, from: 10, to: 6 },
-      { id: 18, from: 8, to: 4 },
-      { id: 19, from: 3, to: 12 },
-      { id: 20, from: 2, to: 1 },
-    ])
-
+    const nodes = new window.vis.DataSet(PRESET_NODES)
+    const edges = new window.vis.DataSet(PRESET_EDGES)
     const data = { nodes, edges }
 
     const options = {
       physics: {
         enabled: false,
-        stabilization: {
-          enabled: true,
-          iterations: 100,
-          updateInterval: 25,
-        },
+        stabilization: { enabled: true, iterations: 100, updateInterval: 25 },
       },
       nodes: {
         shape: 'dot',
         size: 15,
         color: {
-          background: '#06b6d4', // Cyan-500
-          border: '#e2e8f0', // Slate-200
+          background: '#06b6d4',
+          border: '#e2e8f0',
           highlight: { background: '#22d3ee', border: '#ffffff' },
         },
         font: {
           size: 20,
-          color: '#f8fafc', // Slate-50
+          color: '#f8fafc',
           face: 'Arial',
           bold: true,
         },
@@ -98,15 +108,12 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
       edges: {
         arrows: { to: { enabled: true, scaleFactor: 1.0 } },
         color: {
-          color: '#64748b', // Slate-500
-          highlight: '#22d3ee', // Cyan-400
+          color: '#64748b',
+          highlight: '#22d3ee',
           hover: '#22d3ee',
         },
         width: 3,
-        smooth: {
-          type: 'curvedCW',
-          roundness: 0.0,
-        },
+        smooth: { type: 'curvedCW', roundness: 0.0 },
         shadow: {
           enabled: true,
           color: 'rgba(0,0,0,0.5)',
@@ -130,12 +137,23 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     edgesRef.current = edges
     networkRef.current = network
 
+    setNetworkReady(true)
+    notifyGraphChange()
+
     return () => {
       network.destroy()
+      setNetworkReady(false)
     }
-  }, [])
+  }, [notifyGraphChange])
 
-  // Lock interaction when idle, unlock + recenter when running
+  // ── Physics toggle ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (networkRef.current) {
+      networkRef.current.setOptions({ physics: { enabled: physics } })
+    }
+  }, [physics])
+
+  // ── Recenter when animation starts ────────────────────────────────────────
   useEffect(() => {
     if (!networkRef.current) return
     if (runKey !== null) {
@@ -145,24 +163,13 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     }
   }, [runKey])
 
-  useEffect(() => {
-    if (networkRef.current) {
-      networkRef.current.setOptions({
-        physics: { enabled: physics },
-      })
-    }
-  }, [physics])
-
-  // Reset nodes to default color with smooth transition
-  const resetNodes = () => {
+  // ── Reset node/edge styles ─────────────────────────────────────────────────
+  const resetNodes = useCallback(() => {
     if (nodesRef.current) {
       nodesRef.current.get().forEach((n) => {
         nodesRef.current.update({
           id: n.id,
-          color: {
-            background: '#06b6d4',
-            border: '#e2e8f0',
-          },
+          color: { background: '#06b6d4', border: '#e2e8f0' },
           size: 15,
         })
       })
@@ -176,15 +183,14 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
         })
       })
     }
-  }
+  }, [])
 
-  // Reset nodes when algorithm or vertex changes (but not on run)
   useEffect(() => {
     resetNodes()
     setTimeout(() => setStatus(''), 0)
-  }, [algorithm, vertex])
+  }, [algorithm, vertex, resetNodes])
 
-  // animate algorithm with enhanced visual effects — only fires when runKey changes
+  // ── BFS / DFS animation — fires only when runKey changes ──────────────────
   useEffect(() => {
     if (
       runKey === null ||
@@ -198,11 +204,10 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     const nodes = nodesRef.current
     const edges = edgesRef.current
 
-    // reset all nodes to default color before starting
     nodes.get().forEach((n) =>
       nodes.update({
         id: n.id,
-        color: { background: '#1e293b', border: '#475569' }, // Dark slate for unvisited
+        color: { background: '#1e293b', border: '#475569' },
         size: 25,
       })
     )
@@ -214,16 +219,14 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     })
 
     const timers = []
+
     const visit = (id, delay) => {
       const t = setTimeout(() => {
-        // Animate node size and color
         nodes.update({
           id,
-          color: { background: '#f43f5e', border: '#ffffff' }, // Rose-500
+          color: { background: '#f43f5e', border: '#ffffff' },
           size: 35,
         })
-        console.log(`node ${id} is visited.`)
-        // Add pulsing effect
         setTimeout(() => {
           nodes.update({ id, size: 30 })
         }, 200 / speed)
@@ -240,12 +243,11 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
 
     const markCompleted = (completionDelay) => {
       const t = setTimeout(() => {
-        // Show completion by changing all visited nodes to green with animation
         nodes.get().forEach((n) => {
-          if (n.color.background === '#f43f5e') {
+          if (n.color && n.color.background === '#f43f5e') {
             nodes.update({
               id: n.id,
-              color: { background: '#10b981', border: '#ffffff' }, // Emerald-500
+              color: { background: '#10b981', border: '#ffffff' },
               size: 28,
             })
           }
@@ -255,15 +257,15 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     }
 
     if (algorithm === 'bfs') {
-      let queue = [parseInt(vertex)]
-      let visited = new Set([parseInt(vertex)])
+      const queue = [parseInt(vertex)]
+      const visited = new Set([parseInt(vertex)])
       let delay = 0
 
       setStatusAtDelay(`Starting BFS from node ${vertex}`, delay)
       delay += 1200 / speed
 
       while (queue.length) {
-        let node = queue.shift()
+        const node = queue.shift()
         visit(node, delay)
         setStatusAtDelay(
           `Visiting node ${node}. Queue: [${queue.join(', ')}]`,
@@ -287,7 +289,6 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
               `Adding ${n} to queue. Queue: [${queue.join(', ')}]`,
               delay
             )
-
             const edge = edges.get().find((e) => e.from === node && e.to === n)
             if (edge) {
               setTimeout(
@@ -310,7 +311,7 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
     }
 
     if (algorithm === 'dfs') {
-      let visited = new Set()
+      const visited = new Set()
       let delay = 0
 
       const dfs = (node) => {
@@ -390,25 +391,39 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
           style={{ background: 'transparent' }}
         />
 
+        {/* Graph Builder Toolbar — rendered after network is ready */}
+        {networkReady && (
+          <GraphBuilderToolbar
+            networkRef={networkRef}
+            nodesRef={nodesRef}
+            edgesRef={edgesRef}
+            presetNodes={PRESET_NODES}
+            presetEdges={PRESET_EDGES}
+            weighted={false}
+            onGraphChange={onGraphChange}
+          />
+        )}
+
         {/* Color legend */}
         <div className="absolute bottom-3 left-3 z-10 flex items-center gap-3 bg-slate-900/80 backdrop-blur-md border border-white/10 rounded-lg px-3 py-2">
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-cyan-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-cyan-500 inline-block" />
             Unvisited
           </span>
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-rose-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-rose-500 inline-block" />
             Visiting
           </span>
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-emerald-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-emerald-500 inline-block" />
             Visited
           </span>
         </div>
 
         {/* Physics toggle */}
-        <div className="absolute top-3 right-3 z-10 group">
+        <div className="absolute bottom-3 right-3 z-10 group">
           <button
+            id="graph-physics-toggle"
             onClick={() => setPhysics(!physics)}
             title="Toggle physics to freely drag and reposition nodes"
             className={`flex items-center gap-2 px-3 py-2 text-xs font-bold rounded-lg shadow-md transition-all duration-300 border backdrop-blur-md ${
@@ -441,11 +456,9 @@ export const CanvasSearching = ({ algorithm, vertex, speed = 1, runKey }) => {
             </svg>
             {physics ? 'Physics ON' : 'Physics OFF'}
           </button>
-          <div className="absolute right-0 top-full mt-1 w-48 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-xs text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
-            Enables dragging nodes to rearrange the graph layout.
-          </div>
         </div>
       </div>
+
       <StatusDisplay
         key={status || 'default-status'}
         message={

--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import StatusDisplay from '../StatusDisplay'
 import { GraphBuilderToolbar } from '../shared/GraphBuilderToolbar'
+import { scheduleNetworkReady } from '../../lib/scheduleNetworkReady'
 
 // ── Preset graph data (also used by Reset button in toolbar) ──────────────────
 const PRESET_NODES = [
@@ -148,14 +149,13 @@ export const CanvasSearching = ({
     edgesRef.current = edges
     networkRef.current = network
 
-    const handleNetworkReady = () => {
+    const cancelReady = scheduleNetworkReady(network, () => {
       setNetworkReady(true)
       notifyGraphChange()
-    }
-    network.once('stabilizationIterationsDone', handleNetworkReady)
+    })
 
     return () => {
-      network.off('stabilizationIterationsDone', handleNetworkReady)
+      cancelReady()
       network.destroy()
       networkRef.current = null
       nodesRef.current = null

--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -137,11 +137,18 @@ export const CanvasSearching = ({
     edgesRef.current = edges
     networkRef.current = network
 
-    setNetworkReady(true)
-    notifyGraphChange()
+    const handleNetworkReady = () => {
+      setNetworkReady(true)
+      notifyGraphChange()
+    }
+    network.once('stabilizationIterationsDone', handleNetworkReady)
 
     return () => {
+      network.off('stabilizationIterationsDone', handleNetworkReady)
       network.destroy()
+      networkRef.current = null
+      nodesRef.current = null
+      edgesRef.current = null
       setNetworkReady(false)
     }
   }, [notifyGraphChange])

--- a/src/components/searchAlgo/CanvasSearching.jsx
+++ b/src/components/searchAlgo/CanvasSearching.jsx
@@ -62,12 +62,23 @@ export const CanvasSearching = ({
   const [status, setStatus] = useState('')
   const [physics, setPhysics] = useState(false)
   const [networkReady, setNetworkReady] = useState(false)
+  const graphVersionRef = useRef(0)
+  const onGraphChangeRef = useRef(onGraphChange)
 
-  // Notify parent of node list
-  const notifyGraphChange = useCallback(() => {
-    if (!nodesRef.current || !onGraphChange) return
-    onGraphChange(nodesRef.current.getIds())
+  useEffect(() => {
+    onGraphChangeRef.current = onGraphChange
   }, [onGraphChange])
+
+  // Notify parent of node list (stable callback for vis init effect)
+  const notifyGraphChange = useCallback(() => {
+    if (!nodesRef.current || !onGraphChangeRef.current) return
+    onGraphChangeRef.current(nodesRef.current.getIds())
+  }, [])
+
+  const handleCanvasGraphChange = useCallback((ids) => {
+    graphVersionRef.current += 1
+    onGraphChangeRef.current?.(ids)
+  }, [])
 
   // ── Initialize vis-network ─────────────────────────────────────────────────
   useEffect(() => {
@@ -226,23 +237,29 @@ export const CanvasSearching = ({
     })
 
     const timers = []
+    const runVersion = graphVersionRef.current
+    const isStale = () => runVersion !== graphVersionRef.current
 
     const visit = (id, delay) => {
       const t = setTimeout(() => {
+        if (isStale()) return
         nodes.update({
           id,
           color: { background: '#f43f5e', border: '#ffffff' },
           size: 35,
         })
-        setTimeout(() => {
+        const t2 = setTimeout(() => {
+          if (isStale()) return
           nodes.update({ id, size: 30 })
         }, 200 / speed)
+        timers.push(t2)
       }, delay)
       timers.push(t)
     }
 
     const setStatusAtDelay = (message, delay) => {
       const t = setTimeout(() => {
+        if (isStale()) return
         setStatus(message)
       }, delay)
       timers.push(t)
@@ -250,6 +267,7 @@ export const CanvasSearching = ({
 
     const markCompleted = (completionDelay) => {
       const t = setTimeout(() => {
+        if (isStale()) return
         nodes.get().forEach((n) => {
           if (n.color && n.color.background === '#f43f5e') {
             nodes.update({
@@ -298,8 +316,9 @@ export const CanvasSearching = ({
             )
             const edge = edges.get().find((e) => e.from === node && e.to === n)
             if (edge) {
-              setTimeout(
+              const edgeTimer = setTimeout(
                 () => {
+                  if (isStale()) return
                   edges.update({
                     id: edge.id,
                     color: { color: '#f43f5e' },
@@ -308,6 +327,7 @@ export const CanvasSearching = ({
                 },
                 delay - 200 / speed
               )
+              timers.push(edgeTimer)
             }
           }
         })
@@ -342,8 +362,9 @@ export const CanvasSearching = ({
             hasUnvisitedNeighbors = true
             const edge = edges.get().find((e) => e.from === node && e.to === n)
             if (edge) {
-              setTimeout(
+              const edgeTimer = setTimeout(
                 () => {
+                  if (isStale()) return
                   edges.update({
                     id: edge.id,
                     color: { color: '#f43f5e' },
@@ -352,6 +373,7 @@ export const CanvasSearching = ({
                 },
                 delay - 200 / speed
               )
+              timers.push(edgeTimer)
             }
             dfs(n)
             setStatusAtDelay(`Backtracking from ${n} to node ${node}`, delay)
@@ -407,7 +429,7 @@ export const CanvasSearching = ({
             presetNodes={PRESET_NODES}
             presetEdges={PRESET_EDGES}
             weighted={false}
-            onGraphChange={onGraphChange}
+            onGraphChange={handleCanvasGraphChange}
           />
         )}
 

--- a/src/components/searchAlgo/MenuSelectNodeSearch.jsx
+++ b/src/components/searchAlgo/MenuSelectNodeSearch.jsx
@@ -1,7 +1,15 @@
 import React from 'react'
 import Tooltip from '../Tooltip'
 
-export const MenuSelectNodeSearch = ({ node, setNode }) => {
+/**
+ * MenuSelectNodeSearch
+ *
+ * Props:
+ *  - node     : currently selected starting node
+ *  - setNode  : setter
+ *  - nodeIds  : number[] – live list of node IDs from the canvas
+ */
+export const MenuSelectNodeSearch = ({ node, setNode, nodeIds = [] }) => {
   const handleChange = (e) => {
     setNode(e.target.value || null)
   }
@@ -18,14 +26,15 @@ export const MenuSelectNodeSearch = ({ node, setNode }) => {
           className="w-full"
         >
           <select
+            id="search-start-node-select"
             value={node ?? ''}
             onChange={handleChange}
             className="w-full bg-slate-800 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm appearance-none cursor-pointer"
           >
             <option value="">Choose a Starting Node</option>
-            {Array.from({ length: 15 }, (_, i) => i + 1).map((element) => (
-              <option key={element} value={element}>
-                {element}
+            {nodeIds.map((id) => (
+              <option key={id} value={id}>
+                {id}
               </option>
             ))}
           </select>
@@ -45,6 +54,12 @@ export const MenuSelectNodeSearch = ({ node, setNode }) => {
           />
         </svg>
       </div>
+
+      {nodeIds.length === 0 && (
+        <p className="text-xs text-amber-400/80 pl-1">
+          No nodes on canvas. Add nodes using the toolbar above.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/searchAlgo/VisualizerPage.jsx
+++ b/src/components/searchAlgo/VisualizerPage.jsx
@@ -272,14 +272,16 @@ export const VisualizerPage = () => {
             How to use
           </p>
           {[
-            { step: '1', label: 'Pick an algorithm' },
-            { step: '2', label: 'Choose a starting node' },
-            { step: '3', label: 'Press Run' },
+            { step: '1', label: 'Build your graph (toolbar on canvas)' },
+            { step: '2', label: 'Pick an algorithm' },
+            { step: '3', label: 'Choose a starting node' },
+            { step: '4', label: 'Press Run' },
           ].map(({ step, label }) => {
             const done =
-              (step === '1' && algorithm) ||
-              (step === '2' && node) ||
-              (step === '3' && runKey !== null)
+              (step === '1' && nodeIds.length > 0) ||
+              (step === '2' && algorithm) ||
+              (step === '3' && node) ||
+              (step === '4' && runKey !== null)
 
             return (
               <div key={step} className="flex items-center gap-3">
@@ -338,7 +340,7 @@ export const VisualizerPage = () => {
       <div className="w-full lg:w-3/4 flex flex-col gap-6">
         {mode === 'solo' ? (
           <>
-            <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
+            <div className="rounded-xl border border-white/10 shadow-lg">
               <CanvasSearching
                 algorithm={algorithm}
                 vertex={node}

--- a/src/components/searchAlgo/VisualizerPage.jsx
+++ b/src/components/searchAlgo/VisualizerPage.jsx
@@ -184,6 +184,21 @@ export const VisualizerPage = () => {
   const [speed, setSpeed] = React.useState(1.0)
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
+  // Live list of node IDs from the canvas (kept in sync via onGraphChange)
+  const [nodeIds, setNodeIds] = React.useState(
+    Array.from({ length: 15 }, (_, i) => i + 1)
+  )
+
+  const handleGraphChange = React.useCallback(
+    (ids) => {
+      setNodeIds(ids)
+      // Deselect starting node if it no longer exists on canvas
+      if (node !== null && !ids.includes(parseInt(node))) {
+        setNode(null)
+      }
+    },
+    [node]
+  )
 
   const handleSpeedChange = (event, newValue) => {
     setSpeed(newValue)
@@ -315,7 +330,7 @@ export const VisualizerPage = () => {
           algorithm={algorithm}
           setAlgorithm={setAlgorithm}
         />
-        <MenuSelectNodeSearch node={node} setNode={setNode} />
+        <MenuSelectNodeSearch node={node} setNode={setNode} nodeIds={nodeIds} />
         <SpeedSlider value={speed} onChange={handleSpeedChange} />
       </div>
 
@@ -329,6 +344,7 @@ export const VisualizerPage = () => {
                 vertex={node}
                 speed={speed}
                 runKey={runKey}
+                onGraphChange={handleGraphChange}
               />
             </div>
 

--- a/src/components/shared/GraphBuilderToolbar.jsx
+++ b/src/components/shared/GraphBuilderToolbar.jsx
@@ -374,7 +374,14 @@ export const GraphBuilderToolbar = ({
   return (
     <>
       {/* ── Floating Toolbar ─────────────────────────────────────────────── */}
-      <div className="absolute top-3 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1 bg-slate-900/85 backdrop-blur-md border border-white/10 rounded-2xl px-2 py-1.5 shadow-2xl">
+      <div
+        role="toolbar"
+        aria-label="Graph builder"
+        className="absolute top-3 left-1/2 -translate-x-1/2 z-[100] pointer-events-auto flex flex-wrap items-center justify-center gap-1 max-w-[calc(100%-1rem)] bg-slate-900/95 backdrop-blur-md border border-cyan-500/30 rounded-2xl px-2 py-1.5 shadow-2xl shadow-cyan-500/10"
+      >
+        <span className="sr-only sm:not-sr-only sm:inline-flex items-center px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-cyan-400/90 border-r border-white/10 mr-1">
+          Build
+        </span>
         {/* Mode pills */}
         <div className="flex items-center gap-1 pr-2 border-r border-white/10">
           {modeButtons.map(({ id, label, icon, tooltip }) => (
@@ -390,7 +397,7 @@ export const GraphBuilderToolbar = ({
               }`}
             >
               {icon}
-              <span className="hidden sm:inline">{label}</span>
+              <span className="text-[10px] sm:text-xs">{label}</span>
             </button>
           ))}
         </div>
@@ -425,7 +432,7 @@ export const GraphBuilderToolbar = ({
                 d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
               />
             </svg>
-            <span className="hidden sm:inline">Delete</span>
+            <span className="text-[10px] sm:text-xs">Delete</span>
           </button>
 
           <button
@@ -447,7 +454,7 @@ export const GraphBuilderToolbar = ({
                 d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
               />
             </svg>
-            <span className="hidden sm:inline">Clear</span>
+            <span className="text-[10px] sm:text-xs">Clear</span>
           </button>
 
           <button
@@ -469,14 +476,14 @@ export const GraphBuilderToolbar = ({
                 d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
               />
             </svg>
-            <span className="hidden sm:inline">Reset</span>
+            <span className="text-[10px] sm:text-xs">Reset</span>
           </button>
         </div>
       </div>
 
       {/* ── Mode hint banner ────────────────────────────────────────────────── */}
       {builderMode !== 'pointer' && (
-        <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+        <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-[100] pointer-events-none">
           <div
             className={`px-4 py-1.5 rounded-full text-xs font-semibold border backdrop-blur-sm ${
               builderMode === 'addNode'

--- a/src/components/shared/GraphBuilderToolbar.jsx
+++ b/src/components/shared/GraphBuilderToolbar.jsx
@@ -1,0 +1,545 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * GraphBuilderToolbar
+ *
+ * A floating glassmorphic toolbar that overlays any vis-network canvas and
+ * lets users interactively build custom graphs.
+ *
+ * Props:
+ *  - networkRef   : React ref holding the vis.Network instance
+ *  - nodesRef     : React ref holding the vis.DataSet of nodes
+ *  - edgesRef     : React ref holding the vis.DataSet of edges
+ *  - presetNodes  : Array – original preset node objects (for Reset)
+ *  - presetEdges  : Array – original preset edge objects (for Reset)
+ *  - weighted     : boolean – if true, prompts for edge weight on Add Edge
+ *  - onGraphChange: (nodeIds: number[]) => void – called whenever nodes change
+ */
+export const GraphBuilderToolbar = ({
+  networkRef,
+  nodesRef,
+  edgesRef,
+  presetNodes,
+  presetEdges,
+  weighted = false,
+  onGraphChange,
+}) => {
+  const [builderMode, setBuilderMode] = useState('pointer')
+  const [selectedElement, setSelectedElement] = useState(null) // { type, id }
+  const [weightModal, setWeightModal] = useState(null) // { from, to }
+  const [weightInput, setWeightInput] = useState('1')
+  const [weightError, setWeightError] = useState('')
+
+  // Track pending first-click node in addEdge mode
+  const pendingEdgeSource = useRef(null)
+  // Stable counter for new node IDs to avoid collisions
+  const nextNodeId = useRef(null)
+  // Stable counter for new edge IDs
+  const nextEdgeId = useRef(null)
+
+  // Keep builderMode accessible inside event listeners without stale closure
+  const builderModeRef = useRef(builderMode)
+  useEffect(() => {
+    builderModeRef.current = builderMode
+    // Reset pending edge source when switching mode
+    pendingEdgeSource.current = null
+    // Reset selection highlight
+    if (networkRef.current) {
+      networkRef.current.unselectAll()
+    }
+    setSelectedElement(null)
+  }, [builderMode, networkRef])
+
+  // Initialise ID counters once nodes/edges are loaded
+  useEffect(() => {
+    if (!nodesRef.current || !edgesRef.current) return
+    const nodeIds = nodesRef.current.getIds()
+    const edgeIds = edgesRef.current.getIds()
+    nextNodeId.current = nodeIds.length > 0 ? Math.max(...nodeIds) + 1 : 1
+    nextEdgeId.current = edgeIds.length > 0 ? Math.max(...edgeIds) + 1 : 1
+  }, [nodesRef, edgesRef])
+
+  // Notify parent of current node list
+  const notifyGraphChange = useCallback(() => {
+    if (!nodesRef.current || !onGraphChange) return
+    onGraphChange(nodesRef.current.getIds())
+  }, [nodesRef, onGraphChange])
+
+  // ─── Event handlers ───────────────────────────────────────────────────────
+
+  const handleClick = useCallback(
+    (params) => {
+      const mode = builderModeRef.current
+      const network = networkRef.current
+      const nodes = nodesRef.current
+      const edges = edgesRef.current
+      if (!network || !nodes || !edges) return
+
+      if (mode === 'addNode') {
+        // Only create a node if user clicked empty canvas space
+        if (params.nodes.length > 0 || params.edges.length > 0) return
+        const pos = network.DOMtoCanvas({
+          x: params.event.center.x,
+          y: params.event.center.y,
+        })
+        const id = nextNodeId.current++
+        nodes.add({ id, label: String(id) })
+        notifyGraphChange()
+        return
+      }
+
+      if (mode === 'addEdge') {
+        const clickedNode = params.nodes[0]
+        if (!clickedNode) return
+
+        if (pendingEdgeSource.current === null) {
+          // First click – highlight as source
+          pendingEdgeSource.current = clickedNode
+          nodes.update({
+            id: clickedNode,
+            color: {
+              background: '#f59e0b',
+              border: '#fbbf24',
+            },
+          })
+        } else {
+          const from = pendingEdgeSource.current
+          const to = clickedNode
+
+          // Reset source highlight
+          nodes.update({
+            id: from,
+            color: { background: '#06b6d4', border: '#e2e8f0' },
+          })
+          pendingEdgeSource.current = null
+
+          if (from === to) return // no self-loops
+
+          if (weighted) {
+            // Open weight modal
+            setWeightModal({ from, to })
+            setWeightInput('1')
+            setWeightError('')
+          } else {
+            // Create unweighted edge immediately
+            const id = nextEdgeId.current++
+            edges.add({ id, from, to })
+          }
+        }
+      }
+    },
+    [networkRef, nodesRef, edgesRef, weighted, notifyGraphChange]
+  )
+
+  const handleSelectNode = useCallback((params) => {
+    if (params.nodes.length > 0) {
+      setSelectedElement({ type: 'node', id: params.nodes[0] })
+    }
+  }, [])
+
+  const handleSelectEdge = useCallback((params) => {
+    if (params.edges.length > 0 && params.nodes.length === 0) {
+      setSelectedElement({ type: 'edge', id: params.edges[0] })
+    }
+  }, [])
+
+  const handleDeselect = useCallback(() => {
+    setSelectedElement(null)
+  }, [])
+
+  // Attach / detach vis-network event listeners when network is ready
+  useEffect(() => {
+    const network = networkRef.current
+    if (!network) return
+
+    network.on('click', handleClick)
+    network.on('selectNode', handleSelectNode)
+    network.on('selectEdge', handleSelectEdge)
+    network.on('deselectNode', handleDeselect)
+    network.on('deselectEdge', handleDeselect)
+
+    return () => {
+      network.off('click', handleClick)
+      network.off('selectNode', handleSelectNode)
+      network.off('selectEdge', handleSelectEdge)
+      network.off('deselectNode', handleDeselect)
+      network.off('deselectEdge', handleDeselect)
+    }
+  }, [
+    networkRef,
+    handleClick,
+    handleSelectNode,
+    handleSelectEdge,
+    handleDeselect,
+  ])
+
+  // ─── Toolbar actions ──────────────────────────────────────────────────────
+
+  const handleDelete = useCallback(() => {
+    if (!selectedElement) return
+    if (selectedElement.type === 'node') {
+      // Also remove all edges connected to this node
+      const connectedEdges = edgesRef.current
+        .get()
+        .filter(
+          (e) => e.from === selectedElement.id || e.to === selectedElement.id
+        )
+        .map((e) => e.id)
+      edgesRef.current.remove(connectedEdges)
+      nodesRef.current.remove(selectedElement.id)
+      notifyGraphChange()
+    } else {
+      edgesRef.current.remove(selectedElement.id)
+    }
+    setSelectedElement(null)
+  }, [selectedElement, nodesRef, edgesRef, notifyGraphChange])
+
+  const handleClearAll = useCallback(() => {
+    if (!nodesRef.current || !edgesRef.current) return
+    edgesRef.current.clear()
+    nodesRef.current.clear()
+    nextNodeId.current = 1
+    nextEdgeId.current = 1
+    pendingEdgeSource.current = null
+    setSelectedElement(null)
+    notifyGraphChange()
+  }, [nodesRef, edgesRef, notifyGraphChange])
+
+  const handleResetPreset = useCallback(() => {
+    if (!nodesRef.current || !edgesRef.current) return
+    edgesRef.current.clear()
+    nodesRef.current.clear()
+    nodesRef.current.add(presetNodes)
+    edgesRef.current.add(presetEdges)
+    const nodeIds = presetNodes.map((n) => n.id)
+    const edgeIds = presetEdges
+      .map((e) => e.id)
+      .filter((id) => id !== undefined)
+    nextNodeId.current = nodeIds.length > 0 ? Math.max(...nodeIds) + 1 : 1
+    nextEdgeId.current = edgeIds.length > 0 ? Math.max(...edgeIds) + 1 : 1
+    pendingEdgeSource.current = null
+    setSelectedElement(null)
+    notifyGraphChange()
+    if (networkRef.current) {
+      networkRef.current.fit({
+        animation: { duration: 400, easingFunction: 'easeInOutQuad' },
+      })
+    }
+  }, [
+    nodesRef,
+    edgesRef,
+    presetNodes,
+    presetEdges,
+    notifyGraphChange,
+    networkRef,
+  ])
+
+  // ─── Weight modal confirm ─────────────────────────────────────────────────
+
+  const handleWeightConfirm = useCallback(() => {
+    const w = parseFloat(weightInput)
+    if (!Number.isFinite(w)) {
+      setWeightError('Enter a valid number (e.g. -1, 4, 7.5)')
+      return
+    }
+    const { from, to } = weightModal
+    const id = nextEdgeId.current++
+    edgesRef.current.add({
+      id,
+      from,
+      to,
+      label: String(w),
+      weight: w,
+    })
+    setWeightModal(null)
+    setWeightError('')
+  }, [weightInput, weightModal, edgesRef])
+
+  const handleWeightCancel = useCallback(() => {
+    setWeightModal(null)
+    setWeightError('')
+  }, [])
+
+  // ─── Render helpers ───────────────────────────────────────────────────────
+
+  const modeButtons = [
+    {
+      id: 'pointer',
+      label: 'Pointer',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className="w-4 h-4"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 15l-6-6m0 0l6-6m-6 6h12"
+          />
+        </svg>
+      ),
+      tooltip: 'Drag nodes, zoom & pan',
+    },
+    {
+      id: 'addNode',
+      label: '+ Node',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className="w-4 h-4"
+        >
+          <circle cx="12" cy="12" r="9" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 8v8M8 12h8"
+          />
+        </svg>
+      ),
+      tooltip: 'Click empty canvas to add a node',
+    },
+    {
+      id: 'addEdge',
+      label: '+ Edge',
+      icon: (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className="w-4 h-4"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M5 12h14M15 8l4 4-4 4"
+          />
+        </svg>
+      ),
+      tooltip: weighted
+        ? 'Click source node → target node, then enter weight'
+        : 'Click source node → target node',
+    },
+  ]
+
+  const modeColors = {
+    pointer: 'cyan',
+    addNode: 'emerald',
+    addEdge: 'purple',
+  }
+
+  const activeColor = modeColors[builderMode]
+
+  const colorMap = {
+    cyan: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/40 shadow-[0_0_8px_rgba(6,182,212,0.25)]',
+    emerald:
+      'bg-emerald-500/20 text-emerald-400 border-emerald-500/40 shadow-[0_0_8px_rgba(16,185,129,0.25)]',
+    purple:
+      'bg-purple-500/20 text-purple-400 border-purple-500/40 shadow-[0_0_8px_rgba(168,85,247,0.25)]',
+  }
+
+  return (
+    <>
+      {/* ── Floating Toolbar ─────────────────────────────────────────────── */}
+      <div className="absolute top-3 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1 bg-slate-900/85 backdrop-blur-md border border-white/10 rounded-2xl px-2 py-1.5 shadow-2xl">
+        {/* Mode pills */}
+        <div className="flex items-center gap-1 pr-2 border-r border-white/10">
+          {modeButtons.map(({ id, label, icon, tooltip }) => (
+            <button
+              key={id}
+              id={`graph-builder-mode-${id}`}
+              title={tooltip}
+              onClick={() => setBuilderMode(id)}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border transition-all duration-200 ${
+                builderMode === id
+                  ? colorMap[modeColors[id]]
+                  : 'text-slate-400 border-transparent hover:text-white hover:bg-white/5'
+              }`}
+            >
+              {icon}
+              <span className="hidden sm:inline">{label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Admin controls */}
+        <div className="flex items-center gap-1 pl-1">
+          <button
+            id="graph-builder-delete"
+            title={
+              selectedElement
+                ? `Delete selected ${selectedElement.type}`
+                : 'Select a node or edge first'
+            }
+            onClick={handleDelete}
+            disabled={!selectedElement}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border transition-all duration-200 ${
+              selectedElement
+                ? 'text-rose-400 border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+                : 'text-slate-600 border-transparent cursor-not-allowed'
+            }`}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="w-4 h-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+              />
+            </svg>
+            <span className="hidden sm:inline">Delete</span>
+          </button>
+
+          <button
+            id="graph-builder-clear"
+            title="Clear all nodes and edges"
+            onClick={handleClearAll}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border border-transparent text-amber-400 hover:bg-amber-500/10 hover:border-amber-500/30 transition-all duration-200"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="w-4 h-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+              />
+            </svg>
+            <span className="hidden sm:inline">Clear</span>
+          </button>
+
+          <button
+            id="graph-builder-reset"
+            title="Restore the default preset graph"
+            onClick={handleResetPreset}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border border-transparent text-slate-300 hover:bg-white/5 hover:border-white/10 transition-all duration-200"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="w-4 h-4"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+              />
+            </svg>
+            <span className="hidden sm:inline">Reset</span>
+          </button>
+        </div>
+      </div>
+
+      {/* ── Mode hint banner ────────────────────────────────────────────────── */}
+      {builderMode !== 'pointer' && (
+        <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+          <div
+            className={`px-4 py-1.5 rounded-full text-xs font-semibold border backdrop-blur-sm ${
+              builderMode === 'addNode'
+                ? 'bg-emerald-900/70 text-emerald-300 border-emerald-500/30'
+                : 'bg-purple-900/70 text-purple-300 border-purple-500/30'
+            }`}
+          >
+            {builderMode === 'addNode'
+              ? '🟢 Click empty canvas to place a node'
+              : pendingEdgeSource.current !== null
+                ? `🟣 Now click the target node (source: ${pendingEdgeSource.current})`
+                : '🟣 Click the source node'}
+          </div>
+        </div>
+      )}
+
+      {/* ── Weight Input Modal ───────────────────────────────────────────────── */}
+      {weightModal && (
+        <div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-950/60 backdrop-blur-sm rounded-lg">
+          <div className="bg-slate-900 border border-white/10 rounded-2xl p-6 w-72 shadow-2xl">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-bold text-white">
+                Edge Weight&nbsp;
+                <span className="text-slate-400 font-normal">
+                  ({weightModal.from} → {weightModal.to})
+                </span>
+              </h3>
+              <button
+                onClick={handleWeightCancel}
+                className="text-slate-400 hover:text-white transition-colors"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  className="w-4 h-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <p className="text-xs text-slate-400 mb-3">
+              Negative weights supported (e.g. for Bellman-Ford).
+            </p>
+
+            <input
+              id="edge-weight-input"
+              type="number"
+              value={weightInput}
+              onChange={(e) => {
+                setWeightInput(e.target.value)
+                setWeightError('')
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleWeightConfirm()
+                if (e.key === 'Escape') handleWeightCancel()
+              }}
+              autoFocus
+              className="w-full bg-slate-800 text-white text-sm border border-slate-600 rounded-xl px-4 py-2.5 focus:outline-none focus:border-cyan-500 transition-colors font-mono"
+              placeholder="e.g. 4"
+            />
+
+            {weightError && (
+              <p className="text-rose-400 text-xs mt-1.5">{weightError}</p>
+            )}
+
+            <div className="flex gap-2 mt-4">
+              <button
+                onClick={handleWeightCancel}
+                className="flex-1 py-2 rounded-xl text-xs font-bold bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 transition-all"
+              >
+                Cancel
+              </button>
+              <button
+                id="edge-weight-confirm"
+                onClick={handleWeightConfirm}
+                className="flex-1 py-2 rounded-xl text-xs font-bold bg-cyan-600 hover:bg-cyan-500 text-white shadow-lg shadow-cyan-500/20 transition-all"
+              >
+                Add Edge
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/shared/GraphBuilderToolbar.jsx
+++ b/src/components/shared/GraphBuilderToolbar.jsx
@@ -30,8 +30,8 @@ export const GraphBuilderToolbar = ({
   const [weightInput, setWeightInput] = useState('1')
   const [weightError, setWeightError] = useState('')
 
-  // Track pending first-click node in addEdge mode
-  const pendingEdgeSource = useRef(null)
+  // Track pending first-click node in addEdge mode (state for UI hints)
+  const [pendingEdgeSourceId, setPendingEdgeSourceId] = useState(null)
   // Stable counter for new node IDs to avoid collisions
   const nextNodeId = useRef(null)
   // Stable counter for new edge IDs
@@ -41,14 +41,23 @@ export const GraphBuilderToolbar = ({
   const builderModeRef = useRef(builderMode)
   useEffect(() => {
     builderModeRef.current = builderMode
-    // Reset pending edge source when switching mode
-    pendingEdgeSource.current = null
-    // Reset selection highlight
-    if (networkRef.current) {
-      networkRef.current.unselectAll()
-    }
-    setSelectedElement(null)
-  }, [builderMode, networkRef])
+  }, [builderMode])
+
+  const selectBuilderMode = useCallback(
+    (id) => {
+      if (pendingEdgeSourceId !== null && nodesRef.current) {
+        nodesRef.current.update({
+          id: pendingEdgeSourceId,
+          color: { background: '#06b6d4', border: '#e2e8f0' },
+        })
+      }
+      setPendingEdgeSourceId(null)
+      setSelectedElement(null)
+      networkRef.current?.unselectAll()
+      setBuilderMode(id)
+    },
+    [pendingEdgeSourceId, nodesRef, networkRef]
+  )
 
   // Initialise ID counters once nodes/edges are loaded
   useEffect(() => {
@@ -83,7 +92,7 @@ export const GraphBuilderToolbar = ({
           y: params.event.center.y,
         })
         const id = nextNodeId.current++
-        nodes.add({ id, label: String(id) })
+        nodes.add({ id, label: String(id), x: pos.x, y: pos.y })
         notifyGraphChange()
         return
       }
@@ -92,9 +101,9 @@ export const GraphBuilderToolbar = ({
         const clickedNode = params.nodes[0]
         if (!clickedNode) return
 
-        if (pendingEdgeSource.current === null) {
+        if (pendingEdgeSourceId === null) {
           // First click – highlight as source
-          pendingEdgeSource.current = clickedNode
+          setPendingEdgeSourceId(clickedNode)
           nodes.update({
             id: clickedNode,
             color: {
@@ -103,7 +112,7 @@ export const GraphBuilderToolbar = ({
             },
           })
         } else {
-          const from = pendingEdgeSource.current
+          const from = pendingEdgeSourceId
           const to = clickedNode
 
           // Reset source highlight
@@ -111,7 +120,7 @@ export const GraphBuilderToolbar = ({
             id: from,
             color: { background: '#06b6d4', border: '#e2e8f0' },
           })
-          pendingEdgeSource.current = null
+          setPendingEdgeSourceId(null)
 
           if (from === to) return // no self-loops
 
@@ -128,7 +137,14 @@ export const GraphBuilderToolbar = ({
         }
       }
     },
-    [networkRef, nodesRef, edgesRef, weighted, notifyGraphChange]
+    [
+      networkRef,
+      nodesRef,
+      edgesRef,
+      weighted,
+      notifyGraphChange,
+      pendingEdgeSourceId,
+    ]
   )
 
   const handleSelectNode = useCallback((params) => {
@@ -200,7 +216,7 @@ export const GraphBuilderToolbar = ({
     nodesRef.current.clear()
     nextNodeId.current = 1
     nextEdgeId.current = 1
-    pendingEdgeSource.current = null
+    setPendingEdgeSourceId(null)
     setSelectedElement(null)
     notifyGraphChange()
   }, [nodesRef, edgesRef, notifyGraphChange])
@@ -217,7 +233,7 @@ export const GraphBuilderToolbar = ({
       .filter((id) => id !== undefined)
     nextNodeId.current = nodeIds.length > 0 ? Math.max(...nodeIds) + 1 : 1
     nextEdgeId.current = edgeIds.length > 0 ? Math.max(...edgeIds) + 1 : 1
-    pendingEdgeSource.current = null
+    setPendingEdgeSourceId(null)
     setSelectedElement(null)
     notifyGraphChange()
     if (networkRef.current) {
@@ -334,8 +350,6 @@ export const GraphBuilderToolbar = ({
     addEdge: 'purple',
   }
 
-  const activeColor = modeColors[builderMode]
-
   const colorMap = {
     cyan: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/40 shadow-[0_0_8px_rgba(6,182,212,0.25)]',
     emerald:
@@ -355,7 +369,7 @@ export const GraphBuilderToolbar = ({
               key={id}
               id={`graph-builder-mode-${id}`}
               title={tooltip}
-              onClick={() => setBuilderMode(id)}
+              onClick={() => selectBuilderMode(id)}
               className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl text-xs font-bold border transition-all duration-200 ${
                 builderMode === id
                   ? colorMap[modeColors[id]]
@@ -459,8 +473,8 @@ export const GraphBuilderToolbar = ({
           >
             {builderMode === 'addNode'
               ? '🟢 Click empty canvas to place a node'
-              : pendingEdgeSource.current !== null
-                ? `🟣 Now click the target node (source: ${pendingEdgeSource.current})`
+              : pendingEdgeSourceId !== null
+                ? `🟣 Now click the target node (source: ${pendingEdgeSourceId})`
                 : '🟣 Click the source node'}
           </div>
         </div>

--- a/src/components/shared/GraphBuilderToolbar.jsx
+++ b/src/components/shared/GraphBuilderToolbar.jsx
@@ -193,6 +193,10 @@ export const GraphBuilderToolbar = ({
 
   const handleDelete = useCallback(() => {
     if (!selectedElement) return
+    const clearedPendingSource =
+      selectedElement.type === 'node' &&
+      selectedElement.id === pendingEdgeSourceId
+
     if (selectedElement.type === 'node') {
       // Also remove all edges connected to this node
       const connectedEdges = edgesRef.current
@@ -207,8 +211,17 @@ export const GraphBuilderToolbar = ({
     } else {
       edgesRef.current.remove(selectedElement.id)
     }
+    if (clearedPendingSource) {
+      setPendingEdgeSourceId(null)
+    }
     setSelectedElement(null)
-  }, [selectedElement, nodesRef, edgesRef, notifyGraphChange])
+  }, [
+    selectedElement,
+    pendingEdgeSourceId,
+    nodesRef,
+    edgesRef,
+    notifyGraphChange,
+  ])
 
   const handleClearAll = useCallback(() => {
     if (!nodesRef.current || !edgesRef.current) return

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import StatusDisplay from '../StatusDisplay'
 import { GraphBuilderToolbar } from '../shared/GraphBuilderToolbar'
+import { scheduleNetworkReady } from '../../lib/scheduleNetworkReady'
 
 // ── Preset graph data (also used by Reset button in toolbar) ──────────────────
 const PRESET_NODES = [
@@ -132,14 +133,13 @@ export const CanvasShortestPath = ({
     edgesRef.current = edges
     networkRef.current = network
 
-    const handleNetworkReady = () => {
+    const cancelReady = scheduleNetworkReady(network, () => {
       setNetworkReady(true)
       notifyGraphChange()
-    }
-    network.once('stabilizationIterationsDone', handleNetworkReady)
+    })
 
     return () => {
-      network.off('stabilizationIterationsDone', handleNetworkReady)
+      cancelReady()
       network.destroy()
       networkRef.current = null
       nodesRef.current = null

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -1,5 +1,35 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import StatusDisplay from '../StatusDisplay'
+import { GraphBuilderToolbar } from '../shared/GraphBuilderToolbar'
+
+// ── Preset graph data (also used by Reset button in toolbar) ──────────────────
+const PRESET_NODES = [
+  { id: 1, label: '1' },
+  { id: 2, label: '2' },
+  { id: 3, label: '3' },
+  { id: 4, label: '4' },
+  { id: 5, label: '5' },
+  { id: 6, label: '6' },
+  { id: 7, label: '7' },
+  { id: 8, label: '8' },
+  { id: 9, label: '9' },
+]
+
+const PRESET_EDGES = [
+  { id: 1, from: 1, to: 2, label: '2', weight: 2 },
+  { id: 2, from: 1, to: 3, label: '4', weight: 4 },
+  { id: 3, from: 2, to: 3, label: '1', weight: 1 },
+  { id: 4, from: 2, to: 4, label: '7', weight: 7 },
+  { id: 5, from: 3, to: 5, label: '3', weight: 3 },
+  { id: 6, from: 4, to: 6, label: '1', weight: 1 },
+  { id: 7, from: 5, to: 4, label: '2', weight: 2 },
+  { id: 8, from: 5, to: 6, label: '5', weight: 5 },
+  { id: 9, from: 6, to: 7, label: '2', weight: 2 },
+  { id: 10, from: 7, to: 8, label: '1', weight: 1 },
+  { id: 11, from: 8, to: 9, label: '4', weight: 4 },
+  { id: 12, from: 3, to: 9, label: '12', weight: 12 },
+  { id: 13, from: 4, to: 3, label: '-1', weight: -1 },
+]
 
 export const CanvasShortestPath = ({
   algorithm,
@@ -7,6 +37,7 @@ export const CanvasShortestPath = ({
   target,
   speed = 1,
   runKey,
+  onGraphChange,
 }) => {
   const containerRef = useRef(null)
   const networkRef = useRef(null)
@@ -14,41 +45,20 @@ export const CanvasShortestPath = ({
   const edgesRef = useRef(null)
   const [status, setStatus] = useState('')
   const [physics, setPhysics] = useState(false)
+  const [networkReady, setNetworkReady] = useState(false)
 
-  // initialize network
+  // Notify parent of node list
+  const notifyGraphChange = useCallback(() => {
+    if (!nodesRef.current || !onGraphChange) return
+    onGraphChange(nodesRef.current.getIds())
+  }, [onGraphChange])
+
+  // ── Initialize vis-network ─────────────────────────────────────────────────
   useEffect(() => {
     if (!window.vis || !containerRef.current) return
 
-    const someNodes = [
-      { id: 1, label: '1' },
-      { id: 2, label: '2' },
-      { id: 3, label: '3' },
-      { id: 4, label: '4' },
-      { id: 5, label: '5' },
-      { id: 6, label: '6' },
-      { id: 7, label: '7' },
-      { id: 8, label: '8' },
-      { id: 9, label: '9' },
-    ]
-
-    const nodes = new window.vis.DataSet(someNodes)
-
-    const edges = new window.vis.DataSet([
-      { from: 1, to: 2, label: '2', weight: 2 },
-      { from: 1, to: 3, label: '4', weight: 4 },
-      { from: 2, to: 3, label: '1', weight: 1 },
-      { from: 2, to: 4, label: '7', weight: 7 },
-      { from: 3, to: 5, label: '3', weight: 3 },
-      { from: 4, to: 6, label: '1', weight: 1 },
-      { from: 5, to: 4, label: '2', weight: 2 },
-      { from: 5, to: 6, label: '5', weight: 5 },
-      { from: 6, to: 7, label: '2', weight: 2 },
-      { from: 7, to: 8, label: '1', weight: 1 },
-      { from: 8, to: 9, label: '4', weight: 4 },
-      { from: 3, to: 9, label: '12', weight: 12 },
-      { from: 4, to: 3, label: '-1', weight: -1 },
-    ])
-
+    const nodes = new window.vis.DataSet(PRESET_NODES)
+    const edges = new window.vis.DataSet(PRESET_EDGES)
     const data = { nodes, edges }
 
     const options = {
@@ -111,12 +121,23 @@ export const CanvasShortestPath = ({
     edgesRef.current = edges
     networkRef.current = network
 
+    setNetworkReady(true)
+    notifyGraphChange()
+
     return () => {
       network.destroy()
+      setNetworkReady(false)
     }
-  }, [])
+  }, [notifyGraphChange])
 
-  // Recenter on run
+  // ── Physics toggle ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (networkRef.current) {
+      networkRef.current.setOptions({ physics: { enabled: physics } })
+    }
+  }, [physics])
+
+  // ── Recenter when animation starts ────────────────────────────────────────
   useEffect(() => {
     if (!networkRef.current || runKey === null) return
     networkRef.current.fit({
@@ -124,13 +145,8 @@ export const CanvasShortestPath = ({
     })
   }, [runKey])
 
-  useEffect(() => {
-    if (networkRef.current) {
-      networkRef.current.setOptions({ physics: { enabled: physics } })
-    }
-  }, [physics])
-
-  const resetStyles = () => {
+  // ── Reset styles ──────────────────────────────────────────────────────────
+  const resetStyles = useCallback(() => {
     if (!nodesRef.current || !edgesRef.current) return
     nodesRef.current.get().forEach((n) => {
       nodesRef.current.update({
@@ -146,9 +162,9 @@ export const CanvasShortestPath = ({
         width: 3,
       })
     })
-  }
+  }, [])
 
-  // Animate — only fires when runKey changes
+  // ── Animate — fires only when runKey changes ──────────────────────────────
   useEffect(() => {
     resetStyles()
     if (runKey === null || !algorithm || !source || !target) {
@@ -362,7 +378,7 @@ export const CanvasShortestPath = ({
     return () => {
       timers.forEach(clearTimeout)
     }
-  }, [runKey, algorithm, source, target, speed])
+  }, [runKey, algorithm, source, target, speed, resetStyles])
 
   return (
     <div className="w-full flex flex-col gap-2">
@@ -374,25 +390,39 @@ export const CanvasShortestPath = ({
           style={{ background: 'transparent' }}
         />
 
+        {/* Graph Builder Toolbar — rendered after network is ready */}
+        {networkReady && (
+          <GraphBuilderToolbar
+            networkRef={networkRef}
+            nodesRef={nodesRef}
+            edgesRef={edgesRef}
+            presetNodes={PRESET_NODES}
+            presetEdges={PRESET_EDGES}
+            weighted={true}
+            onGraphChange={onGraphChange}
+          />
+        )}
+
         {/* Color legend */}
         <div className="absolute bottom-3 left-3 z-10 flex items-center gap-3 bg-slate-900/80 backdrop-blur-md border border-white/10 rounded-lg px-3 py-2">
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-cyan-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-cyan-500 inline-block" />
             Unvisited
           </span>
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-rose-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-rose-500 inline-block" />
             Visiting
           </span>
           <span className="flex items-center gap-1.5 text-xs text-slate-300">
-            <span className="w-3 h-3 rounded-full bg-emerald-500 inline-block"></span>
+            <span className="w-3 h-3 rounded-full bg-emerald-500 inline-block" />
             Path
           </span>
         </div>
 
         {/* Physics toggle */}
-        <div className="absolute top-3 right-3 z-10 group">
+        <div className="absolute bottom-3 right-3 z-10 group">
           <button
+            id="sp-physics-toggle"
             onClick={() => setPhysics(!physics)}
             className={`flex items-center gap-2 px-3 py-2 text-xs font-bold rounded-lg shadow-md transition-all duration-300 border backdrop-blur-md ${
               physics
@@ -424,11 +454,9 @@ export const CanvasShortestPath = ({
             </svg>
             {physics ? 'Physics ON' : 'Physics OFF'}
           </button>
-          <div className="absolute right-0 top-full mt-1 w-48 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-xs text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
-            Enables dragging nodes to rearrange the graph layout.
-          </div>
         </div>
       </div>
+
       <StatusDisplay
         key={status || 'default-status'}
         message={

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -121,11 +121,18 @@ export const CanvasShortestPath = ({
     edgesRef.current = edges
     networkRef.current = network
 
-    setNetworkReady(true)
-    notifyGraphChange()
+    const handleNetworkReady = () => {
+      setNetworkReady(true)
+      notifyGraphChange()
+    }
+    network.once('stabilizationIterationsDone', handleNetworkReady)
 
     return () => {
+      network.off('stabilizationIterationsDone', handleNetworkReady)
       network.destroy()
+      networkRef.current = null
+      nodesRef.current = null
+      edgesRef.current = null
       setNetworkReady(false)
     }
   }, [notifyGraphChange])

--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -46,12 +46,23 @@ export const CanvasShortestPath = ({
   const [status, setStatus] = useState('')
   const [physics, setPhysics] = useState(false)
   const [networkReady, setNetworkReady] = useState(false)
+  const graphVersionRef = useRef(0)
+  const onGraphChangeRef = useRef(onGraphChange)
 
-  // Notify parent of node list
-  const notifyGraphChange = useCallback(() => {
-    if (!nodesRef.current || !onGraphChange) return
-    onGraphChange(nodesRef.current.getIds())
+  useEffect(() => {
+    onGraphChangeRef.current = onGraphChange
   }, [onGraphChange])
+
+  // Notify parent of node list (stable callback for vis init effect)
+  const notifyGraphChange = useCallback(() => {
+    if (!nodesRef.current || !onGraphChangeRef.current) return
+    onGraphChangeRef.current(nodesRef.current.getIds())
+  }, [])
+
+  const handleCanvasGraphChange = useCallback((ids) => {
+    graphVersionRef.current += 1
+    onGraphChangeRef.current?.(ids)
+  }, [])
 
   // ── Initialize vis-network ─────────────────────────────────────────────────
   useEffect(() => {
@@ -202,27 +213,35 @@ export const CanvasShortestPath = ({
     const dst = parseInt(target)
 
     const timers = []
+    const runVersion = graphVersionRef.current
+    const isStale = () => runVersion !== graphVersionRef.current
 
     const visitLaterNode = (id, delay) => {
       const t = setTimeout(() => {
+        if (isStale()) return
         nodes.update({
           id,
           color: { background: '#f43f5e', border: '#ffffff' },
           size: 35,
         })
-        setTimeout(() => {
+        const t2 = setTimeout(() => {
+          if (isStale()) return
           nodes.update({ id, size: 30 })
         }, 300 / speed)
+        timers.push(t2)
       }, delay)
       timers.push(t)
     }
 
     const visitLaterEdge = (edgeId, delay) => {
       const t = setTimeout(() => {
+        if (isStale()) return
         edges.update({ id: edgeId, color: { color: '#10b981' }, width: 6 })
-        setTimeout(() => {
+        const t2 = setTimeout(() => {
+          if (isStale()) return
           edges.update({ id: edgeId, width: 5 })
         }, 200 / speed)
+        timers.push(t2)
       }, delay)
       timers.push(t)
     }
@@ -256,8 +275,9 @@ export const CanvasShortestPath = ({
         }
       })
 
-      setTimeout(
+      const pathDoneTimer = setTimeout(
         () => {
+          if (isStale()) return
           pathNodes.forEach((n) => {
             nodes.update({
               id: n,
@@ -272,6 +292,7 @@ export const CanvasShortestPath = ({
         },
         delay + 500 / speed
       )
+      timers.push(pathDoneTimer)
     }
 
     const runDijkstra = () => {
@@ -406,7 +427,7 @@ export const CanvasShortestPath = ({
             presetNodes={PRESET_NODES}
             presetEdges={PRESET_EDGES}
             weighted={true}
-            onGraphChange={onGraphChange}
+            onGraphChange={handleCanvasGraphChange}
           />
         )}
 

--- a/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
+++ b/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
@@ -1,6 +1,16 @@
 import React from 'react'
 import Tooltip from '../Tooltip'
 
+/**
+ * MenuSelectNodesShortestPath
+ *
+ * Props:
+ *  - source   : currently selected source node
+ *  - target   : currently selected target node
+ *  - setSource: setter
+ *  - setTarget: setter
+ *  - nodeIds  : number[] – live list of node IDs from the canvas
+ */
 const ChevronIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -23,9 +33,8 @@ export const MenuSelectNodesShortestPath = ({
   target,
   setSource,
   setTarget,
+  nodeIds = [],
 }) => {
-  const nodeOptions = Array.from({ length: 9 }, (_, i) => i + 1)
-
   return (
     <div className="space-y-4">
       <h3 className="text-sm font-bold text-slate-400 uppercase tracking-wider pl-1">
@@ -39,12 +48,13 @@ export const MenuSelectNodesShortestPath = ({
             className="w-full"
           >
             <select
+              id="sp-source-select"
               value={source ?? ''}
               onChange={(e) => setSource(e.target.value || null)}
               className="w-full bg-slate-800 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm appearance-none cursor-pointer"
             >
               <option value="">Choose Source</option>
-              {nodeOptions.map((n) => (
+              {nodeIds.map((n) => (
                 <option key={n} value={n}>
                   {n}
                 </option>
@@ -53,6 +63,7 @@ export const MenuSelectNodesShortestPath = ({
           </Tooltip>
           <ChevronIcon />
         </div>
+
         <div className="relative">
           <Tooltip
             content="Choose the target node"
@@ -60,12 +71,13 @@ export const MenuSelectNodesShortestPath = ({
             className="w-full"
           >
             <select
+              id="sp-target-select"
               value={target ?? ''}
               onChange={(e) => setTarget(e.target.value || null)}
               className="w-full bg-slate-800 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm appearance-none cursor-pointer"
             >
               <option value="">Choose Target</option>
-              {nodeOptions.map((n) => (
+              {nodeIds.map((n) => (
                 <option key={n} value={n}>
                   {n}
                 </option>
@@ -75,6 +87,12 @@ export const MenuSelectNodesShortestPath = ({
           <ChevronIcon />
         </div>
       </div>
+
+      {nodeIds.length === 0 && (
+        <p className="text-xs text-amber-400/80 pl-1">
+          No nodes on canvas. Add nodes using the toolbar above.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -36,6 +36,19 @@ export const ShortestPathPage = () => {
   const [speed, setSpeed] = React.useState(1.0)
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
+  // Live list of node IDs from the canvas (kept in sync via onGraphChange)
+  const [nodeIds, setNodeIds] = React.useState(
+    Array.from({ length: 9 }, (_, i) => i + 1)
+  )
+
+  const handleGraphChange = React.useCallback(
+    (ids) => {
+      setNodeIds(ids)
+      if (source !== null && !ids.includes(parseInt(source))) setSource(null)
+      if (target !== null && !ids.includes(parseInt(target))) setTarget(null)
+    },
+    [source, target]
+  )
 
   const handleSpeedChange = (_, newValue) => {
     setSpeed(newValue)
@@ -240,6 +253,7 @@ export const ShortestPathPage = () => {
             target={target}
             setSource={setSource}
             setTarget={setTarget}
+            nodeIds={nodeIds}
           />
         )}
 
@@ -258,6 +272,7 @@ export const ShortestPathPage = () => {
                     target={target}
                     speed={speed}
                     runKey={runKey}
+                    onGraphChange={handleGraphChange}
                   />
                 </div>
 

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -175,27 +175,40 @@ export const ShortestPathPage = () => {
           </p>
 
           {[
+            ...(viewMode === 'network'
+              ? [
+                  {
+                    step: '1',
+                    label: 'Build your graph (toolbar on canvas)',
+                  },
+                ]
+              : []),
             {
-              step: '1',
+              step: viewMode === 'network' ? '2' : '1',
               label: 'Pick an algorithm',
             },
             {
-              step: '2',
+              step: viewMode === 'network' ? '3' : '2',
               label:
                 viewMode === 'grid'
                   ? 'Build your grid'
                   : 'Choose source & target',
             },
             {
-              step: '3',
+              step: viewMode === 'network' ? '4' : '3',
               label: 'Press Run',
             },
           ].map(({ step, label }) => {
             const done =
-              (step === '1' && algorithm) ||
-              (step === '2' &&
+              (viewMode === 'network' &&
+                step === '1' &&
+                nodeIds.length > 0) ||
+              ((viewMode === 'network' ? step === '2' : step === '1') &&
+                algorithm) ||
+              ((viewMode === 'network' ? step === '3' : step === '2') &&
                 (viewMode === 'grid' ? true : source && target)) ||
-              (step === '3' && runKey !== null)
+              ((viewMode === 'network' ? step === '4' : step === '3') &&
+                runKey !== null)
 
             return (
               <div key={step} className="flex items-center gap-3">
@@ -265,7 +278,7 @@ export const ShortestPathPage = () => {
           <>
             {mode === 'solo' ? (
               <>
-                <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
+                <div className="rounded-xl border border-white/10 shadow-lg">
                   <CanvasShortestPath
                     algorithm={algorithm}
                     source={source}

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -200,9 +200,7 @@ export const ShortestPathPage = () => {
             },
           ].map(({ step, label }) => {
             const done =
-              (viewMode === 'network' &&
-                step === '1' &&
-                nodeIds.length > 0) ||
+              (viewMode === 'network' && step === '1' && nodeIds.length > 0) ||
               ((viewMode === 'network' ? step === '2' : step === '1') &&
                 algorithm) ||
               ((viewMode === 'network' ? step === '3' : step === '2') &&

--- a/src/lib/scheduleNetworkReady.js
+++ b/src/lib/scheduleNetworkReady.js
@@ -1,0 +1,28 @@
+/**
+ * Marks a vis-network instance as ready via async callback (lint-safe).
+ * Uses stabilization event when available, with a setTimeout fallback because
+ * stabilizationIterationsDone often does not fire when physics is disabled.
+ */
+export function scheduleNetworkReady(network, onReady) {
+  let called = false
+
+  const call = () => {
+    if (called) return
+    called = true
+    onReady()
+  }
+
+  const timer = window.setTimeout(call, 0)
+  const onStabilized = () => {
+    window.clearTimeout(timer)
+    call()
+  }
+
+  network.once('stabilizationIterationsDone', onStabilized)
+
+  return () => {
+    called = true
+    window.clearTimeout(timer)
+    network.off('stabilizationIterationsDone', onStabilized)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a floating **GraphBuilderToolbar** with Pointer, Add Node, and Add Edge modes on vis-network canvases.
- Integrates into BFS/DFS (`CanvasSearching`) and Dijkstra / Bellman-Ford / Floyd-Warshall (`CanvasShortestPath`) solo network views.
- Shortest-path canvases prompt for edge weights (including negatives for Bellman-Ford).
- Delete, Clear All, and Reset Preset controls; start/source/target dropdowns sync from live node IDs.

## Why

Lets learners draw custom graphs, replicate textbook problems, and test edge cases instead of only using hardcoded presets.

## Test plan

- [x] `/search` solo — toolbar, add node/edge, run BFS/DFS on custom graph
- [ ] `/spath` solo network — weight modal, run Dijkstra / Bellman-Ford / Floyd-Warshall
- [ ] Delete / Clear / Reset Preset work; dropdowns match canvas nodes
- [ ] Compare mode unchanged (fixed graphs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive graph editor overlay: add/remove nodes & edges, weighted-edge input, preset restore, delete/clear actions, and toolbar that appears when the canvas is ready.
  * Canvas reports live node IDs to pages so start/source/target selectors populate from current graph and clear if a node is removed.
  * URL-driven mode toggle (compare mode disables Run); updated legend and physics control placement.

* **Refactoring**
  * Safer animations and style resets: guarded runs, centralized visual-reset logic, and improved cleanup of timed updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="2661" height="1155" alt="Screenshot 2026-05-25 003504" src="https://github.com/user-attachments/assets/aeadd582-d898-4d94-842c-736944d75b9d" />
