### PR TITLE
feat: Add recursive call tree visualization for merge sort

### DIFF
--- a/src/algorithms/sorting/mergeSortSteps.js
+++ b/src/algorithms/sorting/mergeSortSteps.js
@@ -293,13 +293,48 @@ export function generateMergeSortSteps(inputArray) {
   const arr = [...inputArray]
   const steps = []
   const n = arr.length
+  let nodeId = 0
+  let recursionTree = []
 
-  const performMergeSort = (l, r) => {
+ const snapshotTree = () =>
+  recursionTree
+    .filter((node) => node.status !== 'hidden')
+    .map((node) => ({
+      ...node,
+    }))
+  const performMergeSort = (l, r, depth = 0, parentId = null) => {
+    const currentNode = {
+      id: nodeId++,
+      label: `mergeSort(${l}, ${r})`,
+      type: 'divide',
+      l,
+      r,
+      depth,
+      parentId,
+      status: 'active',
+    }
+
+    recursionTree.push(currentNode)
+    steps.push(
+      createStep({
+        lineKey: 'recursion',
+        type: 'divide',
+        array: arr,
+        recursionTree: snapshotTree(),
+        activeNode: currentNode.id,
+        indices: [l, r],
+        message: `Dividing range [${l}, ${r}]`,
+        variables: { l, r },
+        duration: 500,
+      })
+    )
     steps.push(
       createStep({
         lineKey: 'recursion',
         type: 'outer-loop',
         array: arr,
+        recursionTree: snapshotTree(),
+        activeNode: currentNode.id,
         indices: [l, r],
         message: `Merge Sort on range [${l}, ${r}].`,
         variables: { l, r },
@@ -308,19 +343,80 @@ export function generateMergeSortSteps(inputArray) {
     )
 
     if (l < r) {
+
       const m = Math.floor((l + r) / 2)
-      performMergeSort(l, m)
-      performMergeSort(m + 1, r)
-      performMerge(l, m, r)
-    }
+      performMergeSort(l, m, depth + 1, currentNode.id)
+      performMergeSort(m + 1, r, depth + 1, currentNode.id)
+      
+      const mergeNode = {
+  id: nodeId++,
+  label: `merge(${l}, ${r})`,
+  type: 'merge',
+  l,
+  r,
+  depth,
+  parentId: currentNode.id,
+  status: 'active',
+}
+
+recursionTree.push(mergeNode)
+
+steps.push(
+  createStep({
+    lineKey: 'mergeCall',
+    type: 'merge-phase',
+    array: arr,
+    recursionTree: snapshotTree(),
+    activeNode: mergeNode?.id,
+    indices: [l, r],
+    message: `Merging [${l}, ${m}] and [${m + 1}, ${r}]`,
+    variables: { l, m, r },
+    duration: 600,
+  })
+)
+      performMerge(l, m, r, mergeNode)
+      currentNode.status = 'completed'
+
+  steps.push(
+    createStep({
+      lineKey: 'recursion',
+      type: 'divide-complete',
+      array: arr,
+      recursionTree: snapshotTree(),
+      activeNode: currentNode.id,
+      indices: [l, r],
+      message: `Completed mergeSort(${l}, ${r})`,
+      variables: { l, r },
+      duration: 400,
+    })
+  )
+    }else {
+  currentNode.status = 'completed'
+
+  steps.push(
+    createStep({
+      lineKey: 'recursion',
+      type: 'base-case',
+      array: arr,
+      recursionTree: snapshotTree(),
+      activeNode: currentNode.id,
+      indices: [l],
+      message: `Base case reached at index ${l}`,
+      variables: { l, r },
+      duration: 300,
+    })
+  )
+}
   }
 
-  const performMerge = (l, m, r) => {
+  const performMerge = (l, m, r, mergeNode) => {
     steps.push(
       createStep({
         lineKey: 'mergeCall',
         type: 'merge-start',
         array: arr,
+        recursionTree: snapshotTree(),
+activeNode: mergeNode?.id,
         indices: [l, r],
         message: `Merging subarrays [${l}, ${m}] and [${m + 1}, ${r}].`,
         variables: { l, m, r },
@@ -336,6 +432,8 @@ export function generateMergeSortSteps(inputArray) {
         lineKey: 'setupSubarrays',
         type: 'setup',
         array: arr,
+        recursionTree: snapshotTree(),
+activeNode: mergeNode?.id,
         indices: [l, r],
         message: `Copied subarrays into temporary storage.`,
         variables: { l, m, r, L, R },
@@ -353,6 +451,8 @@ export function generateMergeSortSteps(inputArray) {
           lineKey: 'compare',
           type: 'compare',
           array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: mergeNode?.id,
           indices: [k, l + i, m + 1 + j],
           message: `Compare L[${i}] (${L[i]}) and R[${j}] (${R[j]}).`,
           variables: { l, m, r, i, j, k, leftVal: L[i], rightVal: R[j] },
@@ -373,6 +473,8 @@ export function generateMergeSortSteps(inputArray) {
           lineKey: 'overwrite',
           type: 'insert',
           array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: mergeNode?.id,
           indices: [k],
           message: `Overwrite index ${k} with ${arr[k]}.`,
           variables: { l, m, r, i, j, k },
@@ -389,6 +491,8 @@ export function generateMergeSortSteps(inputArray) {
           lineKey: 'overwrite',
           type: 'insert',
           array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: mergeNode?.id,
           indices: [k],
           message: `Copy remaining element ${L[i]} from left subarray.`,
           variables: { l, m, r, i, j, k },
@@ -406,6 +510,8 @@ export function generateMergeSortSteps(inputArray) {
           lineKey: 'overwrite',
           type: 'insert',
           array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: mergeNode?.id,
           indices: [k],
           message: `Copy remaining element ${R[j]} from right subarray.`,
           variables: { l, m, r, i, j, k },
@@ -415,6 +521,21 @@ export function generateMergeSortSteps(inputArray) {
       j++
       k++
     }
+    mergeNode.status = 'completed'
+
+steps.push(
+  createStep({
+    lineKey: 'mergeCall',
+    type: 'merge-complete',
+    array: arr,
+    recursionTree: snapshotTree(),
+    activeNode: mergeNode?.id,
+    indices: [l, r],
+    message: `Merge completed for [${l}, ${r}]`,
+    variables: { l, m, r },
+    duration: 500,
+  })
+)
   }
 
   steps.push(
@@ -430,17 +551,22 @@ export function generateMergeSortSteps(inputArray) {
 
   performMergeSort(0, n - 1)
 
-  steps.push(
-    createStep({
-      lineKey: 'complete',
-      type: 'complete',
-      array: arr,
-      sortedIndices: Array.from({ length: n }, (_, index) => index),
-      message: 'Merge Sort is complete.',
-      variables: { n },
-      duration: 900,
-    })
-  )
+ steps.push(
+  createStep({
+    lineKey: 'complete',
+    type: 'complete',
+    array: arr,
+    recursionTree: snapshotTree(),
+    activeNode: null,
+    sortedIndices: Array.from(
+      { length: n },
+      (_, index) => index
+    ),
+    message: 'Merge Sort is complete.',
+    variables: { n },
+    duration: 900,
+  })
+)
 
   return steps
 }

--- a/src/algorithms/sorting/mergeSortSteps.js
+++ b/src/algorithms/sorting/mergeSortSteps.js
@@ -296,12 +296,12 @@ export function generateMergeSortSteps(inputArray) {
   let nodeId = 0
   let recursionTree = []
 
- const snapshotTree = () =>
-  recursionTree
-    .filter((node) => node.status !== 'hidden')
-    .map((node) => ({
-      ...node,
-    }))
+  const snapshotTree = () =>
+    recursionTree
+      .filter((node) => node.status !== 'hidden')
+      .map((node) => ({
+        ...node,
+      }))
   const performMergeSort = (l, r, depth = 0, parentId = null) => {
     const currentNode = {
       id: nodeId++,
@@ -343,70 +343,69 @@ export function generateMergeSortSteps(inputArray) {
     )
 
     if (l < r) {
-
       const m = Math.floor((l + r) / 2)
       performMergeSort(l, m, depth + 1, currentNode.id)
       performMergeSort(m + 1, r, depth + 1, currentNode.id)
-      
+
       const mergeNode = {
-  id: nodeId++,
-  label: `merge(${l}, ${r})`,
-  type: 'merge',
-  l,
-  r,
-  depth,
-  parentId: currentNode.id,
-  status: 'active',
-}
+        id: nodeId++,
+        label: `merge(${l}, ${r})`,
+        type: 'merge',
+        l,
+        r,
+        depth,
+        parentId: currentNode.id,
+        status: 'active',
+      }
 
-recursionTree.push(mergeNode)
+      recursionTree.push(mergeNode)
 
-steps.push(
-  createStep({
-    lineKey: 'mergeCall',
-    type: 'merge-phase',
-    array: arr,
-    recursionTree: snapshotTree(),
-    activeNode: mergeNode?.id,
-    indices: [l, r],
-    message: `Merging [${l}, ${m}] and [${m + 1}, ${r}]`,
-    variables: { l, m, r },
-    duration: 600,
-  })
-)
+      steps.push(
+        createStep({
+          lineKey: 'mergeCall',
+          type: 'merge-phase',
+          array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: mergeNode?.id,
+          indices: [l, r],
+          message: `Merging [${l}, ${m}] and [${m + 1}, ${r}]`,
+          variables: { l, m, r },
+          duration: 600,
+        })
+      )
       performMerge(l, m, r, mergeNode)
       currentNode.status = 'completed'
 
-  steps.push(
-    createStep({
-      lineKey: 'recursion',
-      type: 'divide-complete',
-      array: arr,
-      recursionTree: snapshotTree(),
-      activeNode: currentNode.id,
-      indices: [l, r],
-      message: `Completed mergeSort(${l}, ${r})`,
-      variables: { l, r },
-      duration: 400,
-    })
-  )
-    }else {
-  currentNode.status = 'completed'
+      steps.push(
+        createStep({
+          lineKey: 'recursion',
+          type: 'divide-complete',
+          array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: currentNode.id,
+          indices: [l, r],
+          message: `Completed mergeSort(${l}, ${r})`,
+          variables: { l, r },
+          duration: 400,
+        })
+      )
+    } else {
+      currentNode.status = 'completed'
 
-  steps.push(
-    createStep({
-      lineKey: 'recursion',
-      type: 'base-case',
-      array: arr,
-      recursionTree: snapshotTree(),
-      activeNode: currentNode.id,
-      indices: [l],
-      message: `Base case reached at index ${l}`,
-      variables: { l, r },
-      duration: 300,
-    })
-  )
-}
+      steps.push(
+        createStep({
+          lineKey: 'recursion',
+          type: 'base-case',
+          array: arr,
+          recursionTree: snapshotTree(),
+          activeNode: currentNode.id,
+          indices: [l],
+          message: `Base case reached at index ${l}`,
+          variables: { l, r },
+          duration: 300,
+        })
+      )
+    }
   }
 
   const performMerge = (l, m, r, mergeNode) => {
@@ -416,7 +415,7 @@ steps.push(
         type: 'merge-start',
         array: arr,
         recursionTree: snapshotTree(),
-activeNode: mergeNode?.id,
+        activeNode: mergeNode?.id,
         indices: [l, r],
         message: `Merging subarrays [${l}, ${m}] and [${m + 1}, ${r}].`,
         variables: { l, m, r },
@@ -433,7 +432,7 @@ activeNode: mergeNode?.id,
         type: 'setup',
         array: arr,
         recursionTree: snapshotTree(),
-activeNode: mergeNode?.id,
+        activeNode: mergeNode?.id,
         indices: [l, r],
         message: `Copied subarrays into temporary storage.`,
         variables: { l, m, r, L, R },
@@ -523,19 +522,19 @@ activeNode: mergeNode?.id,
     }
     mergeNode.status = 'completed'
 
-steps.push(
-  createStep({
-    lineKey: 'mergeCall',
-    type: 'merge-complete',
-    array: arr,
-    recursionTree: snapshotTree(),
-    activeNode: mergeNode?.id,
-    indices: [l, r],
-    message: `Merge completed for [${l}, ${r}]`,
-    variables: { l, m, r },
-    duration: 500,
-  })
-)
+    steps.push(
+      createStep({
+        lineKey: 'mergeCall',
+        type: 'merge-complete',
+        array: arr,
+        recursionTree: snapshotTree(),
+        activeNode: mergeNode?.id,
+        indices: [l, r],
+        message: `Merge completed for [${l}, ${r}]`,
+        variables: { l, m, r },
+        duration: 500,
+      })
+    )
   }
 
   steps.push(
@@ -551,22 +550,19 @@ steps.push(
 
   performMergeSort(0, n - 1)
 
- steps.push(
-  createStep({
-    lineKey: 'complete',
-    type: 'complete',
-    array: arr,
-    recursionTree: snapshotTree(),
-    activeNode: null,
-    sortedIndices: Array.from(
-      { length: n },
-      (_, index) => index
-    ),
-    message: 'Merge Sort is complete.',
-    variables: { n },
-    duration: 900,
-  })
-)
+  steps.push(
+    createStep({
+      lineKey: 'complete',
+      type: 'complete',
+      array: arr,
+      recursionTree: snapshotTree(),
+      activeNode: null,
+      sortedIndices: Array.from({ length: n }, (_, index) => index),
+      message: 'Merge Sort is complete.',
+      variables: { n },
+      duration: 900,
+    })
+  )
 
   return steps
 }

--- a/src/components/sortingAlgo/RecursiveTree.jsx
+++ b/src/components/sortingAlgo/RecursiveTree.jsx
@@ -1,0 +1,209 @@
+import { useState, useMemo } from 'react'
+
+const NODE_WIDTH = 100
+const NODE_HEIGHT = 28
+const GAP_Y = 25
+const GAP_X = 10
+
+export default function RecursiveTree({ tree = [], activeNode }) {
+  const [collapsed, setCollapsed] = useState(new Set())
+
+  const nodesById = useMemo(() => {
+    const map = new Map()
+    tree.forEach((node) => map.set(node.id, { ...node, children: [] }))
+    map.forEach((node) => {
+      if (node.parentId !== null && map.has(node.parentId)) {
+        map.get(node.parentId).children.push(node)
+      }
+    })
+    return map
+  }, [tree])
+
+  const roots = useMemo(
+    () => [...nodesById.values()].filter((n) => n.parentId === null),
+    [nodesById]
+  )
+
+  const toggleCollapse = (id) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  const collapseAll = () => {
+    setCollapsed(
+      new Set(
+        [...nodesById.values()]
+          .filter((n) => n.children.length > 0)
+          .map((n) => n.id)
+      )
+    )
+  }
+
+  // ── Layout engine ──────────────────────────────────────────────
+  // Returns { nodes: [{id, x, y, node}], edges: [{x1,y1,x2,y2}], width, height }
+  const layout = useMemo(() => {
+    const placed = []   // { id, x, y, node }
+    const edges = []    // { x1, y1, x2, y2 }
+
+    // measureHeight: total pixel height a subtree occupies
+   const measureWidth = (node) => {
+  if (collapsed.has(node.id) || node.children.length === 0) return NODE_WIDTH
+  const childrenW = node.children.reduce(
+    (sum, c) => sum + measureWidth(c), 0
+  ) + (node.children.length - 1) * GAP_X
+  return Math.max(NODE_WIDTH, childrenW)
+}
+
+    // place: recursively place node at (x, centerY)
+    const place = (node, centerX, y) => {
+  placed.push({ id: node.id, x: centerX - NODE_WIDTH / 2, y, node })
+  if (collapsed.has(node.id) || node.children.length === 0) return
+
+  const childY = y + NODE_HEIGHT + GAP_Y
+  const totalW = node.children.reduce(
+    (sum, c) => sum + measureWidth(c), 0
+  ) + (node.children.length - 1) * GAP_X
+
+  let cursor = centerX - totalW / 2
+  node.children.forEach((child) => {
+    const childW = measureWidth(child)
+    const childCenter = cursor + childW / 2
+    const midY = y + NODE_HEIGHT + GAP_Y / 2
+
+    edges.push({ x1: centerX, y1: y + NODE_HEIGHT, x2: centerX, y2: midY })
+    edges.push({ x1: centerX, y1: midY, x2: childCenter, y2: midY })
+    edges.push({ x1: childCenter, y1: midY, x2: childCenter, y2: childY })
+
+    place(child, childCenter, childY)
+    cursor += childW + GAP_X
+  })
+}
+
+    // place each root stacked vertically
+    let rootCursor = 0
+roots.forEach((root) => {
+  const w = measureWidth(root)
+  place(root, rootCursor + w / 2, 0)
+  rootCursor += w + GAP_X * 2
+})
+
+    const maxX = placed.reduce((m, n) => Math.max(m, n.x + NODE_WIDTH), 0)
+const maxY = placed.reduce((m, n) => Math.max(m, n.y + NODE_HEIGHT), 0)
+return { nodes: placed, edges, width: maxX, height: maxY }
+  }, [roots, collapsed])
+
+  const getColors = (node) => {
+    if (node.id === activeNode)
+      return { bg: 'rgba(59,130,246,0.25)', border: '#3b82f6', text: '#93c5fd' }
+    if (node.status === 'completed')
+      return { bg: 'rgba(139,92,246,0.18)', border: '#7c3aed', text: '#c4b5fd' }
+    return { bg: 'rgba(30,37,51,0.6)', border: '#374151', text: '#6b7280' }
+  }
+
+  const PAD = 16
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(75,85,99,0.4)',
+        borderRadius: 12,
+        background: 'rgba(10,15,28,0.85)',
+        padding: '12px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 200,
+      }}
+    >
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.15em', textTransform: 'uppercase', color: '#9ca3af' }}>
+          Recursive Call Tree
+        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: '#4b5563' }}>
+            Merge Sort
+          </span>
+          <button
+            onClick={collapseAll}
+            style={{ fontSize: 9, padding: '2px 8px', border: '1px solid rgba(107,114,128,0.4)', borderRadius: 4, color: '#6b7280', background: 'transparent', cursor: 'pointer' }}
+          >
+            Collapse All
+          </button>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div style={{ overflowX: 'auto', overflowY: 'auto', flex: 1 }}>
+        <div style={{ position: 'relative', width: layout.width + PAD, height: layout.height + PAD }}>
+
+          {/* SVG edges */}
+          <svg
+            style={{ position: 'absolute', top: 0, left: 0, overflow: 'visible', pointerEvents: 'none' }}
+            width={layout.width + PAD}
+            height={layout.height + PAD}
+          >
+            {layout.edges.map((e, i) => (
+              <line
+                key={i}
+                x1={e.x1} y1={e.y1}
+                x2={e.x2} y2={e.y2}
+                stroke="rgba(107,114,128,0.45)"
+                strokeWidth={1}
+              />
+            ))}
+          </svg>
+
+          {/* Nodes */}
+          {layout.nodes.map(({ id, x, y, node }) => {
+            const colors = getColors(node)
+            const hasChildren = node.children.length > 0
+            return (
+              <div
+                key={id}
+                onClick={() => hasChildren && toggleCollapse(id)}
+                style={{
+                  position: 'absolute',
+                  left: x,
+                  top: y,
+                  width: NODE_WIDTH,
+                  height: NODE_HEIGHT,
+                  background: colors.bg,
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 5,
+                  color: colors.text,
+                  fontFamily: 'monospace',
+                  fontSize: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  whiteSpace: 'nowrap',
+                  cursor: hasChildren ? 'pointer' : 'default',
+                  userSelect: 'none',
+                }}
+              >
+                {node.label}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, paddingTop: 10, borderTop: '1px solid rgba(75,85,99,0.25)', fontSize: 10, color: '#6b7280' }}>
+        {[
+          { color: '#3b82f6', label: 'Current Call' },
+          { color: '#7c3aed', label: 'Completed' },
+          { color: '#4b5563', label: 'Pending' },
+        ].map(({ color, label }) => (
+          <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <div style={{ width: 7, height: 7, borderRadius: '50%', background: color }} />
+            {label}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/sortingAlgo/RecursiveTree.jsx
+++ b/src/components/sortingAlgo/RecursiveTree.jsx
@@ -45,54 +45,55 @@ export default function RecursiveTree({ tree = [], activeNode }) {
   // ── Layout engine ──────────────────────────────────────────────
   // Returns { nodes: [{id, x, y, node}], edges: [{x1,y1,x2,y2}], width, height }
   const layout = useMemo(() => {
-    const placed = []   // { id, x, y, node }
-    const edges = []    // { x1, y1, x2, y2 }
+    const placed = [] // { id, x, y, node }
+    const edges = [] // { x1, y1, x2, y2 }
 
     // measureHeight: total pixel height a subtree occupies
-   const measureWidth = (node) => {
-  if (collapsed.has(node.id) || node.children.length === 0) return NODE_WIDTH
-  const childrenW = node.children.reduce(
-    (sum, c) => sum + measureWidth(c), 0
-  ) + (node.children.length - 1) * GAP_X
-  return Math.max(NODE_WIDTH, childrenW)
-}
+    const measureWidth = (node) => {
+      if (collapsed.has(node.id) || node.children.length === 0)
+        return NODE_WIDTH
+      const childrenW =
+        node.children.reduce((sum, c) => sum + measureWidth(c), 0) +
+        (node.children.length - 1) * GAP_X
+      return Math.max(NODE_WIDTH, childrenW)
+    }
 
     // place: recursively place node at (x, centerY)
     const place = (node, centerX, y) => {
-  placed.push({ id: node.id, x: centerX - NODE_WIDTH / 2, y, node })
-  if (collapsed.has(node.id) || node.children.length === 0) return
+      placed.push({ id: node.id, x: centerX - NODE_WIDTH / 2, y, node })
+      if (collapsed.has(node.id) || node.children.length === 0) return
 
-  const childY = y + NODE_HEIGHT + GAP_Y
-  const totalW = node.children.reduce(
-    (sum, c) => sum + measureWidth(c), 0
-  ) + (node.children.length - 1) * GAP_X
+      const childY = y + NODE_HEIGHT + GAP_Y
+      const totalW =
+        node.children.reduce((sum, c) => sum + measureWidth(c), 0) +
+        (node.children.length - 1) * GAP_X
 
-  let cursor = centerX - totalW / 2
-  node.children.forEach((child) => {
-    const childW = measureWidth(child)
-    const childCenter = cursor + childW / 2
-    const midY = y + NODE_HEIGHT + GAP_Y / 2
+      let cursor = centerX - totalW / 2
+      node.children.forEach((child) => {
+        const childW = measureWidth(child)
+        const childCenter = cursor + childW / 2
+        const midY = y + NODE_HEIGHT + GAP_Y / 2
 
-    edges.push({ x1: centerX, y1: y + NODE_HEIGHT, x2: centerX, y2: midY })
-    edges.push({ x1: centerX, y1: midY, x2: childCenter, y2: midY })
-    edges.push({ x1: childCenter, y1: midY, x2: childCenter, y2: childY })
+        edges.push({ x1: centerX, y1: y + NODE_HEIGHT, x2: centerX, y2: midY })
+        edges.push({ x1: centerX, y1: midY, x2: childCenter, y2: midY })
+        edges.push({ x1: childCenter, y1: midY, x2: childCenter, y2: childY })
 
-    place(child, childCenter, childY)
-    cursor += childW + GAP_X
-  })
-}
+        place(child, childCenter, childY)
+        cursor += childW + GAP_X
+      })
+    }
 
     // place each root stacked vertically
     let rootCursor = 0
-roots.forEach((root) => {
-  const w = measureWidth(root)
-  place(root, rootCursor + w / 2, 0)
-  rootCursor += w + GAP_X * 2
-})
+    roots.forEach((root) => {
+      const w = measureWidth(root)
+      place(root, rootCursor + w / 2, 0)
+      rootCursor += w + GAP_X * 2
+    })
 
     const maxX = placed.reduce((m, n) => Math.max(m, n.x + NODE_WIDTH), 0)
-const maxY = placed.reduce((m, n) => Math.max(m, n.y + NODE_HEIGHT), 0)
-return { nodes: placed, edges, width: maxX, height: maxY }
+    const maxY = placed.reduce((m, n) => Math.max(m, n.y + NODE_HEIGHT), 0)
+    return { nodes: placed, edges, width: maxX, height: maxY }
   }, [roots, collapsed])
 
   const getColors = (node) => {
@@ -118,17 +119,47 @@ return { nodes: placed, edges, width: maxX, height: maxY }
       }}
     >
       {/* Header */}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
-        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.15em', textTransform: 'uppercase', color: '#9ca3af' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase',
+            color: '#9ca3af',
+          }}
+        >
           Recursive Call Tree
         </span>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', color: '#4b5563' }}>
+          <span
+            style={{
+              fontSize: 9,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: '#4b5563',
+            }}
+          >
             Merge Sort
           </span>
           <button
             onClick={collapseAll}
-            style={{ fontSize: 9, padding: '2px 8px', border: '1px solid rgba(107,114,128,0.4)', borderRadius: 4, color: '#6b7280', background: 'transparent', cursor: 'pointer' }}
+            style={{
+              fontSize: 9,
+              padding: '2px 8px',
+              border: '1px solid rgba(107,114,128,0.4)',
+              borderRadius: 4,
+              color: '#6b7280',
+              background: 'transparent',
+              cursor: 'pointer',
+            }}
           >
             Collapse All
           </button>
@@ -137,19 +168,32 @@ return { nodes: placed, edges, width: maxX, height: maxY }
 
       {/* Canvas */}
       <div style={{ overflowX: 'auto', overflowY: 'auto', flex: 1 }}>
-        <div style={{ position: 'relative', width: layout.width + PAD, height: layout.height + PAD }}>
-
+        <div
+          style={{
+            position: 'relative',
+            width: layout.width + PAD,
+            height: layout.height + PAD,
+          }}
+        >
           {/* SVG edges */}
           <svg
-            style={{ position: 'absolute', top: 0, left: 0, overflow: 'visible', pointerEvents: 'none' }}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              overflow: 'visible',
+              pointerEvents: 'none',
+            }}
             width={layout.width + PAD}
             height={layout.height + PAD}
           >
             {layout.edges.map((e, i) => (
               <line
                 key={i}
-                x1={e.x1} y1={e.y1}
-                x2={e.x2} y2={e.y2}
+                x1={e.x1}
+                y1={e.y1}
+                x2={e.x2}
+                y2={e.y2}
                 stroke="rgba(107,114,128,0.45)"
                 strokeWidth={1}
               />
@@ -192,14 +236,34 @@ return { nodes: placed, edges, width: maxX, height: maxY }
       </div>
 
       {/* Legend */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 16, paddingTop: 10, borderTop: '1px solid rgba(75,85,99,0.25)', fontSize: 10, color: '#6b7280' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+          paddingTop: 10,
+          borderTop: '1px solid rgba(75,85,99,0.25)',
+          fontSize: 10,
+          color: '#6b7280',
+        }}
+      >
         {[
           { color: '#3b82f6', label: 'Current Call' },
           { color: '#7c3aed', label: 'Completed' },
           { color: '#4b5563', label: 'Pending' },
         ].map(({ color, label }) => (
-          <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-            <div style={{ width: 7, height: 7, borderRadius: '50%', background: color }} />
+          <div
+            key={label}
+            style={{ display: 'flex', alignItems: 'center', gap: 5 }}
+          >
+            <div
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: color,
+              }}
+            />
             {label}
           </div>
         ))}

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -6,6 +6,7 @@ import { useStepPlayback } from '../visualizer/useStepPlayback'
 import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import TestCaseManager from '../testCaseManager/TestCaseManager'
+import RecursiveTree from './RecursiveTree.jsx'
 
 import * as bubble from '../../algorithms/sorting/bubbleSortSteps'
 import * as selection from '../../algorithms/sorting/selectionSortSteps'
@@ -324,6 +325,7 @@ export default function Visualizer() {
     clearPlayback()
     setSearchParams(newAlgo ? { algo: newAlgo } : {})
   }
+  
 
   return (
     <div className="flex flex-col p-2 sm:p-4 lg:p-5">
@@ -720,6 +722,13 @@ export default function Visualizer() {
                   </div>
                 </div>
               )}
+              {selectedAlgorithm === 'merge' && (
+  <RecursiveTree
+    tree={currentStep?.recursionTree}
+    activeNode={currentStep?.activeNode}
+  />
+)}
+
             </div>
           </div>
         </div>

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -325,7 +325,6 @@ export default function Visualizer() {
     clearPlayback()
     setSearchParams(newAlgo ? { algo: newAlgo } : {})
   }
-  
 
   return (
     <div className="flex flex-col p-2 sm:p-4 lg:p-5">
@@ -723,12 +722,11 @@ export default function Visualizer() {
                 </div>
               )}
               {selectedAlgorithm === 'merge' && (
-  <RecursiveTree
-    tree={currentStep?.recursionTree}
-    activeNode={currentStep?.activeNode}
-  />
-)}
-
+                <RecursiveTree
+                  tree={currentStep?.recursionTree}
+                  activeNode={currentStep?.activeNode}
+                />
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Implemented a recursive call tree visualization for the Merge Sort visualizer to improve recursion and divide-and-conquer understanding.

## Features Added

* Dynamic recursive call tree rendering
* Progressive recursion expansion during execution
* Merge phase visualization
* Active recursive call highlighting
* Completed node state tracking
* Playback synchronization with visualizer controls
* Stable tree layout with hierarchical indentation

## Improvements

* Better educational understanding of Merge Sort recursion flow
* Clear divide and merge phase distinction
* Enhanced interactive learning experience
* Improved visualization consistency during playback

## Testing

* Verified auto playback
* Verified step-by-step playback
* Verified replay/reset functionality
* Verified algorithm switching behavior
* Build and lint checks passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive recursion-tree visualization for merge sort showing divide/merge phases and base-case steps
  * Tree view highlights the current call, completed nodes, and pending nodes; legend included
  * Branches can be expanded/collapsed with a “Collapse All” control for clarity
  * Visualization is shown when the merge sort algorithm is selected and updates with each step

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->