### PR TITLE
feat: make the stack size custom

### DIFF
--- a/src/components/dataStructures/stackIV.jsx
+++ b/src/components/dataStructures/stackIV.jsx
@@ -178,7 +178,14 @@ export default function StackIV({ onStepChange }) {
     if (onStepChange) onStepChange(1)
     for (const char of inputValue.split('')) {
       if (onStepChange) onStepChange(6)
-      await pushItem(char)
+      const pushed = await pushItem(char)
+      if (!pushed) {
+        setConsoleOutput(`Error: stack overflow pushing '${char}'.`)
+        await sleep(SLEEP_MS / 2)
+        setIsRunning(false)
+        if (onStepChange) onStepChange(null)
+        return
+      }
       await sleep(SLEEP_MS / 2)
     }
 
@@ -207,11 +214,18 @@ export default function StackIV({ onStepChange }) {
     const openMap = { '(': ')', '{': '}', '[': ']' }
     const closeMap = { ')': '(', '}': '{', ']': '[' }
     let isValid = true
+    let overflowMessage = ''
 
     for (const char of inputValue.split('')) {
       if (openMap[char]) {
         if (onStepChange) onStepChange(6)
-        await pushItem(char)
+        const pushed = await pushItem(char)
+        if (!pushed) {
+          overflowMessage = `Error: stack overflow pushing '${char}'.`
+          setConsoleOutput(overflowMessage)
+          isValid = false
+          break
+        }
         setConsoleOutput(`Found opener '${char}'. Pushed.`)
       } else if (closeMap[char]) {
         if (onStepChange) onStepChange(10)
@@ -230,7 +244,9 @@ export default function StackIV({ onStepChange }) {
       await sleep(SLEEP_MS)
     }
 
-    if (isValid && stackRef.current.length === 0) {
+    if (overflowMessage) {
+      setConsoleOutput(`${overflowMessage}\nResult: UNBALANCED ❌`)
+    } else if (isValid && stackRef.current.length === 0) {
       setConsoleOutput('Result: BALANCED ✅')
     } else if (isValid && stackRef.current.length > 0) {
       setConsoleOutput('Result: UNBALANCED (Stack not empty) ❌')
@@ -253,7 +269,13 @@ export default function StackIV({ onStepChange }) {
       if (!isNaN(token)) {
         setConsoleOutput(`Pushing number: ${token}`)
         if (onStepChange) onStepChange(6)
-        await pushItem(Number(token))
+        const pushed = await pushItem(Number(token))
+        if (!pushed) {
+          setConsoleOutput(`Error: stack overflow pushing number ${token}.`)
+          setIsRunning(false)
+          if (onStepChange) onStepChange(null)
+          return
+        }
       } else {
         setConsoleOutput(`Operator '${token}' found. Popping 2 operands...`)
         if (onStepChange) onStepChange(10)
@@ -288,7 +310,13 @@ export default function StackIV({ onStepChange }) {
         setConsoleOutput(`${val1} ${token} ${val2} = ${res}. Pushing result.`)
         await sleep(SLEEP_MS)
         if (onStepChange) onStepChange(6)
-        await pushItem(res)
+        const pushed = await pushItem(res)
+        if (!pushed) {
+          setConsoleOutput(`Error: stack overflow pushing result ${res}.`)
+          setIsRunning(false)
+          if (onStepChange) onStepChange(null)
+          return
+        }
       }
       await sleep(SLEEP_MS)
     }
@@ -298,7 +326,15 @@ export default function StackIV({ onStepChange }) {
     if (stackRef.current.length === 0) {
       setConsoleOutput(`Final Result: ${finalResult} 🎉`)
       if (onStepChange) onStepChange(6)
-      await pushItem(finalResult)
+      const pushed = await pushItem(finalResult)
+      if (!pushed) {
+        setConsoleOutput(
+          `Error: stack overflow restoring final result ${finalResult}.`
+        )
+        setIsRunning(false)
+        if (onStepChange) onStepChange(null)
+        return
+      }
     } else {
       setConsoleOutput('Error: Stack not empty after evaluation.')
     }

--- a/src/components/dataStructures/stackIV.jsx
+++ b/src/components/dataStructures/stackIV.jsx
@@ -25,7 +25,9 @@ export default function StackIV({ onStepChange }) {
 
   const stackRef = useRef([])
   const hasStackSize = stackCapacity !== null
-  const emptySlots = hasStackSize ? Math.max(stackCapacity - stack.length, 0) : 0
+  const emptySlots = hasStackSize
+    ? Math.max(stackCapacity - stack.length, 0)
+    : 0
   const isStackFull = hasStackSize && stack.length >= stackCapacity
   const isStackLocked = hasStackStarted
 
@@ -75,9 +77,7 @@ export default function StackIV({ onStepChange }) {
     }
 
     setStackCapacity(nextCapacity)
-    setConsoleOutput(
-      `Stack size set to ${nextCapacity}. Start pushing values.`
-    )
+    setConsoleOutput(`Stack size set to ${nextCapacity}. Start pushing values.`)
   }
 
   const runAnimation = (el, params) => {
@@ -430,7 +430,9 @@ export default function StackIV({ onStepChange }) {
   return (
     <div className="flex flex-col h-full items-center">
       <div className="mb-6 w-full max-w-2xl flex lg:flex-row flex-col items-center justify-between bg-slate-800/50 p-4 rounded-xl border border-slate-700">
-        <label className="text-slate-300 font-bold mr-4">Application Mode:</label>
+        <label className="text-slate-300 font-bold mr-4">
+          Application Mode:
+        </label>
         <select
           value={mode}
           onChange={(e) => handleModeChange(e.target.value)}
@@ -478,7 +480,9 @@ export default function StackIV({ onStepChange }) {
               : 'bg-cyan-950/40 border-cyan-700/50 text-cyan-300'
           }`}
         >
-          {hasStackSize ? `${stack.length}/${stackCapacity} used` : 'size not set'}
+          {hasStackSize
+            ? `${stack.length}/${stackCapacity} used`
+            : 'size not set'}
         </div>
       </div>
 

--- a/src/components/dataStructures/stackIV.jsx
+++ b/src/components/dataStructures/stackIV.jsx
@@ -10,24 +10,35 @@ const MODES = {
 }
 
 const SLEEP_MS = 800
+const MAX_STACK_CAPACITY = 20
 
 export default function StackIV({ onStepChange }) {
   const [stack, setStack] = useState([])
   const [mode, setMode] = useState(MODES.STANDARD)
   const [inputValue, setInputValue] = useState('')
+  const [sizeInput, setSizeInput] = useState('')
+  const [stackCapacity, setStackCapacity] = useState(null)
+  const [hasStackStarted, setHasStackStarted] = useState(false)
   const [consoleOutput, setConsoleOutput] = useState('')
   const [isRunning, setIsRunning] = useState(false)
   const containerRef = useRef(null)
 
   const stackRef = useRef([])
+  const hasStackSize = stackCapacity !== null
+  const emptySlots = hasStackSize ? Math.max(stackCapacity - stack.length, 0) : 0
+  const isStackFull = hasStackSize && stack.length >= stackCapacity
+  const isStackLocked = hasStackStarted
 
   const handleModeChange = (newMode) => {
     setMode(newMode)
     setStack([])
     stackRef.current = []
     setInputValue('')
+    setSizeInput('')
+    setStackCapacity(null)
     setConsoleOutput('')
     setIsRunning(false)
+    setHasStackStarted(false)
     if (onStepChange) onStepChange(null)
   }
 
@@ -36,6 +47,38 @@ export default function StackIV({ onStepChange }) {
   }, [mode, onStepChange])
 
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+  const handleSizeInputChange = (event) => {
+    const nextSize = event.target.value
+    setSizeInput(nextSize)
+
+    if (!hasStackStarted) return
+
+    setConsoleOutput('Stack size is locked after the first push.')
+  }
+
+  const handleSetStackSize = () => {
+    if (hasStackStarted) {
+      setConsoleOutput('Stack size is locked after the first push.')
+      return
+    }
+
+    const nextCapacity = Number(sizeInput)
+
+    if (
+      !Number.isInteger(nextCapacity) ||
+      nextCapacity <= 0 ||
+      nextCapacity > MAX_STACK_CAPACITY
+    ) {
+      setConsoleOutput(`Invalid stack size. Enter 1 to ${MAX_STACK_CAPACITY}.`)
+      return
+    }
+
+    setStackCapacity(nextCapacity)
+    setConsoleOutput(
+      `Stack size set to ${nextCapacity}. Start pushing values.`
+    )
+  }
 
   const runAnimation = (el, params) => {
     return new Promise((resolve) => {
@@ -47,13 +90,22 @@ export default function StackIV({ onStepChange }) {
   }
 
   const pushItem = async (val) => {
-    if (stackRef.current.length >= 8) {
-      setConsoleOutput((prev) => prev + '\nStack Overflow!')
+    if (!hasStackSize) {
+      setConsoleOutput('Enter stack size first.')
+      return false
+    }
+
+    if (stackRef.current.length >= stackCapacity) {
+      setConsoleOutput((prev) => {
+        const message = `Stack Overflow! Capacity ${stackCapacity}/${stackCapacity} reached.`
+        return prev ? `${prev}\n${message}` : message
+      })
       return false
     }
 
     const newItem = { id: Date.now() + Math.random(), value: val }
     stackRef.current.push(newItem)
+    setHasStackStarted(true)
     setStack((prev) => [...prev, newItem])
 
     await sleep(50)
@@ -271,7 +323,7 @@ export default function StackIV({ onStepChange }) {
             <button
               onClick={handleBrowserVisit}
               className="px-6 py-2 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg shadow-lg"
-              disabled={isRunning}
+              disabled={isRunning || !hasStackSize}
             >
               Visit
             </button>
@@ -298,7 +350,7 @@ export default function StackIV({ onStepChange }) {
             <button
               onClick={runReversal}
               className="px-6 py-2 bg-purple-600 hover:bg-purple-500 text-white font-bold rounded-lg shadow-lg"
-              disabled={isRunning}
+              disabled={isRunning || !hasStackSize}
             >
               Reverse String
             </button>
@@ -318,7 +370,7 @@ export default function StackIV({ onStepChange }) {
             <button
               onClick={runParentheses}
               className="px-6 py-2 bg-yellow-600 hover:bg-yellow-500 text-white font-bold rounded-lg shadow-lg"
-              disabled={isRunning}
+              disabled={isRunning || !hasStackSize}
             >
               Check Balance
             </button>
@@ -338,7 +390,7 @@ export default function StackIV({ onStepChange }) {
             <button
               onClick={runPostfix}
               className="px-6 py-2 bg-pink-600 hover:bg-pink-500 text-white font-bold rounded-lg shadow-lg"
-              disabled={isRunning}
+              disabled={isRunning || !hasStackSize}
             >
               Evaluate
             </button>
@@ -359,7 +411,7 @@ export default function StackIV({ onStepChange }) {
             <button
               onClick={handleStandardPush}
               className="px-6 py-2 bg-cyan-600 hover:bg-cyan-500 text-white font-bold rounded-lg shadow-lg"
-              disabled={isRunning}
+              disabled={isRunning || !hasStackSize}
             >
               Push
             </button>
@@ -378,9 +430,7 @@ export default function StackIV({ onStepChange }) {
   return (
     <div className="flex flex-col h-full items-center">
       <div className="mb-6 w-full max-w-2xl flex lg:flex-row flex-col items-center justify-between bg-slate-800/50 p-4 rounded-xl border border-slate-700">
-        <label className="text-slate-300 font-bold mr-4">
-          Application Mode:
-        </label>
+        <label className="text-slate-300 font-bold mr-4">Application Mode:</label>
         <select
           value={mode}
           onChange={(e) => handleModeChange(e.target.value)}
@@ -393,6 +443,43 @@ export default function StackIV({ onStepChange }) {
           <option value={MODES.PARENTHESES}>Parentheses Checker</option>
           <option value={MODES.POSTFIX}>Postfix Evaluator</option>
         </select>
+      </div>
+
+      <div className="mb-5 w-full max-w-2xl flex flex-wrap items-center justify-center gap-4 bg-slate-900/40 p-4 rounded-xl border border-slate-700/70">
+        <label
+          htmlFor="stack-capacity"
+          className="text-slate-300 font-bold text-sm"
+        >
+          Stack Size
+        </label>
+        <input
+          id="stack-capacity"
+          type="number"
+          min={1}
+          max={MAX_STACK_CAPACITY}
+          value={sizeInput}
+          onChange={handleSizeInputChange}
+          onKeyDown={(e) => e.key === 'Enter' && handleSetStackSize()}
+          placeholder={`Max ${MAX_STACK_CAPACITY}`}
+          className="bg-slate-950 border border-slate-700 rounded-lg px-3 py-2 text-cyan-300 font-mono outline-none w-28 text-center"
+          disabled={isRunning || isStackLocked}
+        />
+        <button
+          onClick={handleSetStackSize}
+          className="px-5 py-2 bg-cyan-600 hover:bg-cyan-500 text-white font-bold rounded-lg shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isRunning || isStackLocked || !sizeInput}
+        >
+          Set Size
+        </button>
+        <div
+          className={`px-3 py-2 rounded-lg border font-mono text-xs ${
+            isStackFull
+              ? 'bg-red-950/70 border-red-500/70 text-red-300'
+              : 'bg-cyan-950/40 border-cyan-700/50 text-cyan-300'
+          }`}
+        >
+          {hasStackSize ? `${stack.length}/${stackCapacity} used` : 'size not set'}
+        </div>
       </div>
 
       <div className="flex flex-wrap gap-4 mb-4 justify-center z-10 min-h-[50px]">
@@ -411,7 +498,30 @@ export default function StackIV({ onStepChange }) {
         className="flex-1 flex items-end justify-center pb-10 w-full"
         ref={containerRef}
       >
-        <div className="relative w-48 min-h-[400px] border-b-4 border-l-4 border-r-4 border-slate-600 rounded-b-xl bg-slate-900/30 backdrop-blur-sm flex flex-col-reverse items-center p-2 gap-2 transition-all duration-500">
+        <div
+          className={`relative w-48 border-b-4 border-l-4 border-r-4 rounded-b-xl bg-slate-900/30 backdrop-blur-sm flex flex-col-reverse items-center p-2 gap-2 transition-all duration-500 ${
+            isStackFull
+              ? 'border-red-500 shadow-[0_0_28px_rgba(239,68,68,0.22)]'
+              : 'border-slate-600'
+          }`}
+          style={{ minHeight: `${(stackCapacity || 5) * 56 + 32}px` }}
+        >
+          <div
+            className={`absolute -top-8 left-1/2 -translate-x-1/2 font-mono text-xs uppercase tracking-widest whitespace-nowrap ${
+              isStackFull ? 'text-red-300' : 'text-slate-500'
+            }`}
+          >
+            {!hasStackSize
+              ? 'Enter stack size first'
+              : isStackFull
+                ? 'Overflow boundary reached'
+                : 'Overflow boundary'}
+          </div>
+          <div
+            className={`absolute -top-1 left-0 h-1 w-full ${
+              isStackFull ? 'bg-red-400' : 'bg-slate-500/70'
+            }`}
+          />
           <div className="absolute -bottom-10 text-slate-500 font-mono text-sm uppercase tracking-widest text-center w-full">
             {mode === MODES.BROWSER ? 'History (LIFO)' : 'Stack Memory'}
           </div>
@@ -454,6 +564,15 @@ export default function StackIV({ onStepChange }) {
                   </div>
                 </div>
               )}
+            </div>
+          ))}
+
+          {Array.from({ length: emptySlots }).map((_, index) => (
+            <div
+              key={`empty-slot-${index}`}
+              className="w-full h-12 rounded-md border border-dashed border-slate-700/80 bg-slate-950/20 flex items-center justify-center text-[10px] font-mono text-slate-600"
+            >
+              empty
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Pull Request Summary

### What changed?
Added a fixed-size stack flow to the stack visualizer. Users must now enter the stack size before performing any stack operations. Push and other actions remain disabled until a valid stack size is set, and the stack size becomes locked once the first element is pushed.

### Why is this needed?
This improves the learning experience by matching real fixed-size stack behavior. It helps users clearly understand stack overflow conditions and prevents confusion caused by changing stack capacity during execution.

Closes #394 

## Type of Change

<!-- Select every category that applies. These should align with the Conventional Commit type in the PR title. -->

- [x] `feat` - New user-facing feature or algorithm capability
- [ ] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes
Updated the stack visualizer to use a fixed user-defined stack size with proper overflow handling.
##Release note category:

- [ ] Added
- [x] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

-Updated the stack visualizer to use a fixed user-defined stack size with proper overflow handling.

## Testing and Verification


- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings


## UI Evidence
Before:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/36e90409-68d1-4474-8a35-ec371ee09281" />

After:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/b94cd3b4-1064-4f9c-8128-486bacf72a04" />


## CI/CD and Deployment Impact


- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge


## Reviewer Checklist

<!-- Keep this section for maintainers and reviewers. -->

- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stack capacity is now user-configurable (1–20 items) via a new "Stack Size" panel.
  * Stack visualization dynamically resizes to chosen capacity and shows dashed placeholders for empty slots.
  * Boundary/usage indicators change color to reflect unset size or overflow.

* **Bug Fixes / Behavior Changes**
  * Push controls are disabled until a valid size is set.
  * Overflow attempts produce explicit output messages and halt related operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->