### PR TITLE
feat: add reset all functionality to grid visualizer

### DIFF
--- a/src/components/shortestPathAlgo/GridVisualizer.jsx
+++ b/src/components/shortestPathAlgo/GridVisualizer.jsx
@@ -23,7 +23,8 @@ const LEGEND_ITEMS = [
 ]
 
 const getCellClassName = (node) => {
-  return `w-7 h-7 border border-(--theme-border) flex items-center justify-center text-[11px] text-(--theme-text-strong) ${node.isStart
+  return `w-7 h-7 border border-(--theme-border) flex items-center justify-center text-[11px] text-(--theme-text-strong) ${
+    node.isStart
       ? 'bg-green-500'
       : node.isEnd
         ? 'bg-red-500'
@@ -40,7 +41,7 @@ const getCellClassName = (node) => {
               : node.visited
                 ? 'bg-cyan-500'
                 : 'bg-(--theme-surface)'
-    }`
+  }`
 }
 
 const createNode = (row, col) => {
@@ -402,9 +403,9 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
             prev.map((r) =>
               r.map((c) =>
                 c.row === node.row &&
-                  c.col === node.col &&
-                  !c.isStart &&
-                  !c.isEnd
+                c.col === node.col &&
+                !c.isStart &&
+                !c.isEnd
                   ? { ...c, visited: true }
                   : c
               )
@@ -423,9 +424,9 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
               prev.map((r) =>
                 r.map((c) =>
                   c.row === node.row &&
-                    c.col === node.col &&
-                    !c.isStart &&
-                    !c.isEnd
+                  c.col === node.col &&
+                  !c.isStart &&
+                  !c.isEnd
                     ? { ...c, path: true }
                     : c
                 )

--- a/src/components/shortestPathAlgo/GridVisualizer.jsx
+++ b/src/components/shortestPathAlgo/GridVisualizer.jsx
@@ -23,8 +23,7 @@ const LEGEND_ITEMS = [
 ]
 
 const getCellClassName = (node) => {
-  return `w-7 h-7 border border-(--theme-border) flex items-center justify-center text-[11px] text-(--theme-text-strong) ${
-    node.isStart
+  return `w-7 h-7 border border-(--theme-border) flex items-center justify-center text-[11px] text-(--theme-text-strong) ${node.isStart
       ? 'bg-green-500'
       : node.isEnd
         ? 'bg-red-500'
@@ -41,7 +40,7 @@ const getCellClassName = (node) => {
               : node.visited
                 ? 'bg-cyan-500'
                 : 'bg-(--theme-surface)'
-  }`
+    }`
 }
 
 const createNode = (row, col) => {
@@ -328,6 +327,15 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
     setVisitedCount(0)
   }
 
+  const resetAll = () => {
+    clearTimers()
+    setRunning(false)
+    setGrid(createGrid())
+    setPathCost(0)
+    setVisitedCount(0)
+    setDrawMode('wall')
+  }
+
   const handleMouseInteraction = (row, col) => {
     if (running) return
     setGrid((prev) => {
@@ -394,9 +402,9 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
             prev.map((r) =>
               r.map((c) =>
                 c.row === node.row &&
-                c.col === node.col &&
-                !c.isStart &&
-                !c.isEnd
+                  c.col === node.col &&
+                  !c.isStart &&
+                  !c.isEnd
                   ? { ...c, visited: true }
                   : c
               )
@@ -415,9 +423,9 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
               prev.map((r) =>
                 r.map((c) =>
                   c.row === node.row &&
-                  c.col === node.col &&
-                  !c.isStart &&
-                  !c.isEnd
+                    c.col === node.col &&
+                    !c.isStart &&
+                    !c.isEnd
                     ? { ...c, path: true }
                     : c
                 )
@@ -501,6 +509,13 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
           className="px-4 py-2 bg-[var(--theme-surface-strong)] rounded-lg text-(--theme-text-strong) font-semibold text-sm"
         >
           Clear Path
+        </button>
+        <button
+          aria-label="Reset All"
+          onClick={resetAll}
+          className="px-4 py-2 bg-[var(--theme-surface-strong)] rounded-lg text-(--theme-text-strong) font-semibold text-sm"
+        >
+          Reset All
         </button>
       </div>
 


### PR DESCRIPTION
### What changed?
Added a new **Reset All** functionality to the Grid Visualizer that restores the application back to its original default state with a single action.
This update introduces a dedicated **Reset All** button in the controls section. The functionality clears active animation timers, recreates the grid using `createGrid()`, resets metrics like `pathCost` and `visitedCount`, restores the default drawing mode, and ensures the visualizer is no longer in a running state.

Main areas affected:
* Grid Visualizer controls UI
* Grid state management
* Animation/timer cleanup logic
* Pathfinding metrics reset workflow

### Why is this needed?
Previously, users had to manually clear multiple states such as paths, grids, metrics, and drawing modes after experimenting with algorithms and maze generations. This made repeated testing and learning workflows inconvenient and time-consuming.
The new Reset All action provides a much smoother experience for:
* Running multiple algorithms consecutively
* Testing different wall and weight configurations
* Classroom demos and practice sessions
* Restarting experiments quickly from a clean initial state

Closes #417 

## Type of Change
* [x] `feat` - New user-facing feature or algorithm capability
* [ ] `fix` - Bug fix or regression fix
* [ ] `docs` - Documentation-only change
* [ ] `style` - Formatting or styling change with no behavior change
* [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
* [ ] `perf` - Performance improvement
* [ ] `test` - Test coverage or test infrastructure change
* [ ] `build` - Build system, dependency, or packaging change
* [ ] `ci` - GitHub Actions, Docker, or release automation change
* [ ] `chore` - Maintenance change that does not affect users
* [ ] `revert` - Reverts a previous change

## Release Notes
Release note category:
* [x] Added
* [ ] Changed
* [ ] Fixed
* [ ] Removed
* [ ] Deprecated
* [ ] Security
* [ ] Not required

Release note entry:
* Added a Reset All button to the Grid Visualizer for restoring the application to its default initial state in one click.

## Testing and Verification
* [x] `npm ci` or `npm install`
* [ ] `npm run format:check`
* [ ] `npm run lint`
* [x] `npm run build`
* [x] Manual browser testing at `http://localhost:5173`
* [x] Responsive testing for affected views
* [x] No new console errors or warnings

## UI Evidence
Before:
* Users had to manually clear grid, paths, metrics, and drawing modes separately.
After:
* Added a dedicated Reset All button that restores the visualizer to its original default state instantly.
https://github.com/user-attachments/assets/91b8e806-db06-4211-920f-14955450bdd0


## CI/CD and Deployment Impact
* [x] No deployment impact expected
* [ ] Updates GitHub Actions or release automation
* [ ] Updates Docker build/runtime behavior
* [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
* [ ] Adds or changes environment variables
* [ ] Adds, removes, or updates npm dependencies
* [ ] Requires maintainer follow-up after merge

Deployment notes:
* No additional deployment or configuration changes required.

## Reviewer Checklist
* [x] PR title follows Conventional Commits and matches the selected change type
* [x] Scope is focused and unrelated changes are excluded
* [x] Release note category and entry are accurate
* [x] CI checks are expected to pass: format, lint, and build
* [ ] UI evidence is included when user-facing screens changed
* [x] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Reset All" button to the controls that clears animations, stops running visualizations, recreates the grid, and resets metrics and drawing mode to default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->