### PR TITLE
fix(sandbox): prevent Worker benchmark spoofing through unrestricted message access 

### DIFF
--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -73,13 +73,37 @@ const Terminal = React.forwardRef(function Terminal({ logs, onClear }, ref) {
 
 const runCodeInWorker = (userCode, inputVal) => {
   return new Promise((resolve) => {
+    const executionToken = typeof crypto !== 'undefined' && crypto.randomUUID 
+      ? crypto.randomUUID() 
+      : Math.random().toString(36).substring(2) + Date.now().toString(36);
+
     const workerCode = `
       self.onmessage = function(e) {
-        const { code, input } = e.data;
+        const { code, input, token } = e.data;
         const logs = [];
         
         const originalLog = self.console.log;
         const originalError = self.console.error;
+        const originalPostMessage = self.postMessage;
+        
+        // 1. Completely remove communication APIs from prototype chain
+        let currentProto = self;
+        while (currentProto) {
+          ['postMessage', 'close', 'importScripts'].forEach(method => {
+            if (currentProto.hasOwnProperty(method)) {
+               try { delete currentProto[method]; } catch(e) {}
+            }
+          });
+          currentProto = Object.getPrototypeOf(currentProto);
+        }
+
+        // 2. Shadow dangerous globals on the instance
+        self.postMessage = undefined;
+        self.close = undefined;
+        self.importScripts = undefined;
+        self.onmessage = undefined;
+        self.WorkerGlobalScope = undefined;
+        self.DedicatedWorkerGlobalScope = undefined;
         
         self.console.log = function(...args) {
           const content = args.map(arg => {
@@ -103,13 +127,15 @@ const runCodeInWorker = (userCode, inputVal) => {
         
         const startTime = self.performance.now();
         try {
-          const runner = new Function('input', code);
+          // 3. Wrap execution in an IIFE that shadows common aliases in local scope
+          const wrappedCode = "\\n(function(self, globalThis, postMessage, close, importScripts, onmessage) {\\n" + code + "\\n})();\\n";
+          const runner = new Function('input', wrappedCode);
           runner(input);
           const endTime = self.performance.now();
-          self.postMessage({ status: 'success', logs, duration: endTime - startTime });
+          originalPostMessage.call(self, { __token: token, status: 'success', logs, duration: endTime - startTime });
         } catch (err) {
           const endTime = self.performance.now();
-          self.postMessage({ status: 'error', error: err.message, logs, duration: endTime - startTime });
+          originalPostMessage.call(self, { __token: token, status: 'error', error: err.message, logs, duration: endTime - startTime });
         } finally {
           self.console.log = originalLog;
           self.console.error = originalError;
@@ -137,10 +163,13 @@ const runCodeInWorker = (userCode, inputVal) => {
     }, 3000)
 
     worker.onmessage = (e) => {
-      clearTimeout(timeout)
-      worker.terminate()
-      URL.revokeObjectURL(workerURL)
-      resolve(e.data)
+      if (e.data && e.data.__token === executionToken) {
+        clearTimeout(timeout)
+        worker.terminate()
+        URL.revokeObjectURL(workerURL)
+        const { __token, ...safeData } = e.data
+        resolve(safeData)
+      }
     }
 
     worker.onerror = (err) => {
@@ -157,7 +186,7 @@ const runCodeInWorker = (userCode, inputVal) => {
       })
     }
 
-    worker.postMessage({ code: userCode, input: inputVal })
+    worker.postMessage({ code: userCode, input: inputVal, token: executionToken })
   })
 }
 


### PR DESCRIPTION
## Pull Request Summary

### What changed?

This PR hardens the Practice Sandbox Worker runtime against benchmark spoofing and unauthorized Worker message manipulation.

The sandbox previously executed user code directly inside the Worker global scope using `new Function(...)`, allowing access to sensitive Worker APIs such as:
- `self.postMessage`
- `postMessage`
- `globalThis.postMessage`
- `close`
- `importScripts`

This made it possible to inject spoofed benchmark timings, fake execution states, and arbitrary runtime payloads into the UI.

To address this, the Worker execution environment is now isolated using:
- prototype-chain communication API stripping
- instance-level shadowing of dangerous globals
- scoped IIFE execution wrapping
- execution token validation for trusted Worker responses

---

### Why is this needed?

Closes #310

Previously, user-controlled code running inside the Worker could directly interfere with the sandbox communication lifecycle and spoof benchmark results.

The root cause was that dynamically executed user code inherited unrestricted access to Worker globals and the UI trusted Worker messages without strict runtime ownership validation.

This PR establishes a lightweight but robust trust boundary while preserving normal sandbox execution performance and usability.

---

## Type of Change

- [x] `fix` - Bug fix or regression fix

---

## Release Notes

Release note category:

- [ ] Added
- [ ] Changed
- [x] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

- Fixed Practice Sandbox Worker benchmark spoofing vulnerability caused by unrestricted access to Worker communication APIs.

---

## Testing and Verification

- [x] `npm install`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

### Additional testing performed

The following exploit payloads were tested and successfully blocked:

```js
self.postMessage({
  status: "success",
  duration: -99999
})
```

```js
globalThis.postMessage({
  status: "success"
})
```

```js
postMessage({
  status: "success"
})
```

```js
Function("self.postMessage({status:'success'})")()
```

Additional runtime verification:
- benchmark timings remain internally controlled
- compare mode still functions correctly
- worker lifecycle cleanup remains stable
- timeout protection still works correctly
- normal recursive and iterative algorithms execute successfully

---

## UI Evidence

### Before

- User code could spoof benchmark timings and inject fake runtime payloads through Worker message APIs.

### After
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/c43c6550-567b-4567-88b6-83dc626d2652" />

- Malicious Worker communication attempts now fail safely with runtime errors.
- Benchmark state remains internally controlled and protected from user manipulation.

---

## CI/CD and Deployment Impact

- [x] No deployment impact expected

Deployment notes:

- No environment variable changes
- No dependency updates
- No routing/build pipeline impact

---

## Reviewer Checklist

- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [x] UI evidence is included when user-facing screens changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security isolation for code execution, preventing unauthorized access to sensitive messaging APIs and system resources during user code execution.

* **Refactor**
  * Improved message verification and routing mechanisms to ensure secure and reliable communication between execution environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->