### PR TITLE
feat: add math theory deep links

### DIFF
--- a/src/components/MathTheory/MathSoloVisualizer.jsx
+++ b/src/components/MathTheory/MathSoloVisualizer.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider'
 import ComplexityCard from '../ComplexityCard'
 import CodePanel from '../visualizer/CodePanel'
@@ -37,7 +38,12 @@ const ALGO_TABS = [
   { key: 'fibonacci', label: 'Fibonacci Sequence', complexityKey: 'fibonacci' },
 ]
 
+const DEFAULT_ALGO_KEY = 'gcd'
+const VALID_ALGO_KEYS = new Set(ALGO_TABS.map((tab) => tab.key))
+
 export const MathSoloVisualizer = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
   useEffect(() => {
     document.title = 'Math Theory | AlgoScope'
   }, [])
@@ -79,6 +85,28 @@ export const MathSoloVisualizer = () => {
     stepForward,
     stepBackward,
   } = useStepPlayback({ speed })
+
+  useEffect(() => {
+    const algoFromUrl = searchParams.get('algo')
+    const nextAlgo =
+      algoFromUrl && VALID_ALGO_KEYS.has(algoFromUrl)
+        ? algoFromUrl
+        : DEFAULT_ALGO_KEY
+
+    if (nextAlgo !== algo) {
+      setAlgo(nextAlgo)
+      clear()
+    }
+  }, [algo, clear, searchParams])
+
+  const handleAlgoChange = (nextAlgo) => {
+    setAlgo(nextAlgo)
+    clear()
+
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.set('algo', nextAlgo)
+    setSearchParams(nextParams)
+  }
 
   const handleVisualize = () => {
     clear()
@@ -150,10 +178,7 @@ export const MathSoloVisualizer = () => {
           {ALGO_TABS.map((t) => (
             <button
               key={t.key}
-              onClick={() => {
-                setAlgo(t.key)
-                clear()
-              }}
+              onClick={() => handleAlgoChange(t.key)}
               className={`w-full text-left px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-200
                 ${
                   algo === t.key

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -211,6 +211,46 @@ const ALGORITHMS = [
     category: 'Math',
     route: '/math-theory',
   },
+  {
+    id: 'gcd',
+    name: 'Euclidean GCD',
+    category: 'Math Theory',
+    route: '/math-theory?algo=gcd',
+    keywords: ['gcd', 'greatest common divisor', 'euclidean algorithm', 'math'],
+  },
+  {
+    id: 'fastExpo',
+    name: 'Fast Exponentiation',
+    category: 'Math Theory',
+    route: '/math-theory?algo=expo',
+    keywords: [
+      'binary exponentiation',
+      'exponentiation by squaring',
+      'power',
+      'math',
+    ],
+  },
+  {
+    id: 'bitManip',
+    name: 'Bit Manipulation',
+    category: 'Math Theory',
+    route: '/math-theory?algo=bits',
+    keywords: ['bits', 'and', 'or', 'xor', 'shift', 'binary', 'math'],
+  },
+  {
+    id: 'sieve',
+    name: 'Sieve of Eratosthenes',
+    category: 'Math Theory',
+    route: '/math-theory?algo=sieve',
+    keywords: ['sieve', 'prime numbers', 'primes', 'eratosthenes', 'math'],
+  },
+  {
+    id: 'fibonacci',
+    name: 'Fibonacci Sequence',
+    category: 'Math Theory',
+    route: '/math-theory?algo=fibonacci',
+    keywords: ['fibonacci', 'recursion', 'sequence', 'math'],
+  },
   // Games & Challenges
   {
     id: 'challenge',


### PR DESCRIPTION
## Summary
- Added direct URL deep links for Math Theory algorithms.
- Synced Math Theory tab selection with the `algo` query parameter.
- Added individual Math Theory algorithms to global search.

## Changes Made
- `/math-theory?algo=gcd`
- `/math-theory?algo=expo`
- `/math-theory?algo=bits`
- `/math-theory?algo=sieve`
- `/math-theory?algo=fibonacci`

## Testing
- `npx.cmd prettier --check src/components/MathTheory/MathSoloVisualizer.jsx src/components/SearchBar.jsx`
- `npm.cmd test`
- `npm.cmd run build`
- Local smoke check: `/math-theory?algo=sieve` returned 200

Closes  #463 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new Math Theory algorithms: Euclidean GCD, Fast Exponentiation, Bit Manipulation, Sieve of Eratosthenes, and Fibonacci Sequence
  * Algorithm selection now persists in the browser URL, enabling easy sharing and bookmarking of specific visualizations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->