### PR TITLE
fix: clear stale path highlights when modifying grid after algorithm execution

### DIFF
--- a/src/components/shortestPathAlgo/GridVisualizer.jsx
+++ b/src/components/shortestPathAlgo/GridVisualizer.jsx
@@ -343,28 +343,30 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
       const node = prev[row][col]
       if (node.isStart || node.isEnd) return prev
 
+      const update = (n) => ({ ...n, visited: false, path: false })
+
       if (drawMode === 'wall') {
         return prev.map((r, y) =>
           r.map((n, x) =>
             y === row && x === col
-              ? { ...n, isWall: !n.isWall, isWeighted: false, weight: 1 }
-              : n
+              ? { ...update(n), isWall: !n.isWall, isWeighted: false, weight: 1 }
+              : update(n)
           )
         )
       } else if (drawMode === 'weight') {
         return prev.map((r, y) =>
           r.map((n, x) =>
             y === row && x === col
-              ? { ...n, isWall: false, isWeighted: true, weight: 5 }
-              : n
+              ? { ...update(n), isWall: false, isWeighted: true, weight: 5 }
+              : update(n)
           )
         )
       } else if (drawMode === 'erase') {
         return prev.map((r, y) =>
           r.map((n, x) =>
             y === row && x === col
-              ? { ...n, isWall: false, isWeighted: false, weight: 1 }
-              : n
+              ? { ...update(n), isWall: false, isWeighted: false, weight: 1 }
+              : update(n)
           )
         )
       }


### PR DESCRIPTION
### Description
After running a shortest path algorithm on the grid, modifying walls or weights leaves stale visited and path highlights on cells that are no longer relevant. This fix clears all stale highlights whenever the user edits the grid (draws walls, adds weights, or erases), ensuring the visual state accurately reflects the current grid topology.

### Related Issue
Fixes #448

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

program: gssoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Grid editing (adding walls, changing weights, erasing) now clears prior pathfinding visualization (visited nodes and paths) across the grid during interaction, preventing stale visualization state and ensuring subsequent runs show accurate, uncluttered results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->