### PR TITLE
fix: make sign in button visible across light and dark themes

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -304,9 +304,8 @@ export const Navbar = () => {
                 <>
                   <SignedOut>
                     <SignInButton mode="modal">
-                      <button className="theme-button-primary relative group overflow-hidden rounded-xl bg-slate-900 px-6 py-2 text-sm font-bold transition-all duration-300 active:scale-95">
+                      <button className="theme-button-primary relative group overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 hover:bg-slate-100 dark:hover:bg-slate-800/80 text-slate-700 dark:text-slate-200 px-6 py-2 text-sm font-bold transition-all duration-300 shadow-md active:scale-95">
                         <span className="relative z-10">Sign In</span>
-
                         <div className="absolute inset-0 bg-gradient-to-r from-indigo-600/20 to-purple-600/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                       </button>
                     </SignInButton>
@@ -328,7 +327,7 @@ export const Navbar = () => {
                   <button
                     title="Auth not configured"
                     disabled
-                    className="theme-button-primary relative group overflow-hidden rounded-xl px-6 py-2 text-sm font-bold transition-all duration-300 opacity-50 cursor-not-allowed"
+                    className="theme-button-primary relative group overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 text-slate-700 dark:text-slate-200 px-6 py-2 text-sm font-bold transition-all duration-300 shadow-md opacity-50 cursor-not-allowed"
                   >
                     Sign In
                   </button>


### PR DESCRIPTION
### What changed?

Updated the Tailwind CSS utility classes for the desktop "Sign In" button within the `Navbar` component. Added explicit borders, background colors, text colors, and shadows to match the adjacent GitHub button styling. These changes were applied to both the active Clerk `<SignInButton>` and the disabled fallback button. 

### Why is this needed?

The "Sign In" button was previously blending into the navigation bar background, rendering it practically invisible and unreadable in both light and dark modes. This fix ensures the authentication entry point is clearly visible and accessible to users regardless of their current theme setting.

Closes #441 

## Type of Change

- [ ] `feat` - New user-facing feature or algorithm capability
- [x] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes

Release note category:

- [ ] Added
- [ ] Changed
- [x] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

- Fixed an issue where the desktop "Sign In" button in the navigation bar was invisible in both light and dark themes.

## Testing and Verification

- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:

Verified that the updated styling only targets the desktop button and does not unintentionally affect or conflict with the existing mobile menu layout.

## UI Evidence

Before:
<img width="1919" height="1031" alt="Screenshot 2026-05-29 131050" src="https://github.com/user-attachments/assets/9d56897e-dd82-415b-8f33-4cccf421949d" />


After:
<img width="1920" height="1140" alt="Screenshot 2026-05-29 135511" src="https://github.com/user-attachments/assets/adf84918-e70c-4cd0-a6b6-289860fd5538" />


## CI/CD and Deployment Impact

- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:

None. This is a CSS-only UI fix.

## Reviewer Checklist

- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Sign In button styling with improved borders, backgrounds, shadows, and opacity effects across authenticated and auth-disabled states for better visual consistency and dark-mode support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->