### PR TITLE
feat(ui): add dynamic breadcrumb navigation for visualizer pages

### DIFF
--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -3,6 +3,7 @@ import { Navbar } from './Navbar'
 import Footer from './Footer'
 import { motion } from 'framer-motion'
 import SeoHead from './SeoHead'
+import Breadcrumbs from './Breadcrumbs'
 
 const Background = () => (
   <div className="absolute inset-0 z-0 pointer-events-none fixed">
@@ -24,6 +25,8 @@ export default function AppLayout({ children, showBackground = true }) {
 
       <div className="flex-1 flex flex-col gap-4 p-2 sm:p-4 z-10">
         <Navbar />
+
+        <Breadcrumbs />
 
         <div className="flex-1">{children}</div>
 

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -7,8 +7,8 @@ const routeLabels = {
   search: 'Searching',
   spath: 'Shortest Path',
   adt: 'Data Structures',
-  math: 'Math Visualizer',
-  string: 'String Algorithms',
+  'math-theory': 'Math Theory',
+  'string-algorithms': 'String Algorithms',
   graph: 'Graph Algorithms',
   visualizer: 'Visualizer',
   compare: 'Compare Mode',
@@ -28,45 +28,55 @@ export default function Breadcrumbs() {
   }
 
   return (
-    <div className="flex items-center flex-wrap gap-2 px-2 sm:px-1 text-sm text-slate-400 overflow-x-auto">
-      <Link
-        to="/"
-        className="flex items-center gap-1 hover:text-cyan-400 transition-colors duration-200"
-      >
-        <Home size={15} />
-        <span>Home</span>
-      </Link>
+    <nav
+      aria-label="Breadcrumb"
+      className="px-2 sm:px-1 text-sm text-slate-400 overflow-x-auto"
+    >
+      <ol className="flex items-center flex-wrap gap-2">
+        <li>
+          <Link
+            to="/"
+            className="flex items-center gap-1 hover:text-cyan-400 transition-colors duration-200"
+          >
+            <Home size={15} />
+            <span>Home</span>
+          </Link>
+        </li>
 
-      {pathnames.map((segment, index) => {
-        const routeTo = `/${pathnames.slice(0, index + 1).join('/')}`
+        {pathnames.map((segment, index) => {
+          const routeTo = `/${pathnames.slice(0, index + 1).join('/')}`
 
-        const isLast = index === pathnames.length - 1
+          const isLast = index === pathnames.length - 1
 
-        const label =
-          routeLabels[segment] ||
-          segment
-            .replace(/-/g, ' ')
-            .replace(/\b\w/g, (char) => char.toUpperCase())
+          const label =
+            routeLabels[segment] ||
+            segment
+              .replace(/-/g, ' ')
+              .replace(/\b\w/g, (char) => char.toUpperCase())
 
-        return (
-          <React.Fragment key={routeTo}>
-            <ChevronRight size={15} className="text-slate-600" />
+          return (
+            <li key={routeTo} className="flex items-center gap-2">
+              <ChevronRight size={15} className="text-slate-600" />
 
-            {isLast ? (
-              <span className="text-cyan-400 font-medium whitespace-nowrap">
-                {label}
-              </span>
-            ) : (
-              <Link
-                to={routeTo}
-                className="hover:text-cyan-400 transition-colors duration-200 whitespace-nowrap"
-              >
-                {label}
-              </Link>
-            )}
-          </React.Fragment>
-        )
-      })}
-    </div>
+              {isLast ? (
+                <span
+                  aria-current="page"
+                  className="text-cyan-400 font-medium whitespace-nowrap"
+                >
+                  {label}
+                </span>
+              ) : (
+                <Link
+                  to={routeTo}
+                  className="hover:text-cyan-400 transition-colors duration-200 whitespace-nowrap"
+                >
+                  {label}
+                </Link>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
   )
 }

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -22,11 +22,7 @@ export default function Breadcrumbs() {
   const location = useLocation()
 
   const pathnames = useMemo(
-    () =>
-      location.pathname
-        .replace(/[?#].*$/, '')
-        .split('/')
-        .filter(Boolean),
+    () => location.pathname.split('/').filter(Boolean),
     [location.pathname]
   )
 

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useMemo } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { ChevronRight, Home } from 'lucide-react'
 
@@ -21,7 +21,14 @@ const routeLabels = {
 export default function Breadcrumbs() {
   const location = useLocation()
 
-  const pathnames = location.pathname.split('/').filter(Boolean)
+  const pathnames = useMemo(
+    () =>
+      location.pathname
+        .replace(/[?#].*$/, '')
+        .split('/')
+        .filter(Boolean),
+    [location.pathname]
+  )
 
   if (pathnames.length === 0) {
     return null

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { ChevronRight, Home } from 'lucide-react'
+
+const routeLabels = {
+  sort: 'Sorting',
+  search: 'Searching',
+  spath: 'Shortest Path',
+  adt: 'Data Structures',
+  math: 'Math Visualizer',
+  string: 'String Algorithms',
+  graph: 'Graph Algorithms',
+  visualizer: 'Visualizer',
+  compare: 'Compare Mode',
+  ldssearch: 'LDS Search',
+  kadane: 'Kadane Algorithm',
+  'moore-voting': 'Moore Voting',
+  backtracking: 'Backtracking',
+}
+
+export default function Breadcrumbs() {
+  const location = useLocation()
+
+  const pathnames = location.pathname.split('/').filter(Boolean)
+
+  if (pathnames.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center flex-wrap gap-2 px-2 sm:px-1 text-sm text-slate-400 overflow-x-auto">
+      <Link
+        to="/"
+        className="flex items-center gap-1 hover:text-cyan-400 transition-colors duration-200"
+      >
+        <Home size={15} />
+        <span>Home</span>
+      </Link>
+
+      {pathnames.map((segment, index) => {
+        const routeTo = `/${pathnames.slice(0, index + 1).join('/')}`
+
+        const isLast = index === pathnames.length - 1
+
+        const label =
+          routeLabels[segment] ||
+          segment
+            .replace(/-/g, ' ')
+            .replace(/\b\w/g, (char) => char.toUpperCase())
+
+        return (
+          <React.Fragment key={routeTo}>
+            <ChevronRight size={15} className="text-slate-600" />
+
+            {isLast ? (
+              <span className="text-cyan-400 font-medium whitespace-nowrap">
+                {label}
+              </span>
+            ) : (
+              <Link
+                to={routeTo}
+                className="hover:text-cyan-400 transition-colors duration-200 whitespace-nowrap"
+              >
+                {label}
+              </Link>
+            )}
+          </React.Fragment>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Changes Made

This PR introduces a dynamic breadcrumb navigation system across the algorithm visualizer pages to improve navigation clarity and overall user experience as the platform grows.

### Features Added

- Added a reusable `Breadcrumbs` component for centralized breadcrumb rendering
- Implemented dynamic route-based breadcrumb generation using `react-router-dom`
- Added clickable breadcrumb navigation links for easier movement across sections
- Integrated breadcrumbs globally through `AppLayout` to avoid duplicated logic across pages
- Added cleaner human-readable labels for algorithm/category routes
- Maintained responsiveness for smaller screen sizes using flexible wrapping
- Matched the existing AlgoScope dark-themed UI and interaction styling

### Routes Supported

The breadcrumb system now supports multiple visualizer/category pages including:

- Sorting
- Searching
- Shortest Path
- Data Structures
- String Algorithms
- Math Visualizer
- Compare Mode
- Kadane Algorithm
- Moore Voting
- Backtracking
- LDS Search

### Technical Notes

- Breadcrumbs are dynamically generated from the current pathname using `useLocation()`
- Homepage breadcrumbs are intentionally hidden for cleaner landing-page UX
- The implementation avoids hardcoded per-page breadcrumbs and keeps the architecture reusable and scalable

---

## 📸 Screenshots

<img width="588" height="271" alt="algoscope_breadincrumbing string algos" src="https://github.com/user-attachments/assets/1dab661d-b4c2-40f5-808c-4b9a9caa7590" />

<img width="780" height="576" alt="algoscope_breadincrumbing backtracking" src="https://github.com/user-attachments/assets/8093398f-a73e-4ac7-a912-bd4b96db9aef" />

<img width="862" height="555" alt="algoscope_breadincrumbing amath theroy" src="https://github.com/user-attachments/assets/35153364-d9a6-4ddc-92a0-23e29761224b" />

<img width="1035" height="595" alt="algoscope_breadincrumbing moore algo" src="https://github.com/user-attachments/assets/990342d2-2ac6-4428-88b6-d6e41a4b819d" />

<img width="777" height="382" alt="algoscope_breadincrumbing kadane" src="https://github.com/user-attachments/assets/37f1ad0e-c7d4-4a55-a5f2-b2bc70b3e452" />

<img width="881" height="377" alt="algoscope_breadincrumbing data structures" src="https://github.com/user-attachments/assets/b959e24d-1bc3-4cc2-ba9e-9beea1840c99" />

<img width="880" height="452" alt="algoscope_breadincrumbing array serach" src="https://github.com/user-attachments/assets/c745590f-02c8-4e29-9a48-2e5b10259412" />

<img width="935" height="657" alt="algoscope_breadincrumbing shortest path" src="https://github.com/user-attachments/assets/14f6e717-6974-4898-95bc-54206d1a4e37" />

<img width="686" height="492" alt="algoscope_breadincrumbing searching" src="https://github.com/user-attachments/assets/19c9852e-b7c6-414b-b98b-395ad7b4dfa1" />

<img width="783" height="388" alt="algoscope_breadincrumbing sorting" src="https://github.com/user-attachments/assets/12d75a63-8e9b-4c43-adf5-3ed4be74ae7c" />


---

Closes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation added to the app layout, shown at the top before page content.
  * Displays a “Home” link plus chevron-separated crumbs reflecting the current path.
  * Intermediate crumbs are clickable to navigate to parent pages; current page shown as non-link with aria-current.
  * Segment labels are humanized (hyphens → spaces, title-cased) and use friendly names when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->