### PR TITLE
feat: add Tower of Hanoi visualizer

### DIFF
--- a/src/algorithms/backtracking/backtrackingSources.js
+++ b/src/algorithms/backtracking/backtrackingSources.js
@@ -221,6 +221,10 @@ func solve(board [][]rune, row, n int, results *[][]string) {
   hanoi: {
     javascript: {
       code: `function towerOfHanoi(n, source, auxiliary, destination) {
+  if (n <= 0) {
+    return;
+  }
+
   if (n === 1) {
     console.log(\`Move disk 1 from \${source} to \${destination}\`);
     return;
@@ -235,6 +239,9 @@ towerOfHanoi(4, 'A', 'B', 'C');`,
     },
     python: {
       code: `def tower_of_hanoi(n, source, auxiliary, destination):
+    if n <= 0:
+        return
+
     if n == 1:
         print(f"Move disk 1 from {source} to {destination}")
         return
@@ -250,6 +257,10 @@ tower_of_hanoi(4, 'A', 'B', 'C')`,
 using namespace std;
 
 void towerOfHanoi(int n, char source, char auxiliary, char destination) {
+    if (n <= 0) {
+        return;
+    }
+
     if (n == 1) {
         cout << "Move disk 1 from " << source << " to " << destination << endl;
         return;
@@ -267,6 +278,10 @@ int main() {
     java: {
       code: `public class TowerOfHanoi {
     static void solve(int n, char source, char auxiliary, char destination) {
+        if (n <= 0) {
+            return;
+        }
+
         if (n == 1) {
             System.out.println("Move disk 1 from " + source + " to " + destination);
             return;
@@ -286,6 +301,10 @@ int main() {
       code: `#include <stdio.h>
 
 void towerOfHanoi(int n, char source, char auxiliary, char destination) {
+    if (n <= 0) {
+        return;
+    }
+
     if (n == 1) {
         printf("Move disk 1 from %c to %c\\n", source, destination);
         return;
@@ -303,6 +322,10 @@ int main() {
     },
     rust: {
       code: `fn tower_of_hanoi(n: u32, source: char, auxiliary: char, destination: char) {
+    if n == 0 {
+        return;
+    }
+
     if n == 1 {
         println!("Move disk 1 from {} to {}", source, destination);
         return;
@@ -323,6 +346,10 @@ fn main() {
 import "fmt"
 
 func towerOfHanoi(n int, source, auxiliary, destination string) {
+    if n <= 0 {
+        return
+    }
+
     if n == 1 {
         fmt.Printf("Move disk 1 from %s to %s\\n", source, destination)
         return

--- a/src/algorithms/backtracking/backtrackingSources.js
+++ b/src/algorithms/backtracking/backtrackingSources.js
@@ -218,6 +218,127 @@ func solve(board [][]rune, row, n int, results *[][]string) {
     },
   },
 
+  hanoi: {
+    javascript: {
+      code: `function towerOfHanoi(n, source, auxiliary, destination) {
+  if (n === 1) {
+    console.log(\`Move disk 1 from \${source} to \${destination}\`);
+    return;
+  }
+
+  towerOfHanoi(n - 1, source, destination, auxiliary);
+  console.log(\`Move disk \${n} from \${source} to \${destination}\`);
+  towerOfHanoi(n - 1, auxiliary, source, destination);
+}
+
+towerOfHanoi(4, 'A', 'B', 'C');`,
+    },
+    python: {
+      code: `def tower_of_hanoi(n, source, auxiliary, destination):
+    if n == 1:
+        print(f"Move disk 1 from {source} to {destination}")
+        return
+
+    tower_of_hanoi(n - 1, source, destination, auxiliary)
+    print(f"Move disk {n} from {source} to {destination}")
+    tower_of_hanoi(n - 1, auxiliary, source, destination)
+
+tower_of_hanoi(4, 'A', 'B', 'C')`,
+    },
+    cpp: {
+      code: `#include <iostream>
+using namespace std;
+
+void towerOfHanoi(int n, char source, char auxiliary, char destination) {
+    if (n == 1) {
+        cout << "Move disk 1 from " << source << " to " << destination << endl;
+        return;
+    }
+
+    towerOfHanoi(n - 1, source, destination, auxiliary);
+    cout << "Move disk " << n << " from " << source << " to " << destination << endl;
+    towerOfHanoi(n - 1, auxiliary, source, destination);
+}
+
+int main() {
+    towerOfHanoi(4, 'A', 'B', 'C');
+}`,
+    },
+    java: {
+      code: `public class TowerOfHanoi {
+    static void solve(int n, char source, char auxiliary, char destination) {
+        if (n == 1) {
+            System.out.println("Move disk 1 from " + source + " to " + destination);
+            return;
+        }
+
+        solve(n - 1, source, destination, auxiliary);
+        System.out.println("Move disk " + n + " from " + source + " to " + destination);
+        solve(n - 1, auxiliary, source, destination);
+    }
+
+    public static void main(String[] args) {
+        solve(4, 'A', 'B', 'C');
+    }
+}`,
+    },
+    c: {
+      code: `#include <stdio.h>
+
+void towerOfHanoi(int n, char source, char auxiliary, char destination) {
+    if (n == 1) {
+        printf("Move disk 1 from %c to %c\\n", source, destination);
+        return;
+    }
+
+    towerOfHanoi(n - 1, source, destination, auxiliary);
+    printf("Move disk %d from %c to %c\\n", n, source, destination);
+    towerOfHanoi(n - 1, auxiliary, source, destination);
+}
+
+int main() {
+    towerOfHanoi(4, 'A', 'B', 'C');
+    return 0;
+}`,
+    },
+    rust: {
+      code: `fn tower_of_hanoi(n: u32, source: char, auxiliary: char, destination: char) {
+    if n == 1 {
+        println!("Move disk 1 from {} to {}", source, destination);
+        return;
+    }
+
+    tower_of_hanoi(n - 1, source, destination, auxiliary);
+    println!("Move disk {} from {} to {}", n, source, destination);
+    tower_of_hanoi(n - 1, auxiliary, source, destination);
+}
+
+fn main() {
+    tower_of_hanoi(4, 'A', 'B', 'C');
+}`,
+    },
+    go: {
+      code: `package main
+
+import "fmt"
+
+func towerOfHanoi(n int, source, auxiliary, destination string) {
+    if n == 1 {
+        fmt.Printf("Move disk 1 from %s to %s\\n", source, destination)
+        return
+    }
+
+    towerOfHanoi(n-1, source, destination, auxiliary)
+    fmt.Printf("Move disk %d from %s to %s\\n", n, source, destination)
+    towerOfHanoi(n-1, auxiliary, source, destination)
+}
+
+func main() {
+    towerOfHanoi(4, "A", "B", "C")
+}`,
+    },
+  },
+
   sudoku: {
     javascript: {
       code: `function solveSudoku(board) {

--- a/src/components/ComplexityCard.jsx
+++ b/src/components/ComplexityCard.jsx
@@ -1,45 +1,63 @@
-import React from 'react'
 import { complexityMap } from '../data/complexityMap'
 
-const ComplexityCard = ({ algorithm }) => {
+const METRICS = [
+  ['Best', 'best'],
+  ['Average', 'average'],
+  ['Worst', 'worst'],
+  ['Space', 'space'],
+]
+
+const ComplexityCard = ({ algorithm, compact = false }) => {
   if (!algorithm || !complexityMap[algorithm]) return null
 
   const current = complexityMap[algorithm]
 
   return (
-    <div className="bg-slate-950/70 border border-slate-700 rounded-xl px-6 py-4 flex flex-col gap-4">
-      <h2 className="text-cyan-400 font-bold text-sm uppercase tracking-[0.18em]">
+    <div
+      className={`bg-slate-950/70 border border-slate-700 rounded-xl flex flex-col ${
+        compact ? 'gap-3 px-4 py-4' : 'gap-4 px-6 py-4'
+      }`}
+    >
+      <h2
+        className={`text-cyan-400 font-bold uppercase ${
+          compact
+            ? 'text-xs leading-5 tracking-[0.16em]'
+            : 'text-sm tracking-[0.18em]'
+        }`}
+      >
         Complexity Analysis
       </h2>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="bg-slate-900/60 rounded-lg px-4 py-3 border border-slate-700/50">
-          <p className="text-slate-400 text-xs mb-1 uppercase tracking-wider">
-            Best
-          </p>
-          <p className="text-white font-semibold text-sm">{current.best}</p>
-        </div>
-
-        <div className="bg-slate-900/60 rounded-lg px-4 py-3 border border-slate-700/50">
-          <p className="text-slate-400 text-xs mb-1 uppercase tracking-wider">
-            Average
-          </p>
-          <p className="text-white font-semibold text-sm">{current.average}</p>
-        </div>
-
-        <div className="bg-slate-900/60 rounded-lg px-4 py-3 border border-slate-700/50">
-          <p className="text-slate-400 text-xs mb-1 uppercase tracking-wider">
-            Worst
-          </p>
-          <p className="text-white font-semibold text-sm">{current.worst}</p>
-        </div>
-
-        <div className="bg-slate-900/60 rounded-lg px-4 py-3 border border-slate-700/50">
-          <p className="text-slate-400 text-xs mb-1 uppercase tracking-wider">
-            Space
-          </p>
-          <p className="text-white font-semibold text-sm">{current.space}</p>
-        </div>
+      <div
+        className={`grid ${
+          compact
+            ? 'grid-cols-2 gap-3'
+            : 'grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4'
+        }`}
+      >
+        {METRICS.map(([label, key]) => (
+          <div
+            key={key}
+            className={`min-w-0 rounded-lg border border-slate-700/50 bg-slate-900/60 ${
+              compact ? 'px-3 py-3 text-center' : 'px-4 py-3'
+            }`}
+          >
+            <p
+              className={`mb-1 uppercase text-slate-400 ${
+                compact ? 'text-[10px] tracking-wide' : 'text-xs tracking-wider'
+              }`}
+            >
+              {label}
+            </p>
+            <p
+              className={`break-words font-semibold leading-snug text-white ${
+                compact ? 'text-sm' : 'text-sm'
+              }`}
+            >
+              {current[key]}
+            </p>
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -69,7 +69,7 @@ const ALGORITHMS = [
   {
     title: 'Backtracking',
     description:
-      'N-Queens and Sudoku Solver — watch the algorithm place, conflict, and undo in real time.',
+      'N-Queens, Sudoku Solver, and Tower of Hanoi with step-by-step recursion.',
     color: 'theme-card border-rose-500/30 hover:border-rose-400',
     link: '/backtracking',
   },

--- a/src/components/backtrackingAlgo/CanvasTowerOfHanoi.jsx
+++ b/src/components/backtrackingAlgo/CanvasTowerOfHanoi.jsx
@@ -70,20 +70,13 @@ export const CanvasTowerOfHanoi = ({
   trigger = 0,
 }) => {
   const [frame, setFrame] = useState(null)
-  const [done, setDone] = useState(false)
-  const [prevTrigger, setPrevTrigger] = useState(trigger)
+  const [doneTrigger, setDoneTrigger] = useState(null)
   const timerRef = useRef(null)
 
   const frames = useMemo(() => {
     if (trigger === 0) return []
     return generateHanoiFrames(diskCount)
   }, [trigger, diskCount])
-
-  if (trigger !== prevTrigger) {
-    setPrevTrigger(trigger)
-    setFrame(null)
-    setDone(false)
-  }
 
   useEffect(() => {
     clearTimeout(timerRef.current)
@@ -96,9 +89,9 @@ export const CanvasTowerOfHanoi = ({
       if (index >= frames.length) return
 
       timerRef.current = setTimeout(() => {
-        setFrame(frames[index])
+        setFrame({ ...frames[index], trigger })
         if (index === frames.length - 1) {
-          setDone(true)
+          setDoneTrigger(trigger)
         } else {
           scheduleNext(index + 1)
         }
@@ -110,30 +103,32 @@ export const CanvasTowerOfHanoi = ({
     return () => clearTimeout(timerRef.current)
   }, [trigger, speed, frames])
 
-  const displayRods = frame?.rods ?? {
+  const activeFrame = frame?.trigger === trigger ? frame : null
+  const done = doneTrigger === trigger && trigger !== 0
+  const displayRods = activeFrame?.rods ?? {
     A: Array.from({ length: diskCount }, (_, index) => diskCount - index),
     B: [],
     C: [],
   }
   const totalMoves = 2 ** diskCount - 1
-  const currentMove = Math.min(frame?.moveNumber ?? 0, totalMoves)
+  const currentMove = Math.min(activeFrame?.moveNumber ?? 0, totalMoves)
   const status =
-    frame?.message ??
+    activeFrame?.message ??
     'Choose disk count and click Visualize to watch the recursive moves.'
 
   const diskClass = (rodKey, disk) => {
     if (
-      frame?.type === 'move' &&
-      frame?.to === rodKey &&
-      frame?.disk === disk
+      activeFrame?.type === 'move' &&
+      activeFrame?.to === rodKey &&
+      activeFrame?.disk === disk
     ) {
       return 'bg-cyan-400 text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.55)]'
     }
 
     if (
-      frame?.type === 'move' &&
-      frame?.from === rodKey &&
-      frame?.disk === disk
+      activeFrame?.type === 'move' &&
+      activeFrame?.from === rodKey &&
+      activeFrame?.disk === disk
     ) {
       return 'bg-orange-400 text-slate-950'
     }
@@ -147,11 +142,11 @@ export const CanvasTowerOfHanoi = ({
         <div className="grid w-full max-w-4xl grid-cols-1 gap-5 sm:grid-cols-3">
           {RODS.map((rodKey) => {
             const isActive =
-              frame?.from === rodKey ||
-              frame?.to === rodKey ||
-              frame?.source === rodKey ||
-              frame?.destination === rodKey ||
-              frame?.auxiliary === rodKey
+              activeFrame?.from === rodKey ||
+              activeFrame?.to === rodKey ||
+              activeFrame?.source === rodKey ||
+              activeFrame?.destination === rodKey ||
+              activeFrame?.auxiliary === rodKey
 
             return (
               <div
@@ -213,17 +208,17 @@ export const CanvasTowerOfHanoi = ({
           <div className="rounded-xl bg-slate-800/60 p-4 border border-slate-700 text-center">
             <p className="text-slate-400 text-xs">Recursive N</p>
             <h2 className="text-2xl font-bold text-orange-400 mt-1">
-              {frame?.activeN ?? '-'}
+              {activeFrame?.activeN ?? '-'}
             </h2>
           </div>
         </div>
 
-        {frame?.type === 'call' && (
+        {activeFrame?.type === 'call' && (
           <div className="w-full max-w-xl rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
             <span className="font-bold text-cyan-300">Call depth:</span>{' '}
-            {frame.depth} | move {frame.activeN} disk
-            {frame.activeN === 1 ? '' : 's'} from {frame.source} to{' '}
-            {frame.destination} using {frame.auxiliary}.
+            {activeFrame.depth} | move {activeFrame.activeN} disk
+            {activeFrame.activeN === 1 ? '' : 's'} from {activeFrame.source} to{' '}
+            {activeFrame.destination} using {activeFrame.auxiliary}.
           </div>
         )}
 

--- a/src/components/backtrackingAlgo/CanvasTowerOfHanoi.jsx
+++ b/src/components/backtrackingAlgo/CanvasTowerOfHanoi.jsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import StatusDisplay from '../StatusDisplay'
+import { calculateStepDelay } from '../../lib/utils'
+
+const RODS = ['A', 'B', 'C']
+
+function generateHanoiFrames(diskCount) {
+  const rods = {
+    A: Array.from({ length: diskCount }, (_, index) => diskCount - index),
+    B: [],
+    C: [],
+  }
+  const frames = []
+  let moveNumber = 0
+
+  function snapshot(type, message, active = {}) {
+    frames.push({
+      rods: {
+        A: [...rods.A],
+        B: [...rods.B],
+        C: [...rods.C],
+      },
+      type,
+      message,
+      moveNumber,
+      ...active,
+    })
+  }
+
+  function moveDisk(from, to) {
+    const disk = rods[from].pop()
+    rods[to].push(disk)
+    moveNumber += 1
+    snapshot('move', `Move disk ${disk} from rod ${from} to rod ${to}.`, {
+      from,
+      to,
+      disk,
+    })
+  }
+
+  function solve(n, source, auxiliary, destination, depth = 1) {
+    snapshot(
+      'call',
+      n === 1
+        ? `Base case: move disk 1 from ${source} to ${destination}.`
+        : `Move ${n - 1} disk${n - 1 === 1 ? '' : 's'} from ${source} to ${auxiliary} first.`,
+      { source, auxiliary, destination, depth, activeN: n }
+    )
+
+    if (n === 1) {
+      moveDisk(source, destination)
+      return
+    }
+
+    solve(n - 1, source, destination, auxiliary, depth + 1)
+    moveDisk(source, destination)
+    solve(n - 1, auxiliary, source, destination, depth + 1)
+  }
+
+  snapshot('start', `Starting Tower of Hanoi with ${diskCount} disks.`)
+  solve(diskCount, 'A', 'B', 'C')
+  snapshot('complete', `Complete in ${moveNumber} moves.`)
+
+  return frames
+}
+
+export const CanvasTowerOfHanoi = ({
+  diskCount = 4,
+  speed = 1,
+  trigger = 0,
+}) => {
+  const [frame, setFrame] = useState(null)
+  const [done, setDone] = useState(false)
+  const [prevTrigger, setPrevTrigger] = useState(trigger)
+  const timerRef = useRef(null)
+
+  const frames = useMemo(() => {
+    if (trigger === 0) return []
+    return generateHanoiFrames(diskCount)
+  }, [trigger, diskCount])
+
+  if (trigger !== prevTrigger) {
+    setPrevTrigger(trigger)
+    setFrame(null)
+    setDone(false)
+  }
+
+  useEffect(() => {
+    clearTimeout(timerRef.current)
+
+    if (trigger === 0 || frames.length === 0) return
+
+    const delay = calculateStepDelay(260, speed)
+
+    function scheduleNext(index) {
+      if (index >= frames.length) return
+
+      timerRef.current = setTimeout(() => {
+        setFrame(frames[index])
+        if (index === frames.length - 1) {
+          setDone(true)
+        } else {
+          scheduleNext(index + 1)
+        }
+      }, delay)
+    }
+
+    scheduleNext(0)
+
+    return () => clearTimeout(timerRef.current)
+  }, [trigger, speed, frames])
+
+  const displayRods = frame?.rods ?? {
+    A: Array.from({ length: diskCount }, (_, index) => diskCount - index),
+    B: [],
+    C: [],
+  }
+  const totalMoves = 2 ** diskCount - 1
+  const currentMove = Math.min(frame?.moveNumber ?? 0, totalMoves)
+  const status =
+    frame?.message ??
+    'Choose disk count and click Visualize to watch the recursive moves.'
+
+  const diskClass = (rodKey, disk) => {
+    if (
+      frame?.type === 'move' &&
+      frame?.to === rodKey &&
+      frame?.disk === disk
+    ) {
+      return 'bg-cyan-400 text-slate-950 shadow-[0_0_18px_rgba(34,211,238,0.55)]'
+    }
+
+    if (
+      frame?.type === 'move' &&
+      frame?.from === rodKey &&
+      frame?.disk === disk
+    ) {
+      return 'bg-orange-400 text-slate-950'
+    }
+
+    return 'bg-gradient-to-r from-indigo-500 to-cyan-500 text-white'
+  }
+
+  return (
+    <div className="w-full">
+      <div className="rounded-xl border border-white/10 bg-slate-900/50 p-5 sm:p-8 shadow-lg min-h-[350px] flex flex-col items-center justify-center gap-6">
+        <div className="grid w-full max-w-4xl grid-cols-1 gap-5 sm:grid-cols-3">
+          {RODS.map((rodKey) => {
+            const isActive =
+              frame?.from === rodKey ||
+              frame?.to === rodKey ||
+              frame?.source === rodKey ||
+              frame?.destination === rodKey ||
+              frame?.auxiliary === rodKey
+
+            return (
+              <div
+                key={rodKey}
+                className={`relative flex h-72 flex-col justify-end rounded-xl border p-4 transition-all duration-200 ${
+                  isActive
+                    ? 'border-cyan-400/70 bg-cyan-500/10'
+                    : 'border-slate-700 bg-slate-950/50'
+                }`}
+              >
+                <div className="absolute bottom-5 left-1/2 h-56 w-2 -translate-x-1/2 rounded-full bg-slate-600" />
+                <div className="absolute bottom-4 left-6 right-6 h-3 rounded-full bg-slate-600" />
+
+                <div className="relative z-10 flex min-h-56 flex-col-reverse items-center justify-start gap-1 pb-4">
+                  {displayRods[rodKey].map((disk) => {
+                    const width = 34 + disk * 13
+                    return (
+                      <div
+                        key={`${rodKey}-${disk}`}
+                        className={`h-7 rounded-lg border border-white/30 text-center text-xs font-extrabold leading-7 transition-all duration-300 ${diskClass(
+                          rodKey,
+                          disk
+                        )}`}
+                        style={{
+                          width: `${Math.min(width, 132)}px`,
+                        }}
+                      >
+                        {disk}
+                      </div>
+                    )
+                  })}
+                </div>
+
+                <div className="relative z-10 mt-3 text-center">
+                  <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">
+                    Rod {rodKey}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="grid w-full max-w-xl grid-cols-3 gap-4">
+          <div className="rounded-xl bg-slate-800/60 p-4 border border-slate-700 text-center">
+            <p className="text-slate-400 text-xs">Disks</p>
+            <h2 className="text-2xl font-bold text-cyan-400 mt-1">
+              {diskCount}
+            </h2>
+          </div>
+
+          <div className="rounded-xl bg-slate-800/60 p-4 border border-slate-700 text-center">
+            <p className="text-slate-400 text-xs">Move</p>
+            <h2 className="text-2xl font-bold text-emerald-400 mt-1">
+              {currentMove}/{totalMoves}
+            </h2>
+          </div>
+
+          <div className="rounded-xl bg-slate-800/60 p-4 border border-slate-700 text-center">
+            <p className="text-slate-400 text-xs">Recursive N</p>
+            <h2 className="text-2xl font-bold text-orange-400 mt-1">
+              {frame?.activeN ?? '-'}
+            </h2>
+          </div>
+        </div>
+
+        {frame?.type === 'call' && (
+          <div className="w-full max-w-xl rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
+            <span className="font-bold text-cyan-300">Call depth:</span>{' '}
+            {frame.depth} | move {frame.activeN} disk
+            {frame.activeN === 1 ? '' : 's'} from {frame.source} to{' '}
+            {frame.destination} using {frame.auxiliary}.
+          </div>
+        )}
+
+        {done && (
+          <p className="text-emerald-400 font-bold text-sm">
+            Complete in {totalMoves} moves.
+          </p>
+        )}
+      </div>
+
+      <div className="mt-8 mb-2">
+        <StatusDisplay message={status} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/backtrackingAlgo/MenuSetAlgoBacktracking.jsx
+++ b/src/components/backtrackingAlgo/MenuSetAlgoBacktracking.jsx
@@ -6,6 +6,8 @@ export const MenuSetAlgoBacktracking = ({
   setAlgo,
   boardSize,
   setBoardSize,
+  diskCount,
+  setDiskCount,
   onVisualize,
   onReset,
 }) => {
@@ -22,8 +24,8 @@ export const MenuSetAlgoBacktracking = ({
             Algorithm
           </label>
 
-          <div className="flex rounded-xl overflow-hidden border border-slate-700">
-            {['nqueens', 'sudoku'].map((key) => (
+          <div className="grid grid-cols-3 rounded-xl overflow-hidden border border-slate-700">
+            {['nqueens', 'sudoku', 'hanoi'].map((key) => (
               <button
                 key={key}
                 onClick={() => setAlgo(key)}
@@ -33,7 +35,11 @@ export const MenuSetAlgoBacktracking = ({
                     : 'bg-slate-800 text-slate-400 hover:text-white'
                 }`}
               >
-                {key === 'nqueens' ? 'N-Queens' : 'Sudoku'}
+                {key === 'nqueens'
+                  ? 'N-Queens'
+                  : key === 'sudoku'
+                    ? 'Sudoku'
+                    : 'Hanoi'}
               </button>
             ))}
           </div>
@@ -59,6 +65,33 @@ export const MenuSetAlgoBacktracking = ({
                 {[4, 5, 6, 7, 8].map((n) => (
                   <option key={n} value={n}>
                     {n} × {n}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </Tooltip>
+        )}
+
+        {/* Tower of Hanoi Disk Count */}
+        {algo === 'hanoi' && (
+          <Tooltip
+            content="Each extra disk doubles the number of moves"
+            position="right"
+            className="w-full"
+          >
+            <div>
+              <label className="block text-xs text-slate-400 mb-1 pl-1">
+                Disk Count
+              </label>
+
+              <select
+                value={diskCount}
+                onChange={(e) => setDiskCount(Number(e.target.value))}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white outline-none focus:border-cyan-500"
+              >
+                {[3, 4, 5, 6, 7, 8].map((n) => (
+                  <option key={n} value={n}>
+                    {n} disks - {2 ** n - 1} moves
                   </option>
                 ))}
               </select>

--- a/src/components/backtrackingAlgo/VisualizerPage.jsx
+++ b/src/components/backtrackingAlgo/VisualizerPage.jsx
@@ -6,6 +6,7 @@ import ComplexityCard from '../ComplexityCard'
 import CodePanel from '../visualizer/CodePanel'
 import { CanvasNQueens } from './CanvasNQueens'
 import { CanvasSudoku } from './CanvasSudoku'
+import { CanvasTowerOfHanoi } from './CanvasTowerOfHanoi'
 import { MenuSetAlgoBacktracking } from './MenuSetAlgoBacktracking'
 import { ComparisonMode } from './ComparisonMode'
 import { getBacktrackingSource } from '../../algorithms/backtracking/backtrackingSources'
@@ -133,6 +134,7 @@ export default function VisualizerPage() {
 function SoloMode() {
   const [algo, setAlgo] = useState('nqueens')
   const [boardSize, setBoardSize] = useState(6)
+  const [diskCount, setDiskCount] = useState(4)
   const [speed, setSpeed] = useState(1)
   const [language, setLanguage] = useState('javascript')
   const [trigger, setTrigger] = useState(0)
@@ -150,7 +152,8 @@ function SoloMode() {
     [algo, language]
   )
 
-  const complexityKey = algo === 'nqueens' ? 'nqueens' : 'sudoku'
+  const complexityKey =
+    algo === 'nqueens' ? 'nqueens' : algo === 'hanoi' ? 'hanoi' : 'sudoku'
 
   return (
     <div className="flex flex-col lg:flex-row p-4 sm:p-6 gap-6">
@@ -165,6 +168,8 @@ function SoloMode() {
           setAlgo={handleAlgoChange}
           boardSize={boardSize}
           setBoardSize={setBoardSize}
+          diskCount={diskCount}
+          setDiskCount={setDiskCount}
           onVisualize={handleVisualize}
           onReset={handleReset}
         />
@@ -193,13 +198,19 @@ function SoloMode() {
           </select>
         </div>
 
-        <ComplexityCard algorithm={complexityKey} />
+        <ComplexityCard algorithm={complexityKey} compact />
       </div>
 
       {/* Canvas + Code Panel */}
       <div className="w-full lg:w-3/4 xl:w-4/5 flex flex-col gap-6">
         {algo === 'nqueens' ? (
           <CanvasNQueens n={boardSize} speed={speed} trigger={trigger} />
+        ) : algo === 'hanoi' ? (
+          <CanvasTowerOfHanoi
+            diskCount={diskCount}
+            speed={speed}
+            trigger={trigger}
+          />
         ) : (
           <CanvasSudoku speed={speed} trigger={trigger} />
         )}
@@ -208,7 +219,9 @@ function SoloMode() {
           title={
             algo === 'nqueens'
               ? 'N-Queens Implementation'
-              : 'Sudoku Solver Implementation'
+              : algo === 'hanoi'
+                ? 'Tower of Hanoi Implementation'
+                : 'Sudoku Solver Implementation'
           }
           code={currentSource}
           language={language}

--- a/src/data/complexityMap.js
+++ b/src/data/complexityMap.js
@@ -123,6 +123,12 @@ export const complexityMap = {
     worst: 'O(9^M)',
     space: 'O(M)',
   },
+  hanoi: {
+    best: 'O(2^N)',
+    average: 'O(2^N)',
+    worst: 'O(2^N)',
+    space: 'O(N)',
+  },
   gcd: {
     best: 'O(log min(a, b))',
     average: 'O(log min(a, b))',


### PR DESCRIPTION
## Pull Request Summary


### What changed?
Added a Tower of Hanoi visualizer to the Backtracking section with animated rod and disk movement, disk-count selection, move tracking, recursive call context, and completion state. The Backtracking controls, code panel, complexity card, and home page card were updated to include Tower of Hanoi alongside N-Queens and Sudoku.

Also added multilingual Tower of Hanoi source snippets and a compact complexity layout for the Backtracking sidebar.

### Why is this needed?
Tower of Hanoi is a foundational recursion problem and fits naturally with AlgoScope's Backtracking visualizer. This gives learners a simpler visual entry point into recursive decomposition, base cases, call flow, and exponential time complexity before moving to harder problems like N-Queens and Sudoku.

Closes #359 

## Type of Change

- [x] `feat` - New user-facing feature or algorithm capability
- [x] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [x] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes
- Added a Tower of Hanoi visualizer with animated disk movement, recursive call context, move tracking, and complexity analysis.

Release note category:

- [x] Added
- [ ] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required



## Testing and Verification

- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings


## UI Evidence
Before:
Backtracking section only supported N-Queens and Sudoku.

After:
Backtracking section includes Tower of Hanoi with disk count selection, animated rods/disks, move counter, recursive call display, code snippets, and compact complexity analysis.
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/386ef89f-5438-48d3-8110-08cef6ad1a44" />


## CI/CD and Deployment Impact

- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:
No new dependencies, environment variables, routing changes, or deployment steps are required.

## Reviewer Checklist


- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tower of Hanoi examples in multiple languages and a new interactive, step-by-step Hanoi visualization with disk count and speed controls; integrated into the algorithm selector and code panel.
  * Home page description updated to include Tower of Hanoi alongside N‑Queens and Sudoku.

* **Style**
  * Refactored complexity display into a data-driven, responsive card with an optional compact layout.
  * Added Hanoi to complexity metrics (O(2^N) time, O(N) space).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->