### PR TITLE
feat: add FFT algorithm visualization

### DIFF
--- a/src/algorithms/mathTheory/mathTheorySources.jsx
+++ b/src/algorithms/mathTheory/mathTheorySources.jsx
@@ -649,3 +649,206 @@ export const getFibonacciSource = (language) =>
 
 export const resolveFibonacciLine = (language, lineKey) =>
   (fibonacciSources[language] ?? fibonacciSources.javascript).lineMap?.[lineKey]
+
+// FAST FOURIER TRANSFORM 
+
+export const fftSources = {
+  javascript: {
+    code: `function fft(signal) {
+  const n = signal.length;
+  if (n <= 1) return signal;
+
+  // Bit-reverse permutation
+  const out = bitReverse(signal);
+
+  // Cooley-Tukey butterfly stages
+  for (let stage = 1; stage <= Math.log2(n); stage++) {
+    const half = 1 << (stage - 1);
+    const full = 1 << stage;
+
+    for (let k = 0; k < n; k += full) {
+      for (let j = 0; j < half; j++) {
+        const angle = -2 * Math.PI * j / full;
+        const tw = { re: Math.cos(angle), im: Math.sin(angle) };
+
+        // Butterfly operation
+        const top = out[k + j];
+        const bot = out[k + j + half];
+        const t = complexMul(tw, bot);
+
+        out[k + j]        = complexAdd(top, t);
+        out[k + j + half] = complexSub(top, t);
+      }
+    }
+  }
+  return out;
+}
+
+console.log(fft([1, 2, 3, 4]));`,
+    lineMap: {
+      start: 1,
+      bitReverse: 5,
+      stageLoop: 8,
+      butterfly: 16,
+      butterflyResult: 19,
+      result: 24,
+    },
+  },
+  python: {
+    code: `import cmath
+import math
+
+def fft(signal):
+    n = len(signal)
+    if n <= 1:
+        return signal
+
+    # Bit-reverse permutation
+    out = bit_reverse(signal)
+
+    # Cooley-Tukey butterfly stages
+    stage = 1
+    while stage <= int(math.log2(n)):
+        half = 1 << (stage - 1)
+        full = 1 << stage
+
+        for k in range(0, n, full):
+            for j in range(half):
+                angle = -2 * math.pi * j / full
+                tw = complex(math.cos(angle), math.sin(angle))
+
+                # Butterfly operation
+                top = out[k + j]
+                bot = out[k + j + half]
+                t = tw * bot
+
+                out[k + j]         = top + t
+                out[k + j + half]  = top - t
+
+        stage += 1
+
+    return out
+
+print(fft([1, 2, 3, 4]))`,
+    lineMap: {
+      start: 4,
+      bitReverse: 9,
+      stageLoop: 12,
+      butterfly: 20,
+      butterflyResult: 25,
+      result: 30,
+    },
+  },
+  cpp: {
+    code: `#include <iostream>
+#include <vector>
+#include <complex>
+#include <cmath>
+using namespace std;
+
+typedef complex<double> cd;
+const double PI = acos(-1);
+
+void fft(vector<cd>& a) {
+    int n = a.size();
+
+    // Bit-reverse permutation
+    for (int i = 1, j = 0; i < n; i++) {
+        int bit = n >> 1;
+        for (; j & bit; bit >>= 1) j ^= bit;
+        j ^= bit;
+        if (i < j) swap(a[i], a[j]);
+    }
+
+    // Cooley-Tukey butterfly stages
+    for (int stage = 2; stage <= n; stage <<= 1) {
+        cd w(cos(2*PI/stage), -sin(2*PI/stage));
+        for (int k = 0; k < n; k += stage) {
+            cd wn(1);
+            for (int j = 0; j < stage/2; j++) {
+                // Butterfly operation
+                cd top = a[k + j];
+                cd bot = wn * a[k + j + stage/2];
+                a[k + j]             = top + bot;
+                a[k + j + stage/2]   = top - bot;
+                wn *= w;
+            }
+        }
+    }
+}
+
+int main() {
+    vector<cd> s = {1, 2, 3, 4};
+    fft(s);
+    for (auto& x : s) cout << x << " ";
+}`,
+    lineMap: {
+      start: 10,
+      bitReverse: 13,
+      stageLoop: 21,
+      butterfly: 26,
+      butterflyResult: 29,
+      result: 37,
+    },
+  },
+  java: {
+    code: `public class FFT {
+    static final double PI = Math.PI;
+
+    static void fft(double[] re, double[] im) {
+        int n = re.length;
+
+        // Bit-reverse permutation
+        for (int i = 1, j = 0; i < n; i++) {
+            int bit = n >> 1;
+            for (; (j & bit) != 0; bit >>= 1) j ^= bit;
+            j ^= bit;
+            if (i < j) {
+                double tmp = re[i]; re[i] = re[j]; re[j] = tmp;
+                tmp = im[i]; im[i] = im[j]; im[j] = tmp;
+            }
+        }
+
+        // Cooley-Tukey butterfly stages
+        for (int stage = 2; stage <= n; stage <<= 1) {
+            double ang = 2 * PI / stage;
+            double wRe = Math.cos(ang), wIm = -Math.sin(ang);
+            for (int k = 0; k < n; k += stage) {
+                double curRe = 1, curIm = 0;
+                for (int j = 0; j < stage / 2; j++) {
+                    // Butterfly operation
+                    int top = k + j, bot = k + j + stage / 2;
+                    double tRe = curRe*re[bot] - curIm*im[bot];
+                    double tIm = curRe*im[bot] + curIm*re[bot];
+                    re[bot] = re[top] - tRe;  im[bot] = im[top] - tIm;
+                    re[top] = re[top] + tRe;  im[top] = im[top] + tIm;
+                    double nRe = curRe*wRe - curIm*wIm;
+                    curIm = curRe*wIm + curIm*wRe;
+                    curRe = nRe;
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        double[] re = {1,2,3,4}, im = {0,0,0,0};
+        fft(re, im);
+    }
+}`,
+    lineMap: {
+      start: 4,
+      bitReverse: 7,
+      stageLoop: 18,
+      butterfly: 25,
+      butterflyResult: 29,
+      result: 40,
+    },
+  },
+}
+
+export const getFFTSource = (language) =>
+  fftSources[language]?.code ?? fftSources.javascript.code
+
+export const resolveFFTLine = (language, lineKey) =>
+  (fftSources[language] ?? fftSources.javascript).lineMap?.[lineKey]
+

--- a/src/algorithms/mathTheory/mathTheorySteps.jsx
+++ b/src/algorithms/mathTheory/mathTheorySteps.jsx
@@ -1,4 +1,4 @@
-import { createStep } from '../../lib/utils'
+import { createStep, formatComplex } from '../../lib/utils'
 
 // ─────────────────────────────────────────────
 // EUCLIDEAN GCD  (Euclidean modulo vs naive subtraction)
@@ -591,6 +591,278 @@ export function generateFibonacciSteps(n) {
       activePath: null,
       spiralCount: maxNResolved,
       duration: 1000,
+    })
+  )
+
+  return steps
+}
+
+// FAST FOURIER TRANSFORM  (Cooley-Tukey DFT vs FFT)
+
+//helpers
+
+function toPolar(re, im) {
+  const mag = Math.sqrt(re * re + im * im)
+  const phase = Math.atan2(im, re)
+  return { mag: +mag.toFixed(3), phase: +phase.toFixed(3) }
+}
+
+// Bit-reverse permutation
+function bitReverse(arr) {
+  const n = arr.length
+  const bits = Math.log2(n)
+  const out = new Array(n)
+  for (let i = 0; i < n; i++) {
+    let rev = 0
+    let tmp = i
+    for (let b = 0; b < bits; b++) {
+      rev = (rev << 1) | (tmp & 1)
+      tmp >>= 1
+    }
+    out[rev] = arr[i]
+  }
+  return out
+}
+
+// Signal generator for FFT presets
+export function generateSignal(n, type) {
+  switch (type) {
+    case 'sine':
+      return Array.from({ length: n }, (_, i) =>
+        +Math.sin((2 * Math.PI * i) / n).toFixed(4)
+      )
+    case 'cosine':
+      return Array.from({ length: n }, (_, i) =>
+        +Math.cos((2 * Math.PI * i) / n).toFixed(4)
+      )
+    case 'impulse':
+      return Array.from({ length: n }, (_, i) => (i === 0 ? 1 : 0))
+    case 'square':
+      return Array.from({ length: n }, (_, i) => (i < n / 2 ? 1 : -1))
+    case 'ramp':
+      return Array.from({ length: n }, (_, i) => i + 1)
+    case 'noise':
+      return Array.from({ length: n }, () =>
+        +(Math.random() * 2 - 1).toFixed(4)
+      )
+    default:
+      return Array.from({ length: n }, (_, i) => i + 1)
+  }
+}
+
+// generateFFTSteps 
+// input: number[]  (real-valued signal, length must be power of 2, 4–16)
+
+export function generateFFTSteps(inputSignal) {
+  const steps = []
+  const n = inputSignal.length
+
+  // Clamp / pad to nearest power of 2 between 4 and 16
+  const validN = [4, 8, 16].find((p) => p >= n) ?? 8
+  const signal = [...inputSignal]
+  while (signal.length < validN) signal.push(0)
+  const finalSignal = signal.slice(0, validN)
+
+  const totalStages = Math.log2(validN)
+  const naiveTotalOps = validN * validN
+  let fftOps = 0
+
+  // Build initial node array (complex: im = 0 for real input)
+  const makeNodes = (arr, state = 'idle') =>
+    arr.map((v, i) => ({
+      index: i,
+      re: +(typeof v === 'object' ? v.re : v).toFixed(3),
+      im: +(typeof v === 'object' ? v.im : 0).toFixed(3),
+      state,
+    }))
+
+  // ── Step 0: start ─────────────────────────
+  steps.push(
+    createStep({
+      lineKey: 'start',
+      type: 'start',
+      stage: 0,
+      nodes: makeNodes(finalSignal, 'idle'),
+      butterflies: [],
+      naiveOps: naiveTotalOps,
+      fftOps: 0,
+      message: `Input signal x[n] of length ${validN}. DFT naively needs ${naiveTotalOps} ops. FFT will use only ${validN * totalStages} ops.`,
+      variables: {
+        n: validN,
+        stage: 0,
+        totalStages,
+        naiveOps: naiveTotalOps,
+        fftOps: 0,
+      },
+      duration: 1000,
+    })
+  )
+
+  // ── Step 1: bit-reverse permutation ──────
+  const permuted = bitReverse(finalSignal)
+  steps.push(
+    createStep({
+      lineKey: 'bitReverse',
+      type: 'compare',
+      stage: 0,
+      nodes: makeNodes(permuted, 'active'),
+      butterflies: [],
+      naiveOps: naiveTotalOps,
+      fftOps,
+      message: `Bit-reverse permutation: reorder indices so recursive halves are contiguous. x = [${permuted.join(', ')}]`,
+      variables: {
+        n: validN,
+        stage: 0,
+        totalStages,
+        naiveOps: naiveTotalOps,
+        fftOps,
+      },
+      duration: 900,
+    })
+  )
+
+  // Working buffer of complex numbers
+  let buf = permuted.map((v) => ({ re: v, im: 0 }))
+
+  // ── Steps 2+: butterfly stages ───────────
+  for (let s = 1; s <= totalStages; s++) {
+    const half = 1 << (s - 1) // half = 2^(s-1)
+    const full = 1 << s // full = 2^s
+
+    // Announce stage
+    steps.push(
+      createStep({
+        lineKey: 'stageLoop',
+        type: 'compare',
+        stage: s,
+        nodes: makeNodes(buf, 'idle'),
+        butterflies: [],
+        naiveOps: naiveTotalOps,
+        fftOps,
+        message: `Stage ${s} of ${totalStages}: merge ${validN / full} group(s) of size ${full} using ${half}-point twiddle factors.`,
+        variables: {
+          n: validN,
+          stage: s,
+          totalStages,
+          naiveOps: naiveTotalOps,
+          fftOps,
+        },
+        duration: 800,
+      })
+    )
+
+    // Process each group
+    for (let k = 0; k < validN; k += full) {
+
+      for (let j = 0; j < half; j++) {
+        const topIdx = k + j
+        const botIdx = k + j + half
+
+        // Twiddle factor: W = e^(-2πi·j/full) = cos(…) - i·sin(…)
+        const angle = (-2 * Math.PI * j) / full
+        const twRe = Math.cos(angle)
+        const twIm = Math.sin(angle)
+
+        // Show which butterfly is being computed
+        const nodesSnapshot = makeNodes(buf, 'idle')
+        nodesSnapshot[topIdx] = { ...nodesSnapshot[topIdx], state: 'active' }
+        nodesSnapshot[botIdx] = { ...nodesSnapshot[botIdx], state: 'computing' }
+
+        steps.push(
+          createStep({
+            lineKey: 'butterfly',
+            type: 'compare',
+            stage: s,
+            nodes: nodesSnapshot,
+            butterflies: [{ top: topIdx, bot: botIdx, twiddleRe: +twRe.toFixed(3), twiddleIm: +twIm.toFixed(3) }],
+            naiveOps: naiveTotalOps,
+            fftOps,
+            message: `Butterfly (${topIdx}, ${botIdx}): W = ${formatComplex(twRe, twIm)} · X[${botIdx}]`,
+            variables: {
+              n: validN,
+              stage: s,
+              topIdx,
+              botIdx,
+              totalStages,
+              naiveOps: naiveTotalOps,
+              fftOps,
+            },
+            duration: 700,
+          })
+        )
+
+        // Apply butterfly
+        const tRe = twRe * buf[botIdx].re - twIm * buf[botIdx].im
+        const tIm = twRe * buf[botIdx].im + twIm * buf[botIdx].re
+
+        const newTopRe = buf[topIdx].re + tRe
+        const newTopIm = buf[topIdx].im + tIm
+        const newBotRe = buf[topIdx].re - tRe
+        const newBotIm = buf[topIdx].im - tIm
+
+        buf[topIdx] = { re: newTopRe, im: newTopIm }
+        buf[botIdx] = { re: newBotRe, im: newBotIm }
+        fftOps += 2
+
+        // Show result of butterfly
+        const afterNodes = makeNodes(buf, 'idle')
+        afterNodes[topIdx] = { ...afterNodes[topIdx], state: 'done' }
+        afterNodes[botIdx] = { ...afterNodes[botIdx], state: 'done' }
+
+        steps.push(
+          createStep({
+            lineKey: 'butterflyResult',
+            type: 'swap',
+            stage: s,
+            nodes: afterNodes,
+            butterflies: [],
+            naiveOps: naiveTotalOps,
+            fftOps,
+            message: `X[${topIdx}] = ${formatComplex(newTopRe, newTopIm)},  X[${botIdx}] = ${formatComplex(newBotRe, newBotIm)}`,
+            variables: {
+              n: validN,
+              stage: s,
+              topIdx,
+              botIdx,
+              totalStages,
+              naiveOps: naiveTotalOps,
+              fftOps,
+            },
+            duration: 650,
+          })
+        )
+      }
+    }
+  }
+
+  // ── Final step ────────────────────────────
+  const output = buf.map((c, i) => ({
+    index: i,
+    ...toPolar(c.re, c.im),
+    re: +c.re.toFixed(2),
+    im: +c.im.toFixed(2),
+    state: 'done',
+  }))
+
+  steps.push(
+    createStep({
+      lineKey: 'result',
+      type: 'complete',
+      stage: totalStages,
+      nodes: output,
+      butterflies: [],
+      naiveOps: naiveTotalOps,
+      fftOps,
+      message: `FFT complete! ${fftOps} ops vs ${naiveTotalOps} for naive DFT. Speedup: ${(naiveTotalOps / fftOps).toFixed(1)}×`,
+      variables: {
+        n: validN,
+        stage: totalStages,
+        totalStages,
+        naiveOps: naiveTotalOps,
+        fftOps,
+        speedup: +(naiveTotalOps / fftOps).toFixed(1),
+      },
+      duration: 1200,
     })
   )
 

--- a/src/algorithms/mathTheory/mathTheorySteps.jsx
+++ b/src/algorithms/mathTheory/mathTheorySteps.jsx
@@ -658,7 +658,7 @@ export function generateFFTSteps(inputSignal) {
   const n = inputSignal.length
 
   // Clamp / pad to nearest power of 2 between 4 and 16
-  const validN = [4, 8, 16].find((p) => p >= n) ?? 8
+  const validN = [4, 8, 16].find((p) => p >= n) ?? 16
   const signal = [...inputSignal]
   while (signal.length < validN) signal.push(0)
   const finalSignal = signal.slice(0, validN)

--- a/src/components/MathTheory/CanvasFFT.jsx
+++ b/src/components/MathTheory/CanvasFFT.jsx
@@ -1,0 +1,257 @@
+import React, { useMemo, useState } from 'react'
+import { GitBranch, BarChart3 } from "lucide-react";
+import { motion, AnimatePresence } from 'framer-motion'
+import StatusDisplay from '../StatusDisplay'
+import { formatComplex } from '../../lib/utils'
+import { generateSignal } from '../../algorithms/mathTheory/mathTheorySteps'
+
+// ButterflyDiagram
+
+function ButterflyDiagram({ nodes, butterflies, stage, totalStages }) {
+  const n    = nodes.length
+  const W    = 580
+  const rowH = Math.max(22, Math.min(56, 320 / Math.max(n, 1)))
+  const H    = n * rowH + 80
+  const cols = totalStages + 1
+  const colX = (c) => 52 + c * ((W - 72) / cols)
+  const nodeY = (i) => 36 + i * rowH + rowH / 2
+
+  const nodeColor  = (s) => ({ active: '#a855f7', computing: '#f59e0b', done: '#10b981' }[s] ?? '#334155')
+  const nodeStroke = (s) => ({ active: '#d8b4fe', computing: '#fde68a', done: '#6ee7b7' }[s] ?? '#475569')
+  const activeSet  = new Set(butterflies.flatMap((b) => [b.top, b.bot]))
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ maxHeight: 360 }}>
+      {/* Column headers */}
+      {Array.from({ length: cols }, (_, c) => (
+        <text key={c} x={colX(c)} y={18} textAnchor="middle" fontSize={9}
+          fill="#64748b" fontFamily="monospace">
+          {c === 0 ? 'input' : `stage ${c}`}
+        </text>
+      ))}
+
+      {/* Active butterfly connections */}
+      {butterflies.map((b, bi) => {
+        const x1 = colX(stage - 1), x2 = colX(stage)
+        const yT = nodeY(b.top),    yB = nodeY(b.bot)
+        return (
+          <g key={bi}>
+            <line x1={x1} y1={yT} x2={x2} y2={yB} stroke="#a855f7" strokeWidth={1.5} strokeDasharray="4 2" opacity={0.7}/>
+            <line x1={x1} y1={yB} x2={x2} y2={yT} stroke="#f59e0b" strokeWidth={1.5} strokeDasharray="4 2" opacity={0.7}/>
+            <line x1={x1} y1={yT} x2={x2} y2={yT} stroke="#a855f7" strokeWidth={0.8} opacity={0.35}/>
+            <line x1={x1} y1={yB} x2={x2} y2={yB} stroke="#f59e0b" strokeWidth={0.8} opacity={0.35}/>
+            {b.twiddleRe !== undefined && b.twiddleIm !== undefined && (
+              <text x={(x1 + x2) / 2} y={(yT + yB) / 2 - 5} textAnchor="middle"
+                fontSize={8} fill="#94a3b8" fontFamily="monospace">
+                {formatComplex(b.twiddleRe, b.twiddleIm)}
+              </text>
+            )}
+          </g>
+        )
+      })}
+
+      {/* Pass-through lines for inactive nodes */}
+      {stage > 0 && nodes.map((_, i) => {
+        if (activeSet.has(i)) return null
+        const y = nodeY(i)
+        return <line key={i} x1={colX(stage - 1)} y1={y} x2={colX(stage)} y2={y} stroke="#1e293b" strokeWidth={1}/>
+      })}
+
+      {/* Nodes */}
+      {nodes.map((node, i) => {
+        const cx = colX(stage)
+        const cy = nodeY(i)
+        return (
+          <g key={i}>
+            <motion.circle cx={cx} cy={cy} r={rowH * 0.27}
+              fill={nodeColor(node.state)} stroke={nodeStroke(node.state)} strokeWidth={1.5}
+              initial={{ scale: 0.6, opacity: 0.3 }} animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.25 }}/>
+            <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle"
+              fontSize={rowH * 0.22} fill="#f1f5f9" fontWeight="700" fontFamily="monospace">{i}</text>
+            <text x={cx + rowH * 0.38} y={cy} dominantBaseline="middle"
+              fontSize={9} fill="#94a3b8" fontFamily="monospace">
+              {formatComplex(node.re, node.im)}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
+  )
+}
+
+// MagnitudeChart
+
+function MagnitudeChart({ nodes }) {
+  const mags   = nodes.map((nd) => Math.sqrt((nd.re ?? 0) ** 2 + (nd.im ?? 0) ** 2))
+  const maxMag = Math.max(...mags, 1)
+
+  return (
+    <div className="w-full space-y-4">
+      <p className="text-[10px] text-slate-500 uppercase tracking-widest text-center font-mono">
+        |X[k]| — Magnitude spectrum
+      </p>
+
+      {/* Bar chart */}
+      <div className="relative h-40 w-full">
+        <div className="absolute inset-0 flex items-end gap-1.5 px-3 pb-6">
+          {mags.map((m, i) => (
+            <div key={i} className="flex-1 flex flex-col items-center justify-end h-full gap-1">
+              <motion.div
+                className="w-full rounded-t min-h-[2px]"
+                style={{ background: `hsl(${180 + i * 15}, 70%, 55%)` }}
+                initial={{ height: 0 }}
+                animate={{ height: `${(m / maxMag) * 100}%` }}
+                transition={{ duration: 0.4, type: 'spring', stiffness: 180, damping: 20 }}
+              />
+              <span className="text-[10px] text-slate-500 font-mono leading-none">{i}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Value cards */}
+      <div className="grid grid-cols-2 gap-2">
+        {nodes.slice(0, 8).map((nd, i) => (
+          <div key={i} className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/40 border border-slate-700/30">
+            <div className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+              style={{ background: `hsl(${180 + i * 15}, 70%, 55%)` }}/>
+            <span className="text-[11px] font-mono text-slate-300 truncate">
+              X[{i}] = {formatComplex(nd.re, nd.im)}
+            </span>
+            <span className="text-[11px] font-mono text-slate-500 ml-auto flex-shrink-0 tabular-nums">
+              {mags[i].toFixed(2)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// StatCard
+
+function StatCard({ label, value, color, subtext }) {
+  return (
+    <div className="rounded-xl bg-slate-800/40 px-4 py-3 border border-slate-700/30 text-center flex flex-col gap-1">
+      <p className="text-slate-500 text-[10px] uppercase tracking-wider font-semibold font-mono">{label}</p>
+      <p className={`text-2xl font-bold font-mono ${color}`}>{value}</p>
+      {subtext && <p className="text-[9px] text-slate-600 font-mono">{subtext}</p>}
+    </div>
+  )
+}
+
+// CanvasFFT  — main export
+
+export const CanvasFFT = ({ currentStep, fftN, fftType }) => {
+  const [view, setView] = useState('butterfly')
+
+  const validN = [4, 8, 16].find((p) => p >= fftN) ?? 8
+  const totalStages = Math.log2(validN)
+
+  const idleSignal = generateSignal(validN, fftType)
+  const nodes = currentStep?.nodes
+    ?? idleSignal.map((v, i) => ({ index: i, re: v, im: 0, state: 'idle' }))
+  const butterflies = currentStep?.butterflies ?? []
+  const stage       = currentStep?.stage ?? 0
+  const naiveOps    = currentStep?.variables?.naiveOps ?? validN * validN
+  const fftOps      = currentStep?.variables?.fftOps   ?? 0
+  const message     = currentStep?.message ?? 'Enter signal values and click Visualize.'
+
+  const speedup = useMemo(() => {
+    const ops = fftOps || validN * Math.log2(validN)
+    return (naiveOps / ops).toFixed(1)
+  }, [naiveOps, fftOps, validN])
+
+  const totalFftOps = fftOps || Math.round(validN * Math.log2(validN))
+
+  const TABS = [
+    { key: 'butterfly', label: 'Butterfly', icon: <GitBranch size={14} />, cls: 'bg-purple-500/20 text-purple-700 border-purple-400 shadow-sm' },
+    { key: 'magnitude', label: 'Spectrum', icon: <BarChart3 size={14} />, cls: 'bg-cyan-500/20 text-cyan-700 border-cyan-400 shadow-sm' },
+  ]
+
+  return (
+    <div className="w-full">
+      <div className="rounded-2xl border border-white/8 bg-slate-900/60 backdrop-blur-sm
+                      shadow-xl shadow-black/30 overflow-hidden">
+
+        {/* Tab bar */}
+        <div className="flex items-center justify-between px-5 sm:px-7 pt-5 pb-4 border-b border-white/5">
+          <div className="flex bg-slate-950/80 p-1 rounded-xl border border-white/5 gap-1">
+            {TABS.map((t) => (
+              <button
+                key={t.key}
+                onClick={() => setView(t.key)}
+                className={`px-4 py-1.5 rounded-lg text-xs font-bold tracking-wide uppercase
+                            transition-all duration-200 border flex items-center gap-2
+                            ${
+                              view === t.key
+                                ? `${t.cls} shadow-sm`
+                                : 'text-slate-500 border-transparent hover:text-slate-200'
+                            }`}
+              >
+                {t.icon}
+                <span>{t.label}</span>
+              </button>
+            ))}
+          </div>
+          {/* Inline stage pill */}
+          <div className="text-xs font-mono text-slate-500 bg-slate-800/50 px-3 py-1.5 rounded-lg border border-slate-700/30">
+            {stage > 0 ? (
+              <span>stage <span className="text-purple-400 font-bold">{stage}</span> / {totalStages}</span>
+            ) : (
+              <span className="text-slate-600">idle</span>
+            )}
+          </div>
+        </div>
+
+        {/* Content area */}
+        <div className="px-5 sm:px-7 py-5 min-h-[300px] flex items-center justify-center">
+          <AnimatePresence mode="wait">
+            {view === 'butterfly' && (
+              <motion.div key="butterfly" className="w-full overflow-x-auto"
+                initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.2 }}>
+                <ButterflyDiagram nodes={nodes} butterflies={butterflies}
+                  stage={stage} totalStages={totalStages}/>
+              </motion.div>
+            )}
+            {view === 'magnitude' && (
+              <motion.div key="magnitude" className="w-full"
+                initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.2 }}>
+                <MagnitudeChart nodes={nodes}/>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        {/* Stats strip */}
+        <div className="grid grid-cols-3 gap-3 px-5 sm:px-7 pb-5 border-t border-white/5 pt-4">
+          <StatCard
+            label="Total FFT Ops"
+            value={totalFftOps}
+            color="text-cyan-400"
+            subtext={`N·log₂N = ${validN}·${totalStages}`}
+          />
+          <StatCard
+            label="Total DFT Ops"
+            value={naiveOps}
+            color="text-rose-400"
+            subtext={`N² = ${validN}²`}
+          />
+          <StatCard
+            label="Speedup"
+            value={`${speedup}×`}
+            color="text-emerald-400"
+            subtext="FFT vs naive DFT"
+          />
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <StatusDisplay message={message}/>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MathTheory/MathSoloVisualizer.jsx
+++ b/src/components/MathTheory/MathSoloVisualizer.jsx
@@ -9,12 +9,15 @@ import { CanvasFastExpo } from './CanvasFastExpo.jsx'
 import { CanvasBitManip } from './CanvasBitManip.jsx'
 import { CanvasSieve } from './CanvasSieve.jsx'
 import { CanvasFibonacci } from './CanvasFibonacci.jsx'
+import { CanvasFFT } from './CanvasFFT'
 import {
   generateEuclideanGCDSteps,
   generateFastExpoSteps,
   generateBitOpSteps,
   generateSieveSteps,
   generateFibonacciSteps,
+  generateFFTSteps,
+  generateSignal,
 } from '../../algorithms/mathTheory/mathTheorySteps'
 import {
   getGCDSource,
@@ -22,11 +25,13 @@ import {
   getBitManipSource,
   getSieveSource,
   getFibonacciSource,
+  getFFTSource,
   resolveGCDLine,
   resolveFastExpoLine,
   resolveBitManipLine,
   resolveSieveLine,
   resolveFibonacciLine,
+  resolveFFTLine,
 } from '../../algorithms/mathTheory/mathTheorySources'
 
 const ALGO_TABS = [
@@ -35,6 +40,7 @@ const ALGO_TABS = [
   { key: 'bits', label: 'Bit Manipulation', complexityKey: 'bitmanip' },
   { key: 'sieve', label: 'Sieve of Eratosthenes', complexityKey: 'sieve' },
   { key: 'fibonacci', label: 'Fibonacci Sequence', complexityKey: 'fibonacci' },
+  {key: 'fft', label: 'Fast Fourier Transform', complexityKey: 'fft' },
 ]
 
 export const MathSoloVisualizer = () => {
@@ -64,6 +70,10 @@ export const MathSoloVisualizer = () => {
   // Fibonacci state
   const [fibLimit, setFibLimit] = useState(6)
   const [isStepMode, setIsStepMode] = useState(false)
+
+  // FFT state
+  const [fftN, setFftN] = useState(8)
+  const [fftType, setFftType] = useState('ramp')
 
   const {
     currentStep,
@@ -98,6 +108,9 @@ export const MathSoloVisualizer = () => {
       loadSteps(generateFibonacciSteps(Number(fibLimit)), {
         autoPlay: !isStepMode,
       })
+    } else if (algo === 'fft') {
+        const signal = generateSignal(fftN, fftType)
+        loadSteps(generateFFTSteps(signal), { autoPlay: !isStepMode })
     } else {
       loadSteps(generateBitOpSteps(Number(bitA), Number(bitB), bitOp), {
         autoPlay: !isStepMode,
@@ -114,6 +127,7 @@ export const MathSoloVisualizer = () => {
     if (algo === 'expo') return getFastExpoSource(language)
     if (algo === 'sieve') return getSieveSource(language)
     if (algo === 'fibonacci') return getFibonacciSource(language)
+    if (algo === 'fft') return getFFTSource(language)
     return getBitManipSource(language)
   }, [algo, language])
 
@@ -125,6 +139,8 @@ export const MathSoloVisualizer = () => {
     if (algo === 'sieve') return resolveSieveLine(language, currentStep.lineKey)
     if (algo === 'fibonacci')
       return resolveFibonacciLine(language, currentStep.lineKey)
+    if (algo === 'fft')       
+      return resolveFFTLine(language, currentStep.lineKey)
     if (algo === 'bits')
       return resolveBitManipLine(language, currentStep.lineKey)
     return undefined
@@ -375,6 +391,50 @@ export const MathSoloVisualizer = () => {
           </div>
         )}
 
+        {algo === 'fft' && (
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Inputs
+            </p>
+            <div>
+              <label className="text-xs text-slate-500 mb-1 block">
+                N (signal length)
+              </label>
+              <select
+                value={fftN}
+                onChange={(e) => { setFftN(Number(e.target.value)); clear() }}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-2.5 text-white outline-none focus:border-cyan-500 text-sm"
+              >
+                <option value={4}>4</option>
+                <option value={8}>8</option>
+                <option value={16}>16</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-slate-500 mb-1 block">
+                Signal type
+              </label>
+              <select
+                value={fftType}
+                onChange={(e) => { setFftType(e.target.value); clear() }}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-2.5 text-white outline-none focus:border-cyan-500 text-sm"
+              >
+                {['ramp', 'sine', 'cosine', 'impulse', 'square', 'noise'].map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+              <p className="text-[10px] text-slate-600 mt-1">
+                {fftType === 'sine'    && 'One cycle of sin(2πi/N) — two spectrum spikes'}
+                {fftType === 'cosine'  && 'One cycle of cos(2πi/N) — symmetric spikes'}
+                {fftType === 'impulse' && 'x[0]=1, rest 0 — flat magnitude spectrum'}
+                {fftType === 'square'  && 'First half +1, second half −1 — odd harmonics'}
+                {fftType === 'ramp'    && 'x[n] = n+1 — linearly increasing signal'}
+                {fftType === 'noise'   && 'Random values — broad noisy spectrum'}
+              </p>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-3 pt-2 pb-2 border-t border-white/10">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 mb-2">
@@ -516,6 +576,13 @@ export const MathSoloVisualizer = () => {
           <CanvasFibonacci
             currentStep={currentStep}
             inputLimit={Number(fibLimit)}
+          />
+        )}
+        {algo === 'fft' && (
+          <CanvasFFT 
+            currentStep={currentStep} 
+            fftN={fftN} 
+            fftType={fftType} 
           />
         )}
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -107,3 +107,12 @@ export const swap = (arr, i, j) => {
   arr[i] = arr[j]
   arr[j] = temp
 }
+
+export function formatComplex(re, im) {
+  if (re === undefined) return '—'
+  const r = +re.toFixed(2)
+  const i = +im.toFixed(2)
+  if (i === 0) return `${r}`
+  if (i < 0)   return `${r} − ${Math.abs(i)}i`
+  return `${r} + ${i}i`
+}


### PR DESCRIPTION
## Problem Statement

AlgoScope did not include a Fast Fourier Transform (FFT) visualization in the Math Theory section.

## Solution

Added an interactive FFT visualizer featuring:

- Butterfly network visualization
- Step-by-step FFT execution
- Frequency spectrum output
- Educational FFT explanations

## Files Changed

- `src/components/MathTheory/CanvasFFT.jsx` — New FFT visualizer component
- `src/algorithms/mathTheory/mathTheorySteps.jsx` — Added FFT visualization steps
- `src/algorithms/mathTheory/mathTheorySources.jsx` — Added FFT source code examples
- `src/components/MathTheory/MathSoloVisualizer.jsx` — Registered FFT visualizer
- `src/lib/utils.js` — Added utility functions for FFT visualization support

## Testing

- Manually tested FFT visualization
- Ran `npm run build`

## Type of Change

- New feature

Closes #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fast Fourier Transform (FFT) visualization with interactive butterfly and magnitude-spectrum views.
  * Step-by-step FFT playback: permutation, butterfly stages, per-butterfly updates, and overall stats (ops & speedup).
  * Preset signal generator (sine, cosine, impulse, square, ramp, noise) with configurable length.
  * UI controls for FFT length/type and integrated playback/autoplay; main canvas shows FFT when selected.
  * Multi-language FFT source display with line-aware highlighting.
  * Improved complex-number formatting in displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->