### PR TITLE
feat(grid-visualizer): add grid comparison mode

### DIFF
--- a/src/components/shortestPathAlgo/GridComparisonMode.jsx
+++ b/src/components/shortestPathAlgo/GridComparisonMode.jsx
@@ -1,9 +1,8 @@
-import React, { useState, useCallback, useRef, useMemo, memo } from 'react'
+import { useState, useCallback, useMemo, useEffect, memo, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 
 const ROWS = 8
 const COLS = 14
-
 const START_ROW = 3
 const START_COL = 2
 const END_ROW = 4
@@ -23,6 +22,16 @@ const STEP_BATCHING = {
   BELLMAN_FORD_STEP_MODULO: 15,
   FLOYD_WARSHALL_UPDATE_MODULO: 20,
 }
+
+const DEFAULT_METRICS = {
+  visited: 0,
+  pathCost: null,
+  visualizationTime: 0,
+  steps: 0,
+  score: 0,
+}
+
+const ALGORITHM_KEYS = ['dijkstra', 'bellmanford', 'floydwarshall']
 
 const ALGO_META = {
   dijkstra: {
@@ -60,6 +69,8 @@ const ALGO_META = {
   },
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
 const createNode = (row, col) => ({
   row,
   col,
@@ -81,29 +92,42 @@ const createGrid = () => {
     }
     grid.push(currentRow)
   }
-  
+
   const walls = [
-    [2, 4], [2, 5], [2, 6], [2, 7],
-    [5, 6], [5, 7], [5, 8], [5, 9],
-    [1, 8], [2, 8], [3, 8], [4, 8],
+    [2, 4],
+    [2, 5],
+    [2, 6],
+    [2, 7],
+    [5, 6],
+    [5, 7],
+    [5, 8],
+    [5, 9],
+    [1, 8],
+    [2, 8],
+    [3, 8],
+    [4, 8],
   ]
-  
+
   walls.forEach(([r, c]) => {
     if (!grid[r][c].isStart && !grid[r][c].isEnd) {
       grid[r][c].isWall = true
     }
   })
-  
+
   return grid
 }
 
 const getNeighbors = (node, currentGrid) => {
   const neighbors = []
   const { row, col } = node
-  if (row > 0 && !currentGrid[row - 1][col].isWall) neighbors.push(currentGrid[row - 1][col])
-  if (row < ROWS - 1 && !currentGrid[row + 1][col].isWall) neighbors.push(currentGrid[row + 1][col])
-  if (col > 0 && !currentGrid[row][col - 1].isWall) neighbors.push(currentGrid[row][col - 1])
-  if (col < COLS - 1 && !currentGrid[row][col + 1].isWall) neighbors.push(currentGrid[row][col + 1])
+  if (row > 0 && !currentGrid[row - 1][col].isWall)
+    neighbors.push(currentGrid[row - 1][col])
+  if (row < ROWS - 1 && !currentGrid[row + 1][col].isWall)
+    neighbors.push(currentGrid[row + 1][col])
+  if (col > 0 && !currentGrid[row][col - 1].isWall)
+    neighbors.push(currentGrid[row][col - 1])
+  if (col < COLS - 1 && !currentGrid[row][col + 1].isWall)
+    neighbors.push(currentGrid[row][col + 1])
   return neighbors
 }
 
@@ -113,10 +137,10 @@ const generateDijkstraSteps = (grid) => {
   const visited = new Set()
   const parent = new Map()
   const queue = []
-  
+
   const startNode = grid[START_ROW][START_COL]
   const endNode = grid[END_ROW][END_COL]
-  
+
   for (let row of grid) {
     for (let cell of row) {
       distances.set(cell, Infinity)
@@ -124,14 +148,14 @@ const generateDijkstraSteps = (grid) => {
   }
   distances.set(startNode, 0)
   queue.push(startNode)
-  
+
   while (queue.length > 0) {
     queue.sort((a, b) => distances.get(a) - distances.get(b))
     const current = queue.shift()
-    
+
     if (visited.has(current)) continue
     visited.add(current)
-    
+
     steps.push({
       type: 'visit',
       node: current,
@@ -139,9 +163,9 @@ const generateDijkstraSteps = (grid) => {
       queueSize: queue.length,
       currentDistance: distances.get(current),
     })
-    
+
     if (current === endNode) break
-    
+
     const neighbors = getNeighbors(current, grid)
     for (let neighbor of neighbors) {
       if (visited.has(neighbor)) continue
@@ -158,7 +182,7 @@ const generateDijkstraSteps = (grid) => {
       }
     }
   }
-  
+
   const path = []
   let current = endNode
   while (current && parent.has(current)) {
@@ -167,29 +191,34 @@ const generateDijkstraSteps = (grid) => {
   }
   const hasValidPath = path.length > 0 && path[0] === startNode
   const finalPath = hasValidPath ? [startNode, ...path] : []
-  
-  const totalRelaxations = steps.filter(s => s.type === 'relax').length
-  
-  return { steps, path: finalPath, distances, totalRelaxations, visitedCount: visited.size }
+  const totalRelaxations = steps.filter((s) => s.type === 'relax').length
+
+  return {
+    steps,
+    path: finalPath,
+    distances,
+    totalRelaxations,
+    visitedCount: visited.size,
+  }
 }
 
 const generateBellmanFordSteps = (grid) => {
   const steps = []
   const distances = new Map()
   const parent = new Map()
-  
+
   const startNode = grid[START_ROW][START_COL]
   const endNode = grid[END_ROW][END_COL]
   const allNodes = grid.flat()
-  
+
   for (let node of allNodes) {
     distances.set(node, Infinity)
   }
   distances.set(startNode, 0)
-  
+
   let totalRelaxations = 0
   const visitedNodesSet = new Set()
-  
+
   for (let i = 0; i < allNodes.length - 1; i++) {
     let relaxed = false
     for (let u of allNodes) {
@@ -203,7 +232,9 @@ const generateBellmanFordSteps = (grid) => {
           relaxed = true
           totalRelaxations++
           visitedNodesSet.add(v)
-          const shouldRecordStep = steps.length % STEP_BATCHING.BELLMAN_FORD_STEP_MODULO === 0 || steps.length < 10
+          const shouldRecordStep =
+            steps.length % STEP_BATCHING.BELLMAN_FORD_STEP_MODULO === 0 ||
+            steps.length < 10
           if (shouldRecordStep) {
             steps.push({
               type: 'relax',
@@ -218,7 +249,7 @@ const generateBellmanFordSteps = (grid) => {
     }
     if (!relaxed) break
   }
-  
+
   const path = []
   let current = endNode
   while (current && parent.has(current)) {
@@ -227,23 +258,33 @@ const generateBellmanFordSteps = (grid) => {
   }
   const hasValidPath = path.length > 0 && path[0] === startNode
   const finalPath = hasValidPath ? [startNode, ...path] : []
-  
-  return { steps, path: finalPath, distances, totalRelaxations, visitedCount: visitedNodesSet.size }
+
+  return {
+    steps,
+    path: finalPath,
+    distances,
+    totalRelaxations,
+    visitedCount: visitedNodesSet.size,
+  }
 }
 
 const generateFloydWarshallSteps = (grid) => {
-  const allNodes = grid.flat().filter(n => !n.isWall)
+  const allNodes = grid.flat().filter((n) => !n.isWall)
   const nodeIndex = new Map()
   allNodes.forEach((node, idx) => nodeIndex.set(node, idx))
-  
+
   const n = allNodes.length
-  const dist = Array(n).fill().map(() => Array(n).fill(Infinity))
-  const next = Array(n).fill().map(() => Array(n).fill(null))
-  
+  const dist = Array(n)
+    .fill(null)
+    .map(() => Array(n).fill(Infinity))
+  const next = Array(n)
+    .fill(null)
+    .map(() => Array(n).fill(null))
+
   for (let i = 0; i < n; i++) {
     dist[i][i] = 0
   }
-  
+
   for (let u of allNodes) {
     const neighbors = getNeighbors(u, grid)
     for (let v of neighbors) {
@@ -253,11 +294,11 @@ const generateFloydWarshallSteps = (grid) => {
       next[ui][vi] = v
     }
   }
-  
+
   let matrixUpdates = 0
   const steps = []
   const visitedNodesSet = new Set()
-  
+
   for (let k = 0; k < n; k++) {
     for (let i = 0; i < n; i++) {
       for (let j = 0; j < n; j++) {
@@ -266,100 +307,129 @@ const generateFloydWarshallSteps = (grid) => {
           dist[i][j] = dist[i][k] + dist[k][j]
           next[i][j] = next[i][k]
           matrixUpdates++
-          
-          const shouldRecordStep = matrixUpdates % STEP_BATCHING.FLOYD_WARSHALL_UPDATE_MODULO === 0 || matrixUpdates < 10
+
+          const shouldRecordStep =
+            matrixUpdates % STEP_BATCHING.FLOYD_WARSHALL_UPDATE_MODULO === 0 ||
+            matrixUpdates < 10
           if (shouldRecordStep) {
             const node1 = allNodes[i]
             const node2 = allNodes[j]
-            const isValidNode = node1 && !node1.isWall
-            const isValidTarget = node2 && !node2.isWall
-            if (isValidNode) visitedNodesSet.add(node1)
-            if (isValidTarget) visitedNodesSet.add(node2)
-            
-            steps.push({
-              type: 'update',
-              node1,
-              node2,
-              k,
-              matrixUpdates,
-            })
+            if (node1 && !node1.isWall) visitedNodesSet.add(node1)
+            if (node2 && !node2.isWall) visitedNodesSet.add(node2)
+            steps.push({ type: 'update', node1, node2, k, matrixUpdates })
           }
         }
       }
     }
   }
-  
+
   const startNode = grid[START_ROW][START_COL]
   const endNode = grid[END_ROW][END_COL]
   const startIdx = nodeIndex.get(startNode)
   const endIdx = nodeIndex.get(endNode)
-  
+
   const path = []
-  const hasValidIndices = startIdx !== undefined && endIdx !== undefined
-  const hasFiniteDistance = hasValidIndices && dist[startIdx][endIdx] !== Infinity
-  
+  const hasFiniteDistance =
+    startIdx !== undefined &&
+    endIdx !== undefined &&
+    dist[startIdx][endIdx] !== Infinity
+
   if (hasFiniteDistance) {
     let current = startNode
-    while (current !== endNode) {
+    let guard = 0
+    const maxIterations = allNodes.length * 2
+
+    while (current !== endNode && guard < maxIterations) {
       const currentIdx = nodeIndex.get(current)
+      if (currentIdx === undefined) break
       const nextNode = next[currentIdx][endIdx]
-      if (!nextNode) break
+      if (!nextNode || nextNode === current) break
       path.push(nextNode)
       current = nextNode
+      guard++
     }
   }
-  
-  return { steps, path, matrixUpdates, visitedCount: visitedNodesSet.size, distances: dist }
+
+  return {
+    steps,
+    path,
+    matrixUpdates,
+    visitedCount: visitedNodesSet.size,
+    distances: dist,
+  }
 }
 
 const createInitialAlgoStates = () => ({
-  dijkstra: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
-  bellmanford: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
-  floydwarshall: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
+  dijkstra: {
+    status: 'idle',
+    metrics: { ...DEFAULT_METRICS },
+    progress: 0,
+    liveMetrics: {},
+  },
+  bellmanford: {
+    status: 'idle',
+    metrics: { ...DEFAULT_METRICS },
+    progress: 0,
+    liveMetrics: {},
+  },
+  floydwarshall: {
+    status: 'idle',
+    metrics: { ...DEFAULT_METRICS },
+    progress: 0,
+    liveMetrics: {},
+  },
 })
 
-const updateVisitedState = (prevStates, algoKey, node) => {
+const updateVisualizationState = (prevStates, algoKey, node) => {
   const newState = { algoKey, [`${node.row}-${node.col}`]: true }
-  const filtered = prevStates.filter(s => s.algoKey !== algoKey)
-  return [...filtered, newState]
-}
-
-const updatePathState = (prevStates, algoKey, node) => {
-  const newState = { algoKey, [`${node.row}-${node.col}`]: true }
-  const filtered = prevStates.filter(s => s.algoKey !== algoKey)
+  const filtered = prevStates.filter((s) => s.algoKey !== algoKey)
   return [...filtered, newState]
 }
 
 const getPathCost = (result, grid) => {
-  const hasDistanceMatrix = result.distances && typeof result.distances === 'object' && result.distances[END_ROW]
-  if (hasDistanceMatrix) {
-    const cost = result.distances[END_ROW][END_COL]
-    return (cost !== Infinity && cost !== null && cost !== undefined) ? cost : null
+  if (Array.isArray(result.distances)) {
+    const startNode = grid[START_ROW][START_COL]
+    const endNode = grid[END_ROW][END_COL]
+    const allNodes = grid.flat().filter((n) => !n.isWall)
+    const nodeIndex = new Map()
+    allNodes.forEach((node, idx) => nodeIndex.set(node, idx))
+    const startIdx = nodeIndex.get(startNode)
+    const endIdx = nodeIndex.get(endNode)
+    if (startIdx === undefined || endIdx === undefined) return null
+    const cost = result.distances[startIdx][endIdx]
+    return cost !== Infinity ? cost : null
   }
-  
-  const hasMapDistance = result.distances?.get
-  if (hasMapDistance) {
+
+  if (result.distances?.get) {
     const cost = result.distances.get(grid[END_ROW][END_COL])
-    return (cost !== Infinity && cost !== null && cost !== undefined) ? cost : null
+    return cost !== Infinity && cost !== undefined ? cost : null
   }
-  
+
   return null
 }
 
 const buildMetrics = (result, startTime, endTime, grid) => {
   const pathCost = getPathCost(result, grid)
-  const relaxations = result.totalRelaxations || result.steps?.filter(s => s.type === 'relax' || s.type === 'update').length || 0
+  const relaxations =
+    result.totalRelaxations ||
+    result.steps?.filter((s) => s.type === 'relax' || s.type === 'update')
+      .length ||
+    0
   const matrixUpdates = result.matrixUpdates || 0
   const visitedCount = result.visitedCount || 0
-  
+
   return {
     visitedCount,
     pathCost,
-    time: Math.round(endTime - startTime),
+    visualizationTime: Math.round(endTime - startTime),
     pathFound: result.path?.length > 0,
     relaxations,
     matrixUpdates,
   }
+}
+
+const shouldUpdateProgress = (index, totalSteps, batchSize) => {
+  return index % batchSize === 0 || index === totalSteps - 1
 }
 
 const SharedGridPreview = memo(({ grid, visitedStates, pathStates }) => {
@@ -371,166 +441,238 @@ const SharedGridPreview = memo(({ grid, visitedStates, pathStates }) => {
     if (cell.isStart) return '#10b981'
     if (cell.isEnd) return '#ef4444'
     if (cell.isWall) return 'rgba(51,65,85,0.9)'
-    
-    const hasPath = pathStates.some(state => state[`${cell.row}-${cell.col}`])
+
+    const hasPath = pathStates.some((state) => state[`${cell.row}-${cell.col}`])
     if (hasPath) {
-      const activeAlgo = pathStates.find(state => state[`${cell.row}-${cell.col}`])
-      if (activeAlgo) return ALGO_META[activeAlgo.algoKey]?.pathColor || '#fbbf24'
+      const activeAlgo = pathStates.find(
+        (state) => state[`${cell.row}-${cell.col}`]
+      )
+      if (activeAlgo)
+        return ALGO_META[activeAlgo.algoKey]?.pathColor || '#fbbf24'
     }
-    
-    const visitedAlgos = visitedStates.filter(state => state[`${cell.row}-${cell.col}`])
+
+    const visitedAlgos = visitedStates.filter(
+      (state) => state[`${cell.row}-${cell.col}`]
+    )
     const visitedCount = visitedAlgos.length
-    
+
     if (visitedCount > 0) {
       if (visitedCount === 1) {
-        return ALGO_META[visitedAlgos[0].algoKey]?.visitedColor || 'rgba(6,182,212,0.2)'
+        return (
+          ALGO_META[visitedAlgos[0].algoKey]?.visitedColor ||
+          'rgba(6,182,212,0.2)'
+        )
       }
       return 'rgba(100,100,100,0.12)'
     }
-    
+
     if (cell.isWeighted) return 'rgba(249,115,22,0.5)'
     return 'rgba(30,41,59,0.6)'
   }
 
   return (
-    <div className="flex justify-center">
-      <div className="relative rounded-lg overflow-hidden border border-slate-700/60 bg-slate-950/40 shadow-lg">
-        <svg width={width} height={height} style={{ imageRendering: 'pixelated' }}>
-          {grid.map((row, r) =>
-            row.map((cell, c) => (
-              <rect
-                key={`${r}-${c}`}
-                x={c * cellSize}
-                y={r * cellSize}
-                width={cellSize}
-                height={cellSize}
-                fill={getCellColor(cell)}
-                stroke="rgba(71,85,105,0.3)"
-                strokeWidth={0.5}
-              />
-            ))
-          )}
-        </svg>
-      </div>
-    </div>
+    <svg width={width} height={height} style={{ imageRendering: 'pixelated' }}>
+      {grid.map((row, r) =>
+        row.map((cell, c) => (
+          <rect
+            key={`${r}-${c}`}
+            x={c * cellSize}
+            y={r * cellSize}
+            width={cellSize}
+            height={cellSize}
+            fill={getCellColor(cell)}
+            stroke="rgba(71,85,105,0.3)"
+            strokeWidth={0.5}
+          />
+        ))
+      )}
+    </svg>
   )
 })
 
-const ComparisonCard = memo(({ algoKey, status, metrics, isWinner, progress, liveMetrics }) => {
-  const meta = ALGO_META[algoKey]
+SharedGridPreview.displayName = 'SharedGridPreview'
 
-  const getStatusText = () => {
-    if (status === 'idle') return 'Ready'
-    if (status === 'running') return 'Running...'
-    if (status === 'complete') return 'Complete'
-    return 'Ready'
-  }
+const ComparisonCard = memo(
+  ({ algoKey, status, metrics, isWinner, progress, liveMetrics }) => {
+    const meta = ALGO_META[algoKey]
 
-  const statusColor = (() => {
-    if (status === 'complete') return meta.accent
-    if (status === 'running') return '#94a3b8'
-    return '#334155'
-  })()
-
-  const displayVisited = liveMetrics?.visitedCount || metrics.visited || '—'
-  const displayPathCost = (() => {
-    if (liveMetrics?.currentDistance !== undefined && liveMetrics.currentDistance !== Infinity) {
-      return liveMetrics.currentDistance.toFixed(1)
+    const getStatusText = () => {
+      if (status === 'idle') return 'Ready'
+      if (status === 'running') return 'Running...'
+      if (status === 'complete') return 'Complete'
+      return 'Ready'
     }
-    if (metrics.pathCost !== null) return metrics.pathCost.toFixed(1)
-    return '—'
-  })()
-  
-  const hasLiveMetric = liveMetrics?.queueSize !== undefined || liveMetrics?.iteration !== undefined
-  const displayQueueIter = (() => {
-    if (algoKey === 'dijkstra' && liveMetrics?.queueSize !== undefined) return liveMetrics.queueSize
-    if (algoKey === 'bellmanford' && liveMetrics?.iteration !== undefined) return `Iter ${liveMetrics.iteration}`
-    if (algoKey === 'floydwarshall' && liveMetrics?.k !== undefined) return `k=${liveMetrics.k}`
-    return '—'
-  })()
-  
-  const hasRelaxMetric = liveMetrics?.relaxations !== undefined || liveMetrics?.matrixUpdates !== undefined
-  const displayRelaxUpdate = (() => {
-    if (algoKey === 'dijkstra' && liveMetrics?.relaxations !== undefined) return liveMetrics.relaxations
-    if (algoKey === 'bellmanford' && liveMetrics?.relaxations !== undefined) return liveMetrics.relaxations
-    if (algoKey === 'floydwarshall' && liveMetrics?.matrixUpdates !== undefined) return liveMetrics.matrixUpdates
-    return '—'
-  })()
 
-  return (
-    <motion.div
-      className="rounded-2xl flex flex-col overflow-hidden border transition-all duration-500"
-      style={{
-        background: isWinner && status === 'complete'
-          ? `linear-gradient(145deg, rgba(15,23,42,0.98), ${meta.accentBg})`
-          : 'rgba(15,23,42,0.85)',
-        borderColor: isWinner && status === 'complete' ? meta.accent : 'rgba(51,65,85,0.7)',
-        boxShadow: isWinner && status === 'complete' ? `0 0 20px ${meta.glow}` : 'none',
-      }}
-    >
-      <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-800/80">
-        <div className="flex items-center gap-2">
-          <motion.div
-            className="w-2 h-2 rounded-full"
-            style={{ background: meta.accent }}
-            animate={status === 'running' ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
-            transition={{ duration: 0.9, repeat: Infinity }}
-          />
-          <span className="text-xs font-bold text-white tracking-wider">{meta.label}</span>
-        </div>
-        <span className="text-[9px] font-mono px-2 py-0.5 rounded bg-slate-950" style={{ color: statusColor }}>
-          {getStatusText()}
-        </span>
-      </div>
+    const statusColor = (() => {
+      if (status === 'complete') return meta.accent
+      if (status === 'running') return '#94a3b8'
+      return '#334155'
+    })()
 
-      {status === 'running' && progress > 0 && (
-        <div className="h-0.5 bg-slate-800">
-          <motion.div
-            className="h-full"
-            style={{ background: meta.accent }}
-            initial={{ width: 0 }}
-            animate={{ width: `${progress}%` }}
-            transition={{ duration: 0.3 }}
-          />
-        </div>
-      )}
+    const displayVisited = liveMetrics?.visitedCount || metrics.visited || '—'
 
-      <div className="p-4 space-y-3">
-        <div className="grid grid-cols-2 gap-3">
-          <div className="text-center">
-            <p className="text-[8px] uppercase tracking-wider text-slate-500">Visited</p>
-            <p className="text-sm font-mono font-bold" style={{ color: (liveMetrics?.visitedCount || metrics.visited) > 0 ? meta.accent : '#475569' }}>
-              {displayVisited}
-            </p>
+    const displayPathCost = (() => {
+      if (
+        liveMetrics?.currentDistance !== undefined &&
+        liveMetrics.currentDistance !== Infinity
+      ) {
+        return liveMetrics.currentDistance.toFixed(1)
+      }
+      if (metrics.pathCost !== null) return metrics.pathCost.toFixed(1)
+      return '—'
+    })()
+
+    const hasLiveMetric =
+      liveMetrics?.queueSize !== undefined ||
+      liveMetrics?.iteration !== undefined
+
+    const displayQueueIter = (() => {
+      if (algoKey === 'dijkstra' && liveMetrics?.queueSize !== undefined)
+        return liveMetrics.queueSize
+      if (algoKey === 'bellmanford' && liveMetrics?.iteration !== undefined)
+        return `Iter ${liveMetrics.iteration}`
+      if (algoKey === 'floydwarshall' && liveMetrics?.k !== undefined)
+        return `k=${liveMetrics.k}`
+      return '—'
+    })()
+
+    const hasRelaxMetric =
+      liveMetrics?.relaxations !== undefined ||
+      liveMetrics?.matrixUpdates !== undefined
+
+    const displayRelaxUpdate = (() => {
+      if (algoKey === 'dijkstra' && liveMetrics?.relaxations !== undefined)
+        return liveMetrics.relaxations
+      if (algoKey === 'bellmanford' && liveMetrics?.relaxations !== undefined)
+        return liveMetrics.relaxations
+      if (
+        algoKey === 'floydwarshall' &&
+        liveMetrics?.matrixUpdates !== undefined
+      )
+        return liveMetrics.matrixUpdates
+      return '—'
+    })()
+
+    return (
+      <motion.div
+        className="rounded-2xl flex flex-col overflow-hidden border transition-all duration-500"
+        style={{
+          background:
+            isWinner && status === 'complete'
+              ? `linear-gradient(145deg, rgba(15,23,42,0.98), ${meta.accentBg})`
+              : 'rgba(15,23,42,0.85)',
+          borderColor:
+            isWinner && status === 'complete'
+              ? meta.accent
+              : 'rgba(51,65,85,0.7)',
+          boxShadow:
+            isWinner && status === 'complete'
+              ? `0 0 20px ${meta.glow}`
+              : 'none',
+        }}
+      >
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-800/80">
+          <div className="flex items-center gap-2">
+            <motion.div
+              className="w-2 h-2 rounded-full"
+              style={{ background: meta.accent }}
+              animate={
+                status === 'running' ? { opacity: [1, 0.3, 1] } : { opacity: 1 }
+              }
+              transition={{ duration: 0.9, repeat: Infinity }}
+            />
+            <span className="text-xs font-bold text-white tracking-wider">
+              {meta.label}
+            </span>
           </div>
-          <div className="text-center">
-            <p className="text-[8px] uppercase tracking-wider text-slate-500">Path Cost</p>
-            <p className="text-sm font-mono font-bold" style={{ color: metrics.pathCost !== null ? meta.accent : '#475569' }}>
-              {displayPathCost}
-            </p>
-          </div>
-          <div className="text-center">
-            <p className="text-[8px] uppercase tracking-wider text-slate-500">Queue/Iter</p>
-            <p className="text-sm font-mono font-bold" style={{ color: hasLiveMetric ? meta.accent : '#475569' }}>
-              {displayQueueIter}
-            </p>
-          </div>
-          <div className="text-center">
-            <p className="text-[8px] uppercase tracking-wider text-slate-500">Relax/Update</p>
-            <p className="text-sm font-mono font-bold" style={{ color: hasRelaxMetric ? meta.accent : '#475569' }}>
-              {displayRelaxUpdate}
-            </p>
-          </div>
+          <span
+            className="text-[9px] font-mono px-2 py-0.5 rounded bg-slate-950"
+            style={{ color: statusColor }}
+          >
+            {getStatusText()}
+          </span>
         </div>
-        {isWinner && status === 'complete' && (
-          <div className="mt-2 text-center">
-            <span className="text-[10px] font-bold text-cyan-400">🏆 Winner</span>
+
+        {status === 'running' && progress > 0 && (
+          <div className="h-0.5 bg-slate-800">
+            <motion.div
+              className="h-full"
+              style={{ background: meta.accent }}
+              initial={{ width: 0 }}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 0.3 }}
+            />
           </div>
         )}
-      </div>
-    </motion.div>
-  )
-})
+
+        <div className="p-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="text-center">
+              <p className="text-[8px] uppercase tracking-wider text-slate-500">
+                Visited
+              </p>
+              <p
+                className="text-sm font-mono font-bold"
+                style={{
+                  color:
+                    (liveMetrics?.visitedCount || metrics.visited) > 0
+                      ? meta.accent
+                      : '#475569',
+                }}
+              >
+                {displayVisited}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-[8px] uppercase tracking-wider text-slate-500">
+                Path Cost
+              </p>
+              <p
+                className="text-sm font-mono font-bold"
+                style={{
+                  color: metrics.pathCost !== null ? meta.accent : '#475569',
+                }}
+              >
+                {displayPathCost}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-[8px] uppercase tracking-wider text-slate-500">
+                Queue/Iter
+              </p>
+              <p
+                className="text-sm font-mono font-bold"
+                style={{ color: hasLiveMetric ? meta.accent : '#475569' }}
+              >
+                {displayQueueIter}
+              </p>
+            </div>
+            <div className="text-center">
+              <p className="text-[8px] uppercase tracking-wider text-slate-500">
+                Relax/Update
+              </p>
+              <p
+                className="text-sm font-mono font-bold"
+                style={{ color: hasRelaxMetric ? meta.accent : '#475569' }}
+              >
+                {displayRelaxUpdate}
+              </p>
+            </div>
+          </div>
+          {isWinner && status === 'complete' && (
+            <div className="mt-2 text-center">
+              <span className="text-[10px] font-bold text-cyan-400">
+                🏆 Winner
+              </span>
+            </div>
+          )}
+        </div>
+      </motion.div>
+    )
+  }
+)
+
+ComparisonCard.displayName = 'ComparisonCard'
 
 export default function GridComparisonMode() {
   const [speed, setSpeed] = useState(2)
@@ -540,24 +682,30 @@ export default function GridComparisonMode() {
   const [visitedStates, setVisitedStates] = useState([])
   const [pathStates, setPathStates] = useState([])
   const [algoStatus, setAlgoStatus] = useState(createInitialAlgoStates())
+  const mountedRef = useRef(true)
 
-  const shouldUpdateProgress = (index, totalSteps, batchSize) => {
-    return index % batchSize === 0 || index === totalSteps - 1
-  }
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const animateDijkstra = useCallback(async (steps, path, speedMultiplier) => {
     const delay = ANIMATION_DELAYS.DIJKSTRA / speedMultiplier
     const visitedNodes = new Set()
-    
+
     for (let i = 0; i < steps.length; i++) {
+      if (!mountedRef.current) return
       const step = steps[i]
-      const isVisitStep = step.type === 'visit'
-      
-      if (isVisitStep) {
+
+      if (step.type === 'visit') {
         visitedNodes.add(step.node)
-        
-        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.DIJKSTRA_BATCH)) {
-          setAlgoStatus(prev => ({
+
+        if (
+          shouldUpdateProgress(i, steps.length, STEP_BATCHING.DIJKSTRA_BATCH)
+        ) {
+          setAlgoStatus((prev) => ({
             ...prev,
             dijkstra: {
               ...prev.dijkstra,
@@ -566,232 +714,300 @@ export default function GridComparisonMode() {
                 visitedCount: visitedNodes.size,
                 queueSize: step.queueSize,
                 currentDistance: step.currentDistance,
-              }
-            }
+              },
+            },
           }))
         }
-        
-        setVisitedStates(prev => updateVisitedState(prev, 'dijkstra', step.node))
+
+        setVisitedStates((prev) =>
+          updateVisualizationState(prev, 'dijkstra', step.node)
+        )
       }
-      await new Promise(resolve => setTimeout(resolve, delay))
+      await sleep(delay)
     }
-    
+
     const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
     for (let i = 0; i < path.length; i++) {
-      await new Promise(resolve => setTimeout(resolve, pathDelay))
-      setPathStates(prev => updatePathState(prev, 'dijkstra', path[i]))
+      if (!mountedRef.current) return
+      await sleep(pathDelay)
+      setPathStates((prev) =>
+        updateVisualizationState(prev, 'dijkstra', path[i])
+      )
     }
   }, [])
 
-  const animateBellmanFord = useCallback(async (steps, path, speedMultiplier) => {
-    const delay = ANIMATION_DELAYS.BELLMAN_FORD / speedMultiplier
-    const visitedNodes = new Set()
-    
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i]
-      const isRelaxStep = step.type === 'relax'
-      
-      if (isRelaxStep) {
-        visitedNodes.add(step.node)
-        
-        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.BELLMAN_FORD_BATCH)) {
-          setAlgoStatus(prev => ({
-            ...prev,
-            bellmanford: {
-              ...prev.bellmanford,
-              progress: (visitedNodes.size / (ROWS * COLS)) * 100,
-              liveMetrics: {
-                visitedCount: visitedNodes.size,
-                iteration: step.iteration,
-              }
-            }
-          }))
+  const animateBellmanFord = useCallback(
+    async (steps, path, speedMultiplier) => {
+      const delay = ANIMATION_DELAYS.BELLMAN_FORD / speedMultiplier
+      const visitedNodes = new Set()
+
+      for (let i = 0; i < steps.length; i++) {
+        if (!mountedRef.current) return
+        const step = steps[i]
+
+        if (step.type === 'relax') {
+          visitedNodes.add(step.node)
+
+          if (
+            shouldUpdateProgress(
+              i,
+              steps.length,
+              STEP_BATCHING.BELLMAN_FORD_BATCH
+            )
+          ) {
+            setAlgoStatus((prev) => ({
+              ...prev,
+              bellmanford: {
+                ...prev.bellmanford,
+                progress: (visitedNodes.size / (ROWS * COLS)) * 100,
+                liveMetrics: {
+                  visitedCount: visitedNodes.size,
+                  iteration: step.iteration,
+                },
+              },
+            }))
+          }
+
+          setVisitedStates((prev) =>
+            updateVisualizationState(prev, 'bellmanford', step.node)
+          )
         }
-        
-        setVisitedStates(prev => updateVisitedState(prev, 'bellmanford', step.node))
+        await sleep(delay)
       }
-      await new Promise(resolve => setTimeout(resolve, delay))
-    }
-    
-    const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
-    for (let i = 0; i < path.length; i++) {
-      await new Promise(resolve => setTimeout(resolve, pathDelay))
-      setPathStates(prev => updatePathState(prev, 'bellmanford', path[i]))
-    }
-  }, [])
 
-  const animateFloydWarshall = useCallback(async (steps, path, speedMultiplier) => {
-    const delay = ANIMATION_DELAYS.FLOYD_WARSHALL / speedMultiplier
-    const visitedNodes = new Set()
-    
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i]
-      const isUpdateStep = step.type === 'update' && step.node1 && step.node2
-      
-      if (isUpdateStep) {
-        visitedNodes.add(step.node1)
-        visitedNodes.add(step.node2)
-        
-        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.FLOYD_WARSHALL_BATCH)) {
-          setAlgoStatus(prev => ({
-            ...prev,
-            floydwarshall: {
-              ...prev.floydwarshall,
-              progress: (visitedNodes.size / (ROWS * COLS)) * 100,
-              liveMetrics: {
-                visitedCount: visitedNodes.size,
-                k: step.k,
-              }
-            }
-          }))
-        }
-        
-        if (step.node1) {
-          setVisitedStates(prev => updateVisitedState(prev, 'floydwarshall', step.node1))
-        }
-        if (step.node2) {
-          setVisitedStates(prev => updateVisitedState(prev, 'floydwarshall', step.node2))
-        }
+      const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
+      for (let i = 0; i < path.length; i++) {
+        if (!mountedRef.current) return
+        await sleep(pathDelay)
+        setPathStates((prev) =>
+          updateVisualizationState(prev, 'bellmanford', path[i])
+        )
       }
-      await new Promise(resolve => setTimeout(resolve, delay))
-    }
-    
-    const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
-    for (let i = 0; i < path.length; i++) {
-      await new Promise(resolve => setTimeout(resolve, pathDelay))
-      setPathStates(prev => updatePathState(prev, 'floydwarshall', path[i]))
-    }
-  }, [])
+    },
+    []
+  )
 
-  const calculateScore = useCallback((visitedCount, relaxations, matrixUpdates, pathCost) => {
-    const visitedWeight = 1
-    const relaxationWeight = 2
-    const matrixUpdateWeight = 3
-    const pathCostWeight = 0.5
-    return (visitedCount * visitedWeight) + (relaxations * relaxationWeight) + 
-           ((matrixUpdates || 0) * matrixUpdateWeight) + ((pathCost || 0) * pathCostWeight)
-  }, [])
+  const animateFloydWarshall = useCallback(
+    async (steps, path, speedMultiplier) => {
+      const delay = ANIMATION_DELAYS.FLOYD_WARSHALL / speedMultiplier
+      const visitedNodes = new Set()
 
-  const executeAlgorithm = useCallback(async (algoKey, speedMultiplier) => {
-    const startTime = performance.now()
-    
-    let result
-    if (algoKey === 'dijkstra') {
-      result = generateDijkstraSteps(grid)
-      await animateDijkstra(result.steps, result.path, speedMultiplier)
-    } else if (algoKey === 'bellmanford') {
-      result = generateBellmanFordSteps(grid)
-      await animateBellmanFord(result.steps, result.path, speedMultiplier)
-    } else {
-      result = generateFloydWarshallSteps(grid)
-      await animateFloydWarshall(result.steps, result.path, speedMultiplier)
-    }
-    
-    const endTime = performance.now()
-    const metrics = buildMetrics(result, startTime, endTime, grid)
-    const score = calculateScore(metrics.visitedCount, metrics.relaxations, metrics.matrixUpdates, metrics.pathCost)
-    
-    return {
-      visitedCount: metrics.visitedCount,
-      pathCost: metrics.pathCost,
-      time: metrics.time,
-      pathFound: metrics.pathFound,
-      relaxations: metrics.relaxations,
-      matrixUpdates: metrics.matrixUpdates,
-      score,
-    }
-  }, [grid, animateDijkstra, animateBellmanFord, animateFloydWarshall, calculateScore])
+      for (let i = 0; i < steps.length; i++) {
+        if (!mountedRef.current) return
+        const step = steps[i]
+
+        if (step.type === 'update' && step.node1 && step.node2) {
+          visitedNodes.add(step.node1)
+          visitedNodes.add(step.node2)
+
+          if (
+            shouldUpdateProgress(
+              i,
+              steps.length,
+              STEP_BATCHING.FLOYD_WARSHALL_BATCH
+            )
+          ) {
+            setAlgoStatus((prev) => ({
+              ...prev,
+              floydwarshall: {
+                ...prev.floydwarshall,
+                progress: (visitedNodes.size / (ROWS * COLS)) * 100,
+                liveMetrics: {
+                  visitedCount: visitedNodes.size,
+                  k: step.k,
+                },
+              },
+            }))
+          }
+
+          if (step.node1) {
+            setVisitedStates((prev) =>
+              updateVisualizationState(prev, 'floydwarshall', step.node1)
+            )
+          }
+          if (step.node2) {
+            setVisitedStates((prev) =>
+              updateVisualizationState(prev, 'floydwarshall', step.node2)
+            )
+          }
+        }
+        await sleep(delay)
+      }
+
+      const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
+      for (let i = 0; i < path.length; i++) {
+        if (!mountedRef.current) return
+        await sleep(pathDelay)
+        setPathStates((prev) =>
+          updateVisualizationState(prev, 'floydwarshall', path[i])
+        )
+      }
+    },
+    []
+  )
+
+  const calculateScore = useCallback(
+    (visitedCount, relaxations, matrixUpdates, pathCost) => {
+      const normalizedMatrixUpdates = matrixUpdates / (ROWS * COLS)
+      return (
+        visitedCount * 1 +
+        relaxations * 2 +
+        normalizedMatrixUpdates * 3 +
+        (pathCost || 0) * 0.5
+      )
+    },
+    []
+  )
+
+  const executeAlgorithm = useCallback(
+    async (algoKey, speedMultiplier) => {
+      const startTime = performance.now()
+      let result
+
+      if (algoKey === 'dijkstra') {
+        result = generateDijkstraSteps(grid)
+        await animateDijkstra(result.steps, result.path, speedMultiplier)
+      } else if (algoKey === 'bellmanford') {
+        result = generateBellmanFordSteps(grid)
+        await animateBellmanFord(result.steps, result.path, speedMultiplier)
+      } else {
+        result = generateFloydWarshallSteps(grid)
+        await animateFloydWarshall(result.steps, result.path, speedMultiplier)
+      }
+
+      const endTime = performance.now()
+      const metrics = buildMetrics(result, startTime, endTime, grid)
+      const score = calculateScore(
+        metrics.visitedCount,
+        metrics.relaxations,
+        metrics.matrixUpdates,
+        metrics.pathCost
+      )
+
+      return {
+        visitedCount: metrics.visitedCount,
+        pathCost: metrics.pathCost,
+        visualizationTime: metrics.visualizationTime,
+        pathFound: metrics.pathFound,
+        relaxations: metrics.relaxations,
+        matrixUpdates: metrics.matrixUpdates,
+        score,
+      }
+    },
+    [
+      grid,
+      animateDijkstra,
+      animateBellmanFord,
+      animateFloydWarshall,
+      calculateScore,
+    ]
+  )
 
   const handleStart = useCallback(async () => {
     if (isRunning) return
-    
+
     setIsRunning(true)
     setWinner(null)
     setVisitedStates([])
     setPathStates([])
-    setAlgoStatus(createInitialAlgoStates())
-    
+    setAlgoStatus({
+      dijkstra: {
+        ...createInitialAlgoStates().dijkstra,
+        status: 'running',
+      },
+      bellmanford: {
+        ...createInitialAlgoStates().bellmanford,
+        status: 'running',
+      },
+      floydwarshall: {
+        ...createInitialAlgoStates().floydwarshall,
+        status: 'running',
+      },
+    })
+
     const speedMultiplier = speed === 1 ? 1 : speed === 2 ? 2 : 4
-    
+
     const results = await Promise.all([
-      executeAlgorithm('dijkstra', speedMultiplier).then(metrics => {
-        setAlgoStatus(prev => ({ 
-          ...prev, 
-          dijkstra: { 
-            ...prev.dijkstra, 
-            status: 'complete', 
-            metrics: { 
-              visited: metrics.visitedCount, 
-              pathCost: metrics.pathCost, 
-              time: metrics.time, 
-              steps: metrics.relaxations, 
-              score: metrics.score 
-            }, 
-            progress: 100, 
-            liveMetrics: {} 
-          } 
+      executeAlgorithm('dijkstra', speedMultiplier).then((metrics) => {
+        if (!mountedRef.current) return { key: 'dijkstra', metrics }
+        setAlgoStatus((prev) => ({
+          ...prev,
+          dijkstra: {
+            ...prev.dijkstra,
+            status: 'complete',
+            metrics: {
+              visited: metrics.visitedCount,
+              pathCost: metrics.pathCost,
+              visualizationTime: metrics.visualizationTime,
+              steps: metrics.relaxations,
+              score: metrics.score,
+            },
+            progress: 100,
+            liveMetrics: {},
+          },
         }))
         return { key: 'dijkstra', metrics }
       }),
-      executeAlgorithm('bellmanford', speedMultiplier).then(metrics => {
-        setAlgoStatus(prev => ({ 
-          ...prev, 
-          bellmanford: { 
-            ...prev.bellmanford, 
-            status: 'complete', 
-            metrics: { 
-              visited: metrics.visitedCount, 
-              pathCost: metrics.pathCost, 
-              time: metrics.time, 
-              steps: metrics.relaxations, 
-              score: metrics.score 
-            }, 
-            progress: 100, 
-            liveMetrics: {} 
-          } 
+      executeAlgorithm('bellmanford', speedMultiplier).then((metrics) => {
+        if (!mountedRef.current) return { key: 'bellmanford', metrics }
+        setAlgoStatus((prev) => ({
+          ...prev,
+          bellmanford: {
+            ...prev.bellmanford,
+            status: 'complete',
+            metrics: {
+              visited: metrics.visitedCount,
+              pathCost: metrics.pathCost,
+              visualizationTime: metrics.visualizationTime,
+              steps: metrics.relaxations,
+              score: metrics.score,
+            },
+            progress: 100,
+            liveMetrics: {},
+          },
         }))
         return { key: 'bellmanford', metrics }
       }),
-      executeAlgorithm('floydwarshall', speedMultiplier).then(metrics => {
-        setAlgoStatus(prev => ({ 
-          ...prev, 
-          floydwarshall: { 
-            ...prev.floydwarshall, 
-            status: 'complete', 
-            metrics: { 
-              visited: metrics.visitedCount, 
-              pathCost: metrics.pathCost, 
-              time: metrics.time, 
-              steps: metrics.matrixUpdates, 
-              score: metrics.score 
-            }, 
-            progress: 100, 
-            liveMetrics: {} 
-          } 
+      executeAlgorithm('floydwarshall', speedMultiplier).then((metrics) => {
+        if (!mountedRef.current) return { key: 'floydwarshall', metrics }
+        setAlgoStatus((prev) => ({
+          ...prev,
+          floydwarshall: {
+            ...prev.floydwarshall,
+            status: 'complete',
+            metrics: {
+              visited: metrics.visitedCount,
+              pathCost: metrics.pathCost,
+              visualizationTime: metrics.visualizationTime,
+              steps: metrics.matrixUpdates,
+              score: metrics.score,
+            },
+            progress: 100,
+            liveMetrics: {},
+          },
         }))
         return { key: 'floydwarshall', metrics }
-      })
+      }),
     ])
-    
+
+    if (!mountedRef.current) return
+
     let bestScore = Infinity
     let winnerAlgo = null
-    
+
     results.forEach(({ key, metrics }) => {
-      const hasValidPath = metrics.pathFound
-      const isBetterScore = metrics.score < bestScore
-      if (hasValidPath && isBetterScore) {
+      if (metrics.pathFound && metrics.score < bestScore) {
         bestScore = metrics.score
         winnerAlgo = key
       }
     })
-    
+
     if (winnerAlgo) setWinner(winnerAlgo)
     setIsRunning(false)
   }, [isRunning, speed, executeAlgorithm])
 
   const handleReset = useCallback(() => {
     if (isRunning) return
-    
     setWinner(null)
     setIsRunning(false)
     setVisitedStates([])
@@ -799,77 +1015,111 @@ export default function GridComparisonMode() {
     setAlgoStatus(createInitialAlgoStates())
   }, [isRunning])
 
-  const speedButtons = useMemo(() => [
-    { label: '1×', val: 1 },
-    { label: '2×', val: 2 },
-    { label: '4×', val: 4 },
-  ], [])
+  const speedButtons = useMemo(
+    () => [
+      { label: '1×', val: 1 },
+      { label: '2×', val: 2 },
+      { label: '4×', val: 4 },
+    ],
+    []
+  )
 
   return (
-    <div className="flex flex-col gap-5">
-      <div className="rounded-2xl border border-slate-700/60 p-4" style={{ background: 'rgba(15,23,42,0.8)' }}>
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Speed</p>
-            <div className="flex gap-1.5">
-              {speedButtons.map(({ label, val }) => (
-                <button
-                  key={val}
-                  onClick={() => setSpeed(val)}
-                  disabled={isRunning}
-                  className="px-3 h-7 rounded-lg text-[11px] font-bold border transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                  style={{
-                    background: speed === val ? 'rgba(6,182,212,0.15)' : 'rgba(30,41,59,0.5)',
-                    borderColor: speed === val ? '#06b6d4' : 'rgba(51,65,85,0.8)',
-                    color: speed === val ? '#06b6d4' : '#64748b',
-                  }}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-          </div>
+    <div
+      className="rounded-2xl border border-slate-700/60 p-4"
+      style={{ background: 'rgba(15,23,42,0.8)' }}
+    >
+      <div className="flex items-center gap-3 flex-wrap">
+        <span className="text-xs text-slate-400 font-medium">Speed</span>
+        {speedButtons.map(({ label, val }) => (
+          <button
+            key={val}
+            onClick={() => setSpeed(val)}
+            disabled={isRunning}
+            className="px-3 h-7 rounded-lg text-[11px] font-bold border transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{
+              background:
+                speed === val ? 'rgba(6,182,212,0.15)' : 'rgba(30,41,59,0.5)',
+              borderColor: speed === val ? '#06b6d4' : 'rgba(51,65,85,0.8)',
+              color: speed === val ? '#06b6d4' : '#64748b',
+            }}
+          >
+            {label}
+          </button>
+        ))}
 
-          <div className="flex gap-2">
-            <button
-              onClick={handleStart}
-              disabled={isRunning}
-              className="h-8 px-5 rounded-lg text-xs font-bold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-              style={{
-                background: 'rgba(6,182,212,0.85)',
-                color: '#000',
-                boxShadow: '0 0 12px rgba(6,182,212,0.4)',
-              }}
-            >
-              ▶ Run All Three
-            </button>
-            <button
-              onClick={handleReset}
-              disabled={isRunning}
-              className="h-8 px-5 rounded-lg text-xs font-bold transition-all bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              ↺ Reset
-            </button>
-          </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleStart}
+            disabled={isRunning}
+            className="h-8 px-5 rounded-lg text-xs font-bold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{
+              background: 'rgba(6,182,212,0.85)',
+              color: '#000',
+              boxShadow: '0 0 12px rgba(6,182,212,0.4)',
+            }}
+          >
+            ▶ Run All Three
+          </button>
+          <button
+            onClick={handleReset}
+            disabled={isRunning}
+            className="h-8 px-5 rounded-lg text-xs font-bold transition-all bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Reset
+          </button>
         </div>
       </div>
 
-      <div className="rounded-2xl border border-slate-700/60 p-6" style={{ background: 'rgba(15,23,42,0.6)' }}>
-        <SharedGridPreview grid={grid} visitedStates={visitedStates} pathStates={pathStates} />
+      <div className="mt-5 flex justify-center">
+        <SharedGridPreview
+          grid={grid}
+          visitedStates={visitedStates}
+          pathStates={pathStates}
+        />
       </div>
 
       <AnimatePresence>
         {winner && (
           <motion.div
-            initial={{ opacity: 0, y: -10 }}
+            initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            className="rounded-xl px-4 py-2.5 flex items-center gap-3"
+            exit={{ opacity: 0, y: 12 }}
+            className="rounded-xl border px-4 py-3 flex items-center gap-3 mt-4"
             style={{
-              background: ALGO_META[winner].accentBg,
-              border: `1px solid ${ALGO_META[winner].accentBorder}`,
-              boxShadow: `0 0 20px ${ALGO_META[winner].glow}`,
+              background: 'rgba(15,23,42,0.85)',
+              borderColor: ALGO_META[winner].accentBorder,
             }}
           >
             <span className="text-lg">🏆</span>
-           
+            <div>
+              <p
+                className="text-xs font-bold"
+                style={{ color: ALGO_META[winner].accent }}
+              >
+                {ALGO_META[winner].label} wins the comparison
+              </p>
+              <p className="text-[10px] text-slate-400">
+                Lowest visualization score with successful path reconstruction
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-4">
+        {ALGORITHM_KEYS.map((algoKey) => (
+          <ComparisonCard
+            key={algoKey}
+            algoKey={algoKey}
+            status={algoStatus[algoKey].status}
+            metrics={algoStatus[algoKey].metrics}
+            progress={algoStatus[algoKey].progress}
+            liveMetrics={algoStatus[algoKey].liveMetrics}
+            isWinner={winner === algoKey}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/shortestPathAlgo/GridComparisonMode.jsx
+++ b/src/components/shortestPathAlgo/GridComparisonMode.jsx
@@ -422,8 +422,7 @@ const buildMetrics = (result, startTime, endTime, grid) => {
   const pathCost = getPathCost(result, grid)
   const relaxations =
     result.totalRelaxations ||
-    result.steps?.filter((s) => s.type === 'relax' || s.type === 'update')
-      .length ||
+    result.steps?.filter((s) => s.type === 'relax').length ||
     0
   const matrixUpdates = result.matrixUpdates || 0
   const visitedCount = result.visitedCount || 0
@@ -548,18 +547,31 @@ const ComparisonCard = memo(
 
     const hasRelaxMetric =
       liveMetrics?.relaxations !== undefined ||
-      liveMetrics?.matrixUpdates !== undefined
+      liveMetrics?.matrixUpdates !== undefined ||
+      (status === 'complete' && metrics.steps > 0)
 
     const displayRelaxUpdate = (() => {
-      if (algoKey === 'dijkstra' && liveMetrics?.relaxations !== undefined)
-        return liveMetrics.relaxations
-      if (algoKey === 'bellmanford' && liveMetrics?.relaxations !== undefined)
-        return liveMetrics.relaxations
-      if (
-        algoKey === 'floydwarshall' &&
-        liveMetrics?.matrixUpdates !== undefined
-      )
-        return liveMetrics.matrixUpdates
+      if (algoKey === 'dijkstra') {
+        return (
+          liveMetrics?.relaxations ??
+          (status === 'complete' ? metrics.steps : '—')
+        )
+      }
+
+      if (algoKey === 'bellmanford') {
+        return (
+          liveMetrics?.relaxations ??
+          (status === 'complete' ? metrics.steps : '—')
+        )
+      }
+
+      if (algoKey === 'floydwarshall') {
+        return (
+          liveMetrics?.matrixUpdates ??
+          (status === 'complete' ? metrics.steps : '—')
+        )
+      }
+
       return '—'
     })()
 

--- a/src/components/shortestPathAlgo/GridComparisonMode.jsx
+++ b/src/components/shortestPathAlgo/GridComparisonMode.jsx
@@ -185,12 +185,12 @@ const generateDijkstraSteps = (grid) => {
 
   const path = []
   let current = endNode
-  while (current && parent.has(current)) {
+  while (current) {
     path.unshift(current)
+    if (current === startNode) break
     current = parent.get(current)
   }
-  const hasValidPath = path.length > 0 && path[0] === startNode
-  const finalPath = hasValidPath ? [startNode, ...path] : []
+  const finalPath = path[0] === startNode ? path : []
   const totalRelaxations = steps.filter((s) => s.type === 'relax').length
 
   return {
@@ -217,6 +217,7 @@ const generateBellmanFordSteps = (grid) => {
   distances.set(startNode, 0)
 
   let totalRelaxations = 0
+  let relaxationAttemptCount = 0
   const visitedNodesSet = new Set()
 
   for (let i = 0; i < allNodes.length - 1; i++) {
@@ -232,9 +233,10 @@ const generateBellmanFordSteps = (grid) => {
           relaxed = true
           totalRelaxations++
           visitedNodesSet.add(v)
+          relaxationAttemptCount++
           const shouldRecordStep =
-            steps.length % STEP_BATCHING.BELLMAN_FORD_STEP_MODULO === 0 ||
-            steps.length < 10
+            relaxationAttemptCount % STEP_BATCHING.BELLMAN_FORD_STEP_MODULO ===
+              0 || relaxationAttemptCount < 10
           if (shouldRecordStep) {
             steps.push({
               type: 'relax',
@@ -252,12 +254,12 @@ const generateBellmanFordSteps = (grid) => {
 
   const path = []
   let current = endNode
-  while (current && parent.has(current)) {
+  while (current) {
     path.unshift(current)
+    if (current === startNode) break
     current = parent.get(current)
   }
-  const hasValidPath = path.length > 0 && path[0] === startNode
-  const finalPath = hasValidPath ? [startNode, ...path] : []
+  const finalPath = path[0] === startNode ? path : []
 
   return {
     steps,
@@ -308,14 +310,14 @@ const generateFloydWarshallSteps = (grid) => {
           next[i][j] = next[i][k]
           matrixUpdates++
 
+          const node1 = allNodes[i]
+          const node2 = allNodes[j]
+          if (node1 && !node1.isWall) visitedNodesSet.add(node1)
+          if (node2 && !node2.isWall) visitedNodesSet.add(node2)
           const shouldRecordStep =
             matrixUpdates % STEP_BATCHING.FLOYD_WARSHALL_UPDATE_MODULO === 0 ||
             matrixUpdates < 10
           if (shouldRecordStep) {
-            const node1 = allNodes[i]
-            const node2 = allNodes[j]
-            if (node1 && !node1.isWall) visitedNodesSet.add(node1)
-            if (node2 && !node2.isWall) visitedNodesSet.add(node2)
             steps.push({ type: 'update', node1, node2, k, matrixUpdates })
           }
         }
@@ -381,8 +383,16 @@ const createInitialAlgoStates = () => ({
 })
 
 const updateVisualizationState = (prevStates, algoKey, node) => {
-  const newState = { algoKey, [`${node.row}-${node.col}`]: true }
+  const key = `${node.row}-${node.col}`
+  const existing = prevStates.find((s) => s.algoKey === algoKey) || { algoKey }
+
+  const newState = {
+    ...existing,
+    [key]: true,
+  }
+
   const filtered = prevStates.filter((s) => s.algoKey !== algoKey)
+
   return [...filtered, newState]
 }
 
@@ -927,68 +937,74 @@ export default function GridComparisonMode() {
 
     const speedMultiplier = speed === 1 ? 1 : speed === 2 ? 2 : 4
 
-    const results = await Promise.all([
-      executeAlgorithm('dijkstra', speedMultiplier).then((metrics) => {
-        if (!mountedRef.current) return { key: 'dijkstra', metrics }
-        setAlgoStatus((prev) => ({
-          ...prev,
-          dijkstra: {
-            ...prev.dijkstra,
-            status: 'complete',
-            metrics: {
-              visited: metrics.visitedCount,
-              pathCost: metrics.pathCost,
-              visualizationTime: metrics.visualizationTime,
-              steps: metrics.relaxations,
-              score: metrics.score,
+    let results
+
+    try {
+      results = await Promise.all([
+        executeAlgorithm('dijkstra', speedMultiplier).then((metrics) => {
+          if (!mountedRef.current) return { key: 'dijkstra', metrics }
+          setAlgoStatus((prev) => ({
+            ...prev,
+            dijkstra: {
+              ...prev.dijkstra,
+              status: 'complete',
+              metrics: {
+                visited: metrics.visitedCount,
+                pathCost: metrics.pathCost,
+                visualizationTime: metrics.visualizationTime,
+                steps: metrics.relaxations,
+                score: metrics.score,
+              },
+              progress: 100,
+              liveMetrics: {},
             },
-            progress: 100,
-            liveMetrics: {},
-          },
-        }))
-        return { key: 'dijkstra', metrics }
-      }),
-      executeAlgorithm('bellmanford', speedMultiplier).then((metrics) => {
-        if (!mountedRef.current) return { key: 'bellmanford', metrics }
-        setAlgoStatus((prev) => ({
-          ...prev,
-          bellmanford: {
-            ...prev.bellmanford,
-            status: 'complete',
-            metrics: {
-              visited: metrics.visitedCount,
-              pathCost: metrics.pathCost,
-              visualizationTime: metrics.visualizationTime,
-              steps: metrics.relaxations,
-              score: metrics.score,
+          }))
+          return { key: 'dijkstra', metrics }
+        }),
+        executeAlgorithm('bellmanford', speedMultiplier).then((metrics) => {
+          if (!mountedRef.current) return { key: 'bellmanford', metrics }
+          setAlgoStatus((prev) => ({
+            ...prev,
+            bellmanford: {
+              ...prev.bellmanford,
+              status: 'complete',
+              metrics: {
+                visited: metrics.visitedCount,
+                pathCost: metrics.pathCost,
+                visualizationTime: metrics.visualizationTime,
+                steps: metrics.relaxations,
+                score: metrics.score,
+              },
+              progress: 100,
+              liveMetrics: {},
             },
-            progress: 100,
-            liveMetrics: {},
-          },
-        }))
-        return { key: 'bellmanford', metrics }
-      }),
-      executeAlgorithm('floydwarshall', speedMultiplier).then((metrics) => {
-        if (!mountedRef.current) return { key: 'floydwarshall', metrics }
-        setAlgoStatus((prev) => ({
-          ...prev,
-          floydwarshall: {
-            ...prev.floydwarshall,
-            status: 'complete',
-            metrics: {
-              visited: metrics.visitedCount,
-              pathCost: metrics.pathCost,
-              visualizationTime: metrics.visualizationTime,
-              steps: metrics.matrixUpdates,
-              score: metrics.score,
+          }))
+          return { key: 'bellmanford', metrics }
+        }),
+        executeAlgorithm('floydwarshall', speedMultiplier).then((metrics) => {
+          if (!mountedRef.current) return { key: 'floydwarshall', metrics }
+          setAlgoStatus((prev) => ({
+            ...prev,
+            floydwarshall: {
+              ...prev.floydwarshall,
+              status: 'complete',
+              metrics: {
+                visited: metrics.visitedCount,
+                pathCost: metrics.pathCost,
+                visualizationTime: metrics.visualizationTime,
+                steps: metrics.matrixUpdates,
+                score: metrics.score,
+              },
+              progress: 100,
+              liveMetrics: {},
             },
-            progress: 100,
-            liveMetrics: {},
-          },
-        }))
-        return { key: 'floydwarshall', metrics }
-      }),
-    ])
+          }))
+          return { key: 'floydwarshall', metrics }
+        }),
+      ])
+    } finally {
+      if (mountedRef.current) setIsRunning(false)
+    }
 
     if (!mountedRef.current) return
 
@@ -1003,7 +1019,6 @@ export default function GridComparisonMode() {
     })
 
     if (winnerAlgo) setWinner(winnerAlgo)
-    setIsRunning(false)
   }, [isRunning, speed, executeAlgorithm])
 
   const handleReset = useCallback(() => {
@@ -1025,10 +1040,7 @@ export default function GridComparisonMode() {
   )
 
   return (
-    <div
-      className="rounded-2xl border border-slate-700/60 p-4"
-      style={{ background: 'rgba(15,23,42,0.8)' }}
-    >
+    <div className="rounded-2xl border border-slate-700/60 p-4 bg-slate-900/80">
       <div className="flex items-center gap-3 flex-wrap">
         <span className="text-xs text-slate-400 font-medium">Speed</span>
         {speedButtons.map(({ label, val }) => (

--- a/src/components/shortestPathAlgo/GridComparisonMode.jsx
+++ b/src/components/shortestPathAlgo/GridComparisonMode.jsx
@@ -1,0 +1,875 @@
+import React, { useState, useCallback, useRef, useMemo, memo } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+const ROWS = 8
+const COLS = 14
+
+const START_ROW = 3
+const START_COL = 2
+const END_ROW = 4
+const END_COL = 11
+
+const ANIMATION_DELAYS = {
+  DIJKSTRA: 25,
+  BELLMAN_FORD: 20,
+  FLOYD_WARSHALL: 15,
+  PATH_MULTIPLIER: 0.5,
+}
+
+const STEP_BATCHING = {
+  DIJKSTRA_BATCH: 3,
+  BELLMAN_FORD_BATCH: 3,
+  FLOYD_WARSHALL_BATCH: 2,
+  BELLMAN_FORD_STEP_MODULO: 15,
+  FLOYD_WARSHALL_UPDATE_MODULO: 20,
+}
+
+const ALGO_META = {
+  dijkstra: {
+    label: "Dijkstra's",
+    key: 'dijkstra',
+    accent: '#06b6d4',
+    accentBg: 'rgba(6,182,212,0.08)',
+    accentBorder: 'rgba(6,182,212,0.3)',
+    glow: 'rgba(6,182,212,0.3)',
+    visitedColor: 'rgba(6,182,212,0.25)',
+    pathColor: '#06b6d4',
+    description: 'Greedy, optimal, non-negative weights',
+  },
+  bellmanford: {
+    label: 'Bellman-Ford',
+    key: 'bellmanford',
+    accent: '#fb923c',
+    accentBg: 'rgba(251,146,60,0.08)',
+    accentBorder: 'rgba(251,146,60,0.3)',
+    glow: 'rgba(251,146,60,0.3)',
+    visitedColor: 'rgba(251,146,60,0.25)',
+    pathColor: '#fb923c',
+    description: 'Handles negative weights, slower but robust',
+  },
+  floydwarshall: {
+    label: 'Floyd-Warshall',
+    key: 'floydwarshall',
+    accent: '#c084fc',
+    accentBg: 'rgba(192,132,252,0.08)',
+    accentBorder: 'rgba(192,132,252,0.3)',
+    glow: 'rgba(192,132,252,0.3)',
+    visitedColor: 'rgba(192,132,252,0.15)',
+    pathColor: '#c084fc',
+    description: 'All-pairs shortest path',
+  },
+}
+
+const createNode = (row, col) => ({
+  row,
+  col,
+  isStart: row === START_ROW && col === START_COL,
+  isEnd: row === END_ROW && col === END_COL,
+  isWall: false,
+  visited: false,
+  path: false,
+  weight: 1,
+  isWeighted: false,
+})
+
+const createGrid = () => {
+  const grid = []
+  for (let row = 0; row < ROWS; row++) {
+    const currentRow = []
+    for (let col = 0; col < COLS; col++) {
+      currentRow.push(createNode(row, col))
+    }
+    grid.push(currentRow)
+  }
+  
+  const walls = [
+    [2, 4], [2, 5], [2, 6], [2, 7],
+    [5, 6], [5, 7], [5, 8], [5, 9],
+    [1, 8], [2, 8], [3, 8], [4, 8],
+  ]
+  
+  walls.forEach(([r, c]) => {
+    if (!grid[r][c].isStart && !grid[r][c].isEnd) {
+      grid[r][c].isWall = true
+    }
+  })
+  
+  return grid
+}
+
+const getNeighbors = (node, currentGrid) => {
+  const neighbors = []
+  const { row, col } = node
+  if (row > 0 && !currentGrid[row - 1][col].isWall) neighbors.push(currentGrid[row - 1][col])
+  if (row < ROWS - 1 && !currentGrid[row + 1][col].isWall) neighbors.push(currentGrid[row + 1][col])
+  if (col > 0 && !currentGrid[row][col - 1].isWall) neighbors.push(currentGrid[row][col - 1])
+  if (col < COLS - 1 && !currentGrid[row][col + 1].isWall) neighbors.push(currentGrid[row][col + 1])
+  return neighbors
+}
+
+const generateDijkstraSteps = (grid) => {
+  const steps = []
+  const distances = new Map()
+  const visited = new Set()
+  const parent = new Map()
+  const queue = []
+  
+  const startNode = grid[START_ROW][START_COL]
+  const endNode = grid[END_ROW][END_COL]
+  
+  for (let row of grid) {
+    for (let cell of row) {
+      distances.set(cell, Infinity)
+    }
+  }
+  distances.set(startNode, 0)
+  queue.push(startNode)
+  
+  while (queue.length > 0) {
+    queue.sort((a, b) => distances.get(a) - distances.get(b))
+    const current = queue.shift()
+    
+    if (visited.has(current)) continue
+    visited.add(current)
+    
+    steps.push({
+      type: 'visit',
+      node: current,
+      visitedCount: visited.size,
+      queueSize: queue.length,
+      currentDistance: distances.get(current),
+    })
+    
+    if (current === endNode) break
+    
+    const neighbors = getNeighbors(current, grid)
+    for (let neighbor of neighbors) {
+      if (visited.has(neighbor)) continue
+      const newDist = distances.get(current) + neighbor.weight
+      if (newDist < distances.get(neighbor)) {
+        distances.set(neighbor, newDist)
+        parent.set(neighbor, current)
+        if (!queue.includes(neighbor)) queue.push(neighbor)
+        steps.push({
+          type: 'relax',
+          node: neighbor,
+          newDistance: newDist,
+        })
+      }
+    }
+  }
+  
+  const path = []
+  let current = endNode
+  while (current && parent.has(current)) {
+    path.unshift(current)
+    current = parent.get(current)
+  }
+  const hasValidPath = path.length > 0 && path[0] === startNode
+  const finalPath = hasValidPath ? [startNode, ...path] : []
+  
+  const totalRelaxations = steps.filter(s => s.type === 'relax').length
+  
+  return { steps, path: finalPath, distances, totalRelaxations, visitedCount: visited.size }
+}
+
+const generateBellmanFordSteps = (grid) => {
+  const steps = []
+  const distances = new Map()
+  const parent = new Map()
+  
+  const startNode = grid[START_ROW][START_COL]
+  const endNode = grid[END_ROW][END_COL]
+  const allNodes = grid.flat()
+  
+  for (let node of allNodes) {
+    distances.set(node, Infinity)
+  }
+  distances.set(startNode, 0)
+  
+  let totalRelaxations = 0
+  const visitedNodesSet = new Set()
+  
+  for (let i = 0; i < allNodes.length - 1; i++) {
+    let relaxed = false
+    for (let u of allNodes) {
+      if (u.isWall || distances.get(u) === Infinity) continue
+      const neighbors = getNeighbors(u, grid)
+      for (let v of neighbors) {
+        const newDist = distances.get(u) + v.weight
+        if (newDist < distances.get(v)) {
+          distances.set(v, newDist)
+          parent.set(v, u)
+          relaxed = true
+          totalRelaxations++
+          visitedNodesSet.add(v)
+          const shouldRecordStep = steps.length % STEP_BATCHING.BELLMAN_FORD_STEP_MODULO === 0 || steps.length < 10
+          if (shouldRecordStep) {
+            steps.push({
+              type: 'relax',
+              node: v,
+              iteration: i + 1,
+              newDistance: newDist,
+              relaxations: totalRelaxations,
+            })
+          }
+        }
+      }
+    }
+    if (!relaxed) break
+  }
+  
+  const path = []
+  let current = endNode
+  while (current && parent.has(current)) {
+    path.unshift(current)
+    current = parent.get(current)
+  }
+  const hasValidPath = path.length > 0 && path[0] === startNode
+  const finalPath = hasValidPath ? [startNode, ...path] : []
+  
+  return { steps, path: finalPath, distances, totalRelaxations, visitedCount: visitedNodesSet.size }
+}
+
+const generateFloydWarshallSteps = (grid) => {
+  const allNodes = grid.flat().filter(n => !n.isWall)
+  const nodeIndex = new Map()
+  allNodes.forEach((node, idx) => nodeIndex.set(node, idx))
+  
+  const n = allNodes.length
+  const dist = Array(n).fill().map(() => Array(n).fill(Infinity))
+  const next = Array(n).fill().map(() => Array(n).fill(null))
+  
+  for (let i = 0; i < n; i++) {
+    dist[i][i] = 0
+  }
+  
+  for (let u of allNodes) {
+    const neighbors = getNeighbors(u, grid)
+    for (let v of neighbors) {
+      const ui = nodeIndex.get(u)
+      const vi = nodeIndex.get(v)
+      dist[ui][vi] = v.weight
+      next[ui][vi] = v
+    }
+  }
+  
+  let matrixUpdates = 0
+  const steps = []
+  const visitedNodesSet = new Set()
+  
+  for (let k = 0; k < n; k++) {
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        const isImprovement = dist[i][k] + dist[k][j] < dist[i][j]
+        if (isImprovement) {
+          dist[i][j] = dist[i][k] + dist[k][j]
+          next[i][j] = next[i][k]
+          matrixUpdates++
+          
+          const shouldRecordStep = matrixUpdates % STEP_BATCHING.FLOYD_WARSHALL_UPDATE_MODULO === 0 || matrixUpdates < 10
+          if (shouldRecordStep) {
+            const node1 = allNodes[i]
+            const node2 = allNodes[j]
+            const isValidNode = node1 && !node1.isWall
+            const isValidTarget = node2 && !node2.isWall
+            if (isValidNode) visitedNodesSet.add(node1)
+            if (isValidTarget) visitedNodesSet.add(node2)
+            
+            steps.push({
+              type: 'update',
+              node1,
+              node2,
+              k,
+              matrixUpdates,
+            })
+          }
+        }
+      }
+    }
+  }
+  
+  const startNode = grid[START_ROW][START_COL]
+  const endNode = grid[END_ROW][END_COL]
+  const startIdx = nodeIndex.get(startNode)
+  const endIdx = nodeIndex.get(endNode)
+  
+  const path = []
+  const hasValidIndices = startIdx !== undefined && endIdx !== undefined
+  const hasFiniteDistance = hasValidIndices && dist[startIdx][endIdx] !== Infinity
+  
+  if (hasFiniteDistance) {
+    let current = startNode
+    while (current !== endNode) {
+      const currentIdx = nodeIndex.get(current)
+      const nextNode = next[currentIdx][endIdx]
+      if (!nextNode) break
+      path.push(nextNode)
+      current = nextNode
+    }
+  }
+  
+  return { steps, path, matrixUpdates, visitedCount: visitedNodesSet.size, distances: dist }
+}
+
+const createInitialAlgoStates = () => ({
+  dijkstra: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
+  bellmanford: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
+  floydwarshall: { status: 'idle', metrics: { visited: 0, pathCost: null, time: 0, steps: 0, score: 0 }, progress: 0, liveMetrics: {} },
+})
+
+const updateVisitedState = (prevStates, algoKey, node) => {
+  const newState = { algoKey, [`${node.row}-${node.col}`]: true }
+  const filtered = prevStates.filter(s => s.algoKey !== algoKey)
+  return [...filtered, newState]
+}
+
+const updatePathState = (prevStates, algoKey, node) => {
+  const newState = { algoKey, [`${node.row}-${node.col}`]: true }
+  const filtered = prevStates.filter(s => s.algoKey !== algoKey)
+  return [...filtered, newState]
+}
+
+const getPathCost = (result, grid) => {
+  const hasDistanceMatrix = result.distances && typeof result.distances === 'object' && result.distances[END_ROW]
+  if (hasDistanceMatrix) {
+    const cost = result.distances[END_ROW][END_COL]
+    return (cost !== Infinity && cost !== null && cost !== undefined) ? cost : null
+  }
+  
+  const hasMapDistance = result.distances?.get
+  if (hasMapDistance) {
+    const cost = result.distances.get(grid[END_ROW][END_COL])
+    return (cost !== Infinity && cost !== null && cost !== undefined) ? cost : null
+  }
+  
+  return null
+}
+
+const buildMetrics = (result, startTime, endTime, grid) => {
+  const pathCost = getPathCost(result, grid)
+  const relaxations = result.totalRelaxations || result.steps?.filter(s => s.type === 'relax' || s.type === 'update').length || 0
+  const matrixUpdates = result.matrixUpdates || 0
+  const visitedCount = result.visitedCount || 0
+  
+  return {
+    visitedCount,
+    pathCost,
+    time: Math.round(endTime - startTime),
+    pathFound: result.path?.length > 0,
+    relaxations,
+    matrixUpdates,
+  }
+}
+
+const SharedGridPreview = memo(({ grid, visitedStates, pathStates }) => {
+  const cellSize = 28
+  const width = COLS * cellSize
+  const height = ROWS * cellSize
+
+  const getCellColor = (cell) => {
+    if (cell.isStart) return '#10b981'
+    if (cell.isEnd) return '#ef4444'
+    if (cell.isWall) return 'rgba(51,65,85,0.9)'
+    
+    const hasPath = pathStates.some(state => state[`${cell.row}-${cell.col}`])
+    if (hasPath) {
+      const activeAlgo = pathStates.find(state => state[`${cell.row}-${cell.col}`])
+      if (activeAlgo) return ALGO_META[activeAlgo.algoKey]?.pathColor || '#fbbf24'
+    }
+    
+    const visitedAlgos = visitedStates.filter(state => state[`${cell.row}-${cell.col}`])
+    const visitedCount = visitedAlgos.length
+    
+    if (visitedCount > 0) {
+      if (visitedCount === 1) {
+        return ALGO_META[visitedAlgos[0].algoKey]?.visitedColor || 'rgba(6,182,212,0.2)'
+      }
+      return 'rgba(100,100,100,0.12)'
+    }
+    
+    if (cell.isWeighted) return 'rgba(249,115,22,0.5)'
+    return 'rgba(30,41,59,0.6)'
+  }
+
+  return (
+    <div className="flex justify-center">
+      <div className="relative rounded-lg overflow-hidden border border-slate-700/60 bg-slate-950/40 shadow-lg">
+        <svg width={width} height={height} style={{ imageRendering: 'pixelated' }}>
+          {grid.map((row, r) =>
+            row.map((cell, c) => (
+              <rect
+                key={`${r}-${c}`}
+                x={c * cellSize}
+                y={r * cellSize}
+                width={cellSize}
+                height={cellSize}
+                fill={getCellColor(cell)}
+                stroke="rgba(71,85,105,0.3)"
+                strokeWidth={0.5}
+              />
+            ))
+          )}
+        </svg>
+      </div>
+    </div>
+  )
+})
+
+const ComparisonCard = memo(({ algoKey, status, metrics, isWinner, progress, liveMetrics }) => {
+  const meta = ALGO_META[algoKey]
+
+  const getStatusText = () => {
+    if (status === 'idle') return 'Ready'
+    if (status === 'running') return 'Running...'
+    if (status === 'complete') return 'Complete'
+    return 'Ready'
+  }
+
+  const statusColor = (() => {
+    if (status === 'complete') return meta.accent
+    if (status === 'running') return '#94a3b8'
+    return '#334155'
+  })()
+
+  const displayVisited = liveMetrics?.visitedCount || metrics.visited || '—'
+  const displayPathCost = (() => {
+    if (liveMetrics?.currentDistance !== undefined && liveMetrics.currentDistance !== Infinity) {
+      return liveMetrics.currentDistance.toFixed(1)
+    }
+    if (metrics.pathCost !== null) return metrics.pathCost.toFixed(1)
+    return '—'
+  })()
+  
+  const hasLiveMetric = liveMetrics?.queueSize !== undefined || liveMetrics?.iteration !== undefined
+  const displayQueueIter = (() => {
+    if (algoKey === 'dijkstra' && liveMetrics?.queueSize !== undefined) return liveMetrics.queueSize
+    if (algoKey === 'bellmanford' && liveMetrics?.iteration !== undefined) return `Iter ${liveMetrics.iteration}`
+    if (algoKey === 'floydwarshall' && liveMetrics?.k !== undefined) return `k=${liveMetrics.k}`
+    return '—'
+  })()
+  
+  const hasRelaxMetric = liveMetrics?.relaxations !== undefined || liveMetrics?.matrixUpdates !== undefined
+  const displayRelaxUpdate = (() => {
+    if (algoKey === 'dijkstra' && liveMetrics?.relaxations !== undefined) return liveMetrics.relaxations
+    if (algoKey === 'bellmanford' && liveMetrics?.relaxations !== undefined) return liveMetrics.relaxations
+    if (algoKey === 'floydwarshall' && liveMetrics?.matrixUpdates !== undefined) return liveMetrics.matrixUpdates
+    return '—'
+  })()
+
+  return (
+    <motion.div
+      className="rounded-2xl flex flex-col overflow-hidden border transition-all duration-500"
+      style={{
+        background: isWinner && status === 'complete'
+          ? `linear-gradient(145deg, rgba(15,23,42,0.98), ${meta.accentBg})`
+          : 'rgba(15,23,42,0.85)',
+        borderColor: isWinner && status === 'complete' ? meta.accent : 'rgba(51,65,85,0.7)',
+        boxShadow: isWinner && status === 'complete' ? `0 0 20px ${meta.glow}` : 'none',
+      }}
+    >
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-slate-800/80">
+        <div className="flex items-center gap-2">
+          <motion.div
+            className="w-2 h-2 rounded-full"
+            style={{ background: meta.accent }}
+            animate={status === 'running' ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
+            transition={{ duration: 0.9, repeat: Infinity }}
+          />
+          <span className="text-xs font-bold text-white tracking-wider">{meta.label}</span>
+        </div>
+        <span className="text-[9px] font-mono px-2 py-0.5 rounded bg-slate-950" style={{ color: statusColor }}>
+          {getStatusText()}
+        </span>
+      </div>
+
+      {status === 'running' && progress > 0 && (
+        <div className="h-0.5 bg-slate-800">
+          <motion.div
+            className="h-full"
+            style={{ background: meta.accent }}
+            initial={{ width: 0 }}
+            animate={{ width: `${progress}%` }}
+            transition={{ duration: 0.3 }}
+          />
+        </div>
+      )}
+
+      <div className="p-4 space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div className="text-center">
+            <p className="text-[8px] uppercase tracking-wider text-slate-500">Visited</p>
+            <p className="text-sm font-mono font-bold" style={{ color: (liveMetrics?.visitedCount || metrics.visited) > 0 ? meta.accent : '#475569' }}>
+              {displayVisited}
+            </p>
+          </div>
+          <div className="text-center">
+            <p className="text-[8px] uppercase tracking-wider text-slate-500">Path Cost</p>
+            <p className="text-sm font-mono font-bold" style={{ color: metrics.pathCost !== null ? meta.accent : '#475569' }}>
+              {displayPathCost}
+            </p>
+          </div>
+          <div className="text-center">
+            <p className="text-[8px] uppercase tracking-wider text-slate-500">Queue/Iter</p>
+            <p className="text-sm font-mono font-bold" style={{ color: hasLiveMetric ? meta.accent : '#475569' }}>
+              {displayQueueIter}
+            </p>
+          </div>
+          <div className="text-center">
+            <p className="text-[8px] uppercase tracking-wider text-slate-500">Relax/Update</p>
+            <p className="text-sm font-mono font-bold" style={{ color: hasRelaxMetric ? meta.accent : '#475569' }}>
+              {displayRelaxUpdate}
+            </p>
+          </div>
+        </div>
+        {isWinner && status === 'complete' && (
+          <div className="mt-2 text-center">
+            <span className="text-[10px] font-bold text-cyan-400">🏆 Winner</span>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  )
+})
+
+export default function GridComparisonMode() {
+  const [speed, setSpeed] = useState(2)
+  const [isRunning, setIsRunning] = useState(false)
+  const [grid] = useState(() => createGrid())
+  const [winner, setWinner] = useState(null)
+  const [visitedStates, setVisitedStates] = useState([])
+  const [pathStates, setPathStates] = useState([])
+  const [algoStatus, setAlgoStatus] = useState(createInitialAlgoStates())
+
+  const shouldUpdateProgress = (index, totalSteps, batchSize) => {
+    return index % batchSize === 0 || index === totalSteps - 1
+  }
+
+  const animateDijkstra = useCallback(async (steps, path, speedMultiplier) => {
+    const delay = ANIMATION_DELAYS.DIJKSTRA / speedMultiplier
+    const visitedNodes = new Set()
+    
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i]
+      const isVisitStep = step.type === 'visit'
+      
+      if (isVisitStep) {
+        visitedNodes.add(step.node)
+        
+        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.DIJKSTRA_BATCH)) {
+          setAlgoStatus(prev => ({
+            ...prev,
+            dijkstra: {
+              ...prev.dijkstra,
+              progress: (visitedNodes.size / (ROWS * COLS)) * 100,
+              liveMetrics: {
+                visitedCount: visitedNodes.size,
+                queueSize: step.queueSize,
+                currentDistance: step.currentDistance,
+              }
+            }
+          }))
+        }
+        
+        setVisitedStates(prev => updateVisitedState(prev, 'dijkstra', step.node))
+      }
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+    
+    const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
+    for (let i = 0; i < path.length; i++) {
+      await new Promise(resolve => setTimeout(resolve, pathDelay))
+      setPathStates(prev => updatePathState(prev, 'dijkstra', path[i]))
+    }
+  }, [])
+
+  const animateBellmanFord = useCallback(async (steps, path, speedMultiplier) => {
+    const delay = ANIMATION_DELAYS.BELLMAN_FORD / speedMultiplier
+    const visitedNodes = new Set()
+    
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i]
+      const isRelaxStep = step.type === 'relax'
+      
+      if (isRelaxStep) {
+        visitedNodes.add(step.node)
+        
+        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.BELLMAN_FORD_BATCH)) {
+          setAlgoStatus(prev => ({
+            ...prev,
+            bellmanford: {
+              ...prev.bellmanford,
+              progress: (visitedNodes.size / (ROWS * COLS)) * 100,
+              liveMetrics: {
+                visitedCount: visitedNodes.size,
+                iteration: step.iteration,
+              }
+            }
+          }))
+        }
+        
+        setVisitedStates(prev => updateVisitedState(prev, 'bellmanford', step.node))
+      }
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+    
+    const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
+    for (let i = 0; i < path.length; i++) {
+      await new Promise(resolve => setTimeout(resolve, pathDelay))
+      setPathStates(prev => updatePathState(prev, 'bellmanford', path[i]))
+    }
+  }, [])
+
+  const animateFloydWarshall = useCallback(async (steps, path, speedMultiplier) => {
+    const delay = ANIMATION_DELAYS.FLOYD_WARSHALL / speedMultiplier
+    const visitedNodes = new Set()
+    
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i]
+      const isUpdateStep = step.type === 'update' && step.node1 && step.node2
+      
+      if (isUpdateStep) {
+        visitedNodes.add(step.node1)
+        visitedNodes.add(step.node2)
+        
+        if (shouldUpdateProgress(i, steps.length, STEP_BATCHING.FLOYD_WARSHALL_BATCH)) {
+          setAlgoStatus(prev => ({
+            ...prev,
+            floydwarshall: {
+              ...prev.floydwarshall,
+              progress: (visitedNodes.size / (ROWS * COLS)) * 100,
+              liveMetrics: {
+                visitedCount: visitedNodes.size,
+                k: step.k,
+              }
+            }
+          }))
+        }
+        
+        if (step.node1) {
+          setVisitedStates(prev => updateVisitedState(prev, 'floydwarshall', step.node1))
+        }
+        if (step.node2) {
+          setVisitedStates(prev => updateVisitedState(prev, 'floydwarshall', step.node2))
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+    
+    const pathDelay = delay * ANIMATION_DELAYS.PATH_MULTIPLIER
+    for (let i = 0; i < path.length; i++) {
+      await new Promise(resolve => setTimeout(resolve, pathDelay))
+      setPathStates(prev => updatePathState(prev, 'floydwarshall', path[i]))
+    }
+  }, [])
+
+  const calculateScore = useCallback((visitedCount, relaxations, matrixUpdates, pathCost) => {
+    const visitedWeight = 1
+    const relaxationWeight = 2
+    const matrixUpdateWeight = 3
+    const pathCostWeight = 0.5
+    return (visitedCount * visitedWeight) + (relaxations * relaxationWeight) + 
+           ((matrixUpdates || 0) * matrixUpdateWeight) + ((pathCost || 0) * pathCostWeight)
+  }, [])
+
+  const executeAlgorithm = useCallback(async (algoKey, speedMultiplier) => {
+    const startTime = performance.now()
+    
+    let result
+    if (algoKey === 'dijkstra') {
+      result = generateDijkstraSteps(grid)
+      await animateDijkstra(result.steps, result.path, speedMultiplier)
+    } else if (algoKey === 'bellmanford') {
+      result = generateBellmanFordSteps(grid)
+      await animateBellmanFord(result.steps, result.path, speedMultiplier)
+    } else {
+      result = generateFloydWarshallSteps(grid)
+      await animateFloydWarshall(result.steps, result.path, speedMultiplier)
+    }
+    
+    const endTime = performance.now()
+    const metrics = buildMetrics(result, startTime, endTime, grid)
+    const score = calculateScore(metrics.visitedCount, metrics.relaxations, metrics.matrixUpdates, metrics.pathCost)
+    
+    return {
+      visitedCount: metrics.visitedCount,
+      pathCost: metrics.pathCost,
+      time: metrics.time,
+      pathFound: metrics.pathFound,
+      relaxations: metrics.relaxations,
+      matrixUpdates: metrics.matrixUpdates,
+      score,
+    }
+  }, [grid, animateDijkstra, animateBellmanFord, animateFloydWarshall, calculateScore])
+
+  const handleStart = useCallback(async () => {
+    if (isRunning) return
+    
+    setIsRunning(true)
+    setWinner(null)
+    setVisitedStates([])
+    setPathStates([])
+    setAlgoStatus(createInitialAlgoStates())
+    
+    const speedMultiplier = speed === 1 ? 1 : speed === 2 ? 2 : 4
+    
+    const results = await Promise.all([
+      executeAlgorithm('dijkstra', speedMultiplier).then(metrics => {
+        setAlgoStatus(prev => ({ 
+          ...prev, 
+          dijkstra: { 
+            ...prev.dijkstra, 
+            status: 'complete', 
+            metrics: { 
+              visited: metrics.visitedCount, 
+              pathCost: metrics.pathCost, 
+              time: metrics.time, 
+              steps: metrics.relaxations, 
+              score: metrics.score 
+            }, 
+            progress: 100, 
+            liveMetrics: {} 
+          } 
+        }))
+        return { key: 'dijkstra', metrics }
+      }),
+      executeAlgorithm('bellmanford', speedMultiplier).then(metrics => {
+        setAlgoStatus(prev => ({ 
+          ...prev, 
+          bellmanford: { 
+            ...prev.bellmanford, 
+            status: 'complete', 
+            metrics: { 
+              visited: metrics.visitedCount, 
+              pathCost: metrics.pathCost, 
+              time: metrics.time, 
+              steps: metrics.relaxations, 
+              score: metrics.score 
+            }, 
+            progress: 100, 
+            liveMetrics: {} 
+          } 
+        }))
+        return { key: 'bellmanford', metrics }
+      }),
+      executeAlgorithm('floydwarshall', speedMultiplier).then(metrics => {
+        setAlgoStatus(prev => ({ 
+          ...prev, 
+          floydwarshall: { 
+            ...prev.floydwarshall, 
+            status: 'complete', 
+            metrics: { 
+              visited: metrics.visitedCount, 
+              pathCost: metrics.pathCost, 
+              time: metrics.time, 
+              steps: metrics.matrixUpdates, 
+              score: metrics.score 
+            }, 
+            progress: 100, 
+            liveMetrics: {} 
+          } 
+        }))
+        return { key: 'floydwarshall', metrics }
+      })
+    ])
+    
+    let bestScore = Infinity
+    let winnerAlgo = null
+    
+    results.forEach(({ key, metrics }) => {
+      const hasValidPath = metrics.pathFound
+      const isBetterScore = metrics.score < bestScore
+      if (hasValidPath && isBetterScore) {
+        bestScore = metrics.score
+        winnerAlgo = key
+      }
+    })
+    
+    if (winnerAlgo) setWinner(winnerAlgo)
+    setIsRunning(false)
+  }, [isRunning, speed, executeAlgorithm])
+
+  const handleReset = useCallback(() => {
+    if (isRunning) return
+    
+    setWinner(null)
+    setIsRunning(false)
+    setVisitedStates([])
+    setPathStates([])
+    setAlgoStatus(createInitialAlgoStates())
+  }, [isRunning])
+
+  const speedButtons = useMemo(() => [
+    { label: '1×', val: 1 },
+    { label: '2×', val: 2 },
+    { label: '4×', val: 4 },
+  ], [])
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="rounded-2xl border border-slate-700/60 p-4" style={{ background: 'rgba(15,23,42,0.8)' }}>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-400">Speed</p>
+            <div className="flex gap-1.5">
+              {speedButtons.map(({ label, val }) => (
+                <button
+                  key={val}
+                  onClick={() => setSpeed(val)}
+                  disabled={isRunning}
+                  className="px-3 h-7 rounded-lg text-[11px] font-bold border transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{
+                    background: speed === val ? 'rgba(6,182,212,0.15)' : 'rgba(30,41,59,0.5)',
+                    borderColor: speed === val ? '#06b6d4' : 'rgba(51,65,85,0.8)',
+                    color: speed === val ? '#06b6d4' : '#64748b',
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleStart}
+              disabled={isRunning}
+              className="h-8 px-5 rounded-lg text-xs font-bold transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: 'rgba(6,182,212,0.85)',
+                color: '#000',
+                boxShadow: '0 0 12px rgba(6,182,212,0.4)',
+              }}
+            >
+              ▶ Run All Three
+            </button>
+            <button
+              onClick={handleReset}
+              disabled={isRunning}
+              className="h-8 px-5 rounded-lg text-xs font-bold transition-all bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              ↺ Reset
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-700/60 p-6" style={{ background: 'rgba(15,23,42,0.6)' }}>
+        <SharedGridPreview grid={grid} visitedStates={visitedStates} pathStates={pathStates} />
+      </div>
+
+      <AnimatePresence>
+        {winner && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            className="rounded-xl px-4 py-2.5 flex items-center gap-3"
+            style={{
+              background: ALGO_META[winner].accentBg,
+              border: `1px solid ${ALGO_META[winner].accentBorder}`,
+              boxShadow: `0 0 20px ${ALGO_META[winner].glow}`,
+            }}
+          >
+            <span className="text-lg">🏆</span>
+           

--- a/src/components/shortestPathAlgo/GridComparisonMode.jsx
+++ b/src/components/shortestPathAlgo/GridComparisonMode.jsx
@@ -338,6 +338,7 @@ const generateFloydWarshallSteps = (grid) => {
 
   if (hasFiniteDistance) {
     let current = startNode
+    path.push(startNode)
     let guard = 0
     const maxIterations = allNodes.length * 2
 
@@ -785,6 +786,7 @@ export default function GridComparisonMode() {
                 liveMetrics: {
                   visitedCount: visitedNodes.size,
                   iteration: step.iteration,
+                  relaxations: step.relaxations,
                 },
               },
             }))
@@ -837,6 +839,7 @@ export default function GridComparisonMode() {
                 liveMetrics: {
                   visitedCount: visitedNodes.size,
                   k: step.k,
+                  matrixUpdates: step.matrixUpdates,
                 },
               },
             }))

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -61,10 +61,9 @@ export const ShortestPathPage = () => {
     if (!algorithm) return
 
     if (viewMode === 'network') {
-      if (algorithm === 'kruskal') {
-      } else if (algorithm === 'prim') {
+      if (algorithm === 'prim') {
         if (!source) return
-      } else {
+      } else if (algorithm !== 'kruskal') {
         if (!source || !target) return
       }
     }
@@ -92,11 +91,9 @@ export const ShortestPathPage = () => {
     if (!algorithm) return ''
 
     const algoSource = shortestPathSources[algorithm]
-
     if (!algoSource) return ''
 
     const viewSource = algoSource[viewMode]
-
     if (!viewSource) return ''
 
     return viewSource[language]?.code ?? ''
@@ -203,12 +200,7 @@ export const ShortestPathPage = () => {
 
           {[
             ...(viewMode === 'network'
-              ? [
-                  {
-                    step: '1',
-                    label: 'Build your graph (toolbar on canvas)',
-                  },
-                ]
+              ? [{ step: '1', label: 'Build your graph (toolbar on canvas)' }]
               : []),
             {
               step: viewMode === 'network' ? '2' : '1',

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { CanvasShortestPath } from './CanvasShortestPath'
 import GridVisualizer from './GridVisualizer'
+import GridComparisonMode from './GridComparisonMode'
 import CodePanel from '../visualizer/CodePanel'
 import { MenuSelectNodesShortestPath } from './MenuSelectNodesShortestPath'
 import { MenuSetAlgoShortestPath } from './MenuSetAlgoShortestPath'
@@ -39,7 +40,6 @@ export const ShortestPathPage = () => {
   const [speed, setSpeed] = React.useState(1.0)
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
-  // Live list of node IDs from the canvas (kept in sync via onGraphChange)
   const [nodeIds, setNodeIds] = React.useState(
     Array.from({ length: 9 }, (_, i) => i + 1)
   )
@@ -62,7 +62,6 @@ export const ShortestPathPage = () => {
 
     if (viewMode === 'network') {
       if (algorithm === 'kruskal') {
-        // Kruskal's needs no source/target
       } else if (algorithm === 'prim') {
         if (!source) return
       } else {
@@ -170,34 +169,32 @@ export const ShortestPathPage = () => {
           </button>
         </div>
 
-        {viewMode === 'network' && (
-          <div className="flex gap-2">
-            <button
-              onClick={() => setMode('solo')}
-              className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
-                mode === 'solo'
-                  ? 'bg-cyan-600 text-white'
-                  : 'bg-slate-800 text-slate-400'
-              }`}
-            >
-              Solo
-            </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setMode('solo')}
+            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+              mode === 'solo'
+                ? 'bg-cyan-600 text-white'
+                : 'bg-slate-800 text-slate-400'
+            }`}
+          >
+            Solo
+          </button>
 
-            <button
-              onClick={() => setMode('compare')}
-              disabled={algorithm === 'prim' || algorithm === 'kruskal'}
-              className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
-                mode === 'compare'
-                  ? 'bg-cyan-600 text-white'
-                  : algorithm === 'prim' || algorithm === 'kruskal'
-                    ? 'bg-slate-800/40 text-slate-600 cursor-not-allowed border border-white/5'
-                    : 'bg-slate-800 text-slate-400'
-              }`}
-            >
-              Compare
-            </button>
-          </div>
-        )}
+          <button
+            onClick={() => setMode('compare')}
+            disabled={algorithm === 'prim' || algorithm === 'kruskal'}
+            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+              mode === 'compare'
+                ? 'bg-cyan-600 text-white'
+                : algorithm === 'prim' || algorithm === 'kruskal'
+                  ? 'bg-slate-800/40 text-slate-600 cursor-not-allowed border border-white/5'
+                  : 'bg-slate-800 text-slate-400'
+            }`}
+          >
+            Compare
+          </button>
+        </div>
 
         <div className="bg-slate-950/60 rounded-xl border border-white/5 p-3 space-y-2">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
@@ -342,31 +339,37 @@ export const ShortestPathPage = () => {
           </>
         ) : (
           <>
-            <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
-              <GridVisualizer
-                algorithm={algorithm}
-                speed={speed}
-                runKey={runKey}
-              />
-            </div>
+            {mode === 'solo' ? (
+              <>
+                <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
+                  <GridVisualizer
+                    algorithm={algorithm}
+                    speed={speed}
+                    runKey={runKey}
+                  />
+                </div>
 
-            <ComplexityCard algorithm={algorithm} />
+                <ComplexityCard algorithm={algorithm} />
 
-            <div className="w-full">
-              <CodePanel
-                title={
-                  algorithm
-                    ? `${getAlgorithmName(algorithm)} Grid Implementation`
-                    : 'Code Viewer'
-                }
-                code={
-                  currentSource ||
-                  '// Select an algorithm to see implementation'
-                }
-                language={language}
-                onLanguageChange={setLanguage}
-              />
-            </div>
+                <div className="w-full">
+                  <CodePanel
+                    title={
+                      algorithm
+                        ? `${getAlgorithmName(algorithm)} Grid Implementation`
+                        : 'Code Viewer'
+                    }
+                    code={
+                      currentSource ||
+                      '// Select an algorithm to see implementation'
+                    }
+                    language={language}
+                    onLanguageChange={setLanguage}
+                  />
+                </div>
+              </>
+            ) : (
+              <GridComparisonMode />
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
Closes  #295  
## Summary

This PR adds a dedicated grid comparison mode for shortest path algorithms inside the grid visualizer.

The feature allows users to run and visually compare:

* Dijkstra's Algorithm
* Bellman-Ford Algorithm
* Floyd-Warshall Algorithm

side-by-side in a shared interactive comparison view.

## What was added

### Grid Comparison Mode UI

* Added a dedicated comparison layout for grid-based shortest path algorithms
* Added centralized shared grid preview
* Added comparison cards for each algorithm
* Added live execution status indicators
* Added speed controls for traversal animations
* Added winner highlighting system

### Live Visualization System

* Progressive cell-by-cell traversal animations
* Animated path reconstruction rendering
* Real-time metrics updates during execution
* Progress bars during algorithm traversal
* Shared visualization state across all algorithms

### Metrics and Comparison

Each algorithm card now displays:

* Visited nodes
* Path cost
* Queue/iteration state
* Relaxation/update count
* Progress state
* Final comparison result

### Floyd-Warshall Comparison Logic

Implemented native Floyd-Warshall traversal generation inside comparison mode instead of delegating to Dijkstra internally.

This includes:

* matrix relaxation updates
* predecessor tracking
* path reconstruction
* all-pairs traversal visualization logic

### Scoring System

Added a visualization-based scoring system using:

* visited node count
* relaxation count
* matrix updates
* path cost

The winner is determined based on the lowest visualization score among successful pathfinding executions.

### Performance and Stability Improvements

* Added mountedRef cleanup protection for async animation loops
* Reduced unnecessary re-renders during traversal
* Added progressive rendering safeguards for animation updates
* Added batching controls for Floyd-Warshall matrix updates
* Added deterministic algorithm ordering for comparison rendering

## Additional Notes

The comparison mode was designed to visually match the existing shortest path visualization system while supporting simultaneous algorithm execution and live comparison behavior.

Special care was taken to preserve smooth traversal rendering and progressive UI updates during concurrent algorithm execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grid Compare mode to run Dijkstra, Bellman‑Ford, and Floyd‑Warshall side‑by‑side on a shared visual grid with synchronized animations.
  * Live metric cards display visited counts, relax/update counters, path cost, visualization time, and highlight a winner among successful runs.
  * Controls: speed selector (1×/2×/4×), "Run All Three" to execute concurrently, and Reset. Solo/Compare toggles moved into main controls; Compare disabled for unsupported algorithms.

* **Documentation**
  * Minor wording tweak in the network-view "How to use" steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->