### PR TITLE
feat: add responsive scroll-to-top button

### DIFF
--- a/src/components/AppLayout.jsx
+++ b/src/components/AppLayout.jsx
@@ -4,6 +4,7 @@ import Footer from './Footer'
 import { motion } from 'framer-motion'
 import SeoHead from './SeoHead'
 import Breadcrumbs from './Breadcrumbs'
+import ScrollToTopButton from './ScrollToTopButton'
 
 const Background = () => (
   <div className="absolute inset-0 z-0 pointer-events-none fixed">
@@ -31,6 +32,7 @@ export default function AppLayout({ children, showBackground = true }) {
         <div className="flex-1">{children}</div>
 
         <Footer />
+        <ScrollToTopButton />
       </div>
     </motion.div>
   )

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+
+const ScrollToTopButton = () => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 300)
+    }
+
+    window.addEventListener('scroll', onScroll)
+
+    // run once on mount
+    onScroll()
+
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
+  if (!visible) return null
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-50 w-10 h-10 rounded-full bg-violet-600 flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all duration-200"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={3.2}
+        stroke="#ffffff"
+        className="w-4.5 h-4.5 opacity-80"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"
+        />
+      </svg>
+    </button>
+  )
+}
+
+export default ScrollToTopButton


### PR DESCRIPTION
## Pull Request Summary

### What changed?
Added a responsive floating Scroll-to-Top button to improve navigation across long pages. The button appears after scrolling down, includes smooth scrolling behavior, hover animations, and responsive positioning for both desktop and mobile devices.

### Why is this needed?

This feature improves user experience by allowing users to quickly navigate back to the top of lengthy pages without manually scrolling.

Closes #275 

## Type of Change

<!-- Select every category that applies. These should align with the Conventional Commit type in the PR title. -->

- [x] `feat` - New user-facing feature or algorithm capability
- [ ] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes

<!--
release-please builds releases from Conventional Commits, and CHANGELOG.md follows Keep a Changelog sections.
Choose the section that best describes this PR and write one contributor-facing bullet.
Use "Not required" only for changes that should not appear in release notes.
-->

Release note category:

- [x] Added
- [ ] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

## Testing and Verification

<!-- Check every verification step that was completed. If a step is skipped, explain why below. -->

- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:

<!-- Example: "Skipped npm run build because this PR only updates markdown." -->

## UI Evidence

<!-- Required for UI, animation, routing, or visualizer changes. Add screenshots, GIFs, or short screen recordings. -->

After:
<img width="1866" height="970" alt="image" src="https://github.com/user-attachments/assets/77005c01-312a-4577-91e4-b6ea33236c5c" />


## CI/CD and Deployment Impact

<!-- Select all that apply so maintainers can assess release, Docker, and routing impact. -->

- [ ] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:

<!-- Include any required secrets, environment variables, release steps, migration notes, or rollback concerns. -->

## Reviewer Checklist

<!-- Keep this section for maintainers and reviewers. -->

- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating "scroll to top" button that appears when users scroll down the page, enabling quick navigation back to the top with smooth scrolling for improved user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->