### PR TITLE
perf(seo): optimize Google Font loading and eliminate render-blocking @import in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,14 +97,13 @@
       })()
     </script>
     <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Balsamiq+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Bitcount+Grid+Single:wght@100..900&family=Geist:wght@100..900&family=JetBrains+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+    />
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap');
-      @import url('https://fonts.googleapis.com/css2?family=Bitcount+Grid+Single:wght@100..900&display=swap');
-      @import url('https://fonts.googleapis.com/css2?family=Balsamiq+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-      @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap');
-      @import url('https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-      @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
-
       .geist {
         font-family: 'Geist', sans-serif;
         font-optical-sizing: auto;


### PR DESCRIPTION
### Summary
This PR optimizes the Google Fonts loading strategy in `index.html`. It replaces the render-blocking CSS `@import` rules inside the `<style>` block in `<head>` with preconnect headers and a modern combined non-blocking stylesheet `<link>` tag.

### Problem
Previously, the fonts were imported using inline CSS `@import` statements:
```css
@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap');
@import url('https://fonts.googleapis.com/css2?family=Bitcount+Grid+Single:wght@100..900&display=swap');
...
```
This forces sequentially nested blocking network requests, which increases the First Contentful Paint (FCP) and Largest Contentful Paint (LCP) performance metrics.

### Solution
1. Added `<link rel="preconnect" href="https://fonts.googleapis.com" />` and `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />` tags to establish early connections.
2. Combined all Google Fonts into a single network request: `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Balsamiq+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Bitcount+Grid+Single:wght@100..900&family=Geist:wght@100..900&family=JetBrains+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" />`.
3. Removed render-blocking CSS `@import` rules.

### Performance Impact
- **FCP/LCP**: Significantly reduced by removing render-blocking chains.
- **Lighthouse/SEO Audit**: Scores are improved due to preconnection hints.

Closes #353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated font loading mechanism in the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->