### PR TITLE
feat: implemented scroll to top button

### DIFF
--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -3,9 +3,10 @@ import { Navbar } from './Navbar'
 import Footer from './Footer'
 import { motion } from 'framer-motion'
 import SeoHead from './SeoHead'
+import ScrollToTopButton from './ScrollToTopButton'
 
 const Background = () => (
-  <div className="absolute inset-0 z-0 pointer-events-none fixed">
+  <div className="fixed inset-0 z-0 pointer-events-none">
     <div className="theme-grid absolute inset-0 bg-[size:24px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] opacity-20"></div>
   </div>
 )
@@ -13,7 +14,7 @@ const Background = () => (
 export default function AppLayout({ children, showBackground = true }) {
   return (
     <motion.div
-      className="theme-app min-h-screen flex flex-col relative overflow-hidden"
+      className="theme-app min-h-screen flex flex-col relative overflow-x-hidden"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
@@ -25,10 +26,14 @@ export default function AppLayout({ children, showBackground = true }) {
       <div className="flex-1 flex flex-col gap-4 p-2 sm:p-4 z-10">
         <Navbar />
 
-        <div className="flex-1">{children}</div>
+        <div className="flex-1">
+          {children}
+        </div>
 
         <Footer />
       </div>
+
+      <ScrollToTopButton />
     </motion.div>
   )
 }

--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -27,11 +27,7 @@ export default function AppLayout({ children, showBackground = true }) {
       <div className="flex-1 flex flex-col gap-4 p-2 sm:p-4 z-10">
         <Navbar />
 
-        <div className="flex-1">
-          {children}
-        </div>
         <Breadcrumbs />
-
         <div className="flex-1">{children}</div>
 
         <Footer />

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react'
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false)
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    // Check initial mode
+    setIsDark(document.documentElement.classList.contains('dark'))
+
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true)
+      } else {
+        setIsVisible(false)
+      }
+    }
+
+    // Listen for theme change toggles on the HTML element
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+
+    window.addEventListener('scroll', toggleVisibility)
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility)
+      observer.disconnect()
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <>
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          type="button"
+          style={{
+            // Hardcoded hex values to guarantee the colors match your mockup image perfectly
+            backgroundColor: isDark ? '#0f285d' : '#6366f1', 
+            color: '#ffffff', // Ensures the arrow is always crisp white
+            width: '48px',
+            height: '48px',
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            border: 'none',
+          }}
+          className="fixed bottom-6 right-6 z-50 shadow-lg transition-all duration-300 hover:scale-110 active:scale-95"
+          aria-label="Scroll to top"
+        >
+          {/* Thick, striking white arrow matching the mockup */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={3.8}
+            stroke="currentColor"
+            style={{ width: '24px', height: '24px' }}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"
+            />
+          </svg>
+        </button>
+      )}
+    </>
+  )
+}
+
+export default ScrollToTopButton

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -16,6 +16,8 @@ const ScrollToTopButton = () => {
       }
     }
 
+    toggleVisibility()
+
     // Listen for theme change toggles on the HTML element
     const observer = new MutationObserver(() => {
       setIsDark(document.documentElement.classList.contains('dark'))
@@ -26,7 +28,7 @@ const ScrollToTopButton = () => {
       attributeFilter: ['class'],
     })
 
-    window.addEventListener('scroll', toggleVisibility)
+    window.addEventListener('scroll', toggleVisibility, { passive: true })
     return () => {
       window.removeEventListener('scroll', toggleVisibility)
       observer.disconnect()


### PR DESCRIPTION
## Pull Request Summary
### What changed?
Added a reusable ScrollToTopButton component that appears when the user scrolls down the page and smoothly navigates back to the top on click. Integrated the component into the main AppLayout for global visibility across pages and fixed rendering/import issues related to the component setup.

### Why is this needed?

This improves navigation and user experience, especially on long pages with extensive content. Users can now quickly return to the top without manually scrolling.


Closes #275 

## Type of Change

<!-- Select every category that applies. These should align with the Conventional Commit type in the PR title. -->

- [x] `feat` - New user-facing feature or algorithm capability


## UI Evidence

After:
<img width="1893" height="954" alt="image" src="https://github.com/user-attachments/assets/d21883b8-4f29-4671-aa6c-39c42d5add81" />

## Reviewer Checklist

<!-- Keep this section for maintainers and reviewers. -->

- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [x] CI checks are expected to pass: format, lint, and build
- [x] UI evidence is included when user-facing screens changed
- [x] Documentation is updated when behavior, setup, or deployment changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scroll-to-top button that appears when scrolling and smoothly returns to the top.
  * Button adapts its appearance to light and dark modes.

* **UI Improvements**
  * Reorganized main layout for clearer content structure (navbar, breadcrumbs, content, footer).
  * Background overlay positioning updated for more consistent full-screen behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->