### PR TITLE
fix: Sieve of Eratosthenes visualizer crashes on decimal inputs

### DIFF
--- a/src/components/MathTheory/MathSoloVisualizer.jsx
+++ b/src/components/MathTheory/MathSoloVisualizer.jsx
@@ -130,7 +130,7 @@ export const MathSoloVisualizer = () => {
         autoPlay: !isStepMode,
       })
     } else if (algo === 'sieve') {
-      loadSteps(generateSieveSteps(Number(sieveLimit)), {
+      loadSteps(generateSieveSteps(Math.floor(Number(sieveLimit))), {
         autoPlay: !isStepMode,
       })
     } else if (algo === 'fibonacci') {
@@ -372,10 +372,11 @@ export const MathSoloVisualizer = () => {
                   type="number"
                   min={10}
                   max={100}
+                  step={1}
                   value={sieveLimit}
                   onChange={(e) =>
                     setSieveLimit(
-                      Math.min(100, Math.max(10, Number(e.target.value)))
+                      Math.min(100, Math.max(10, Math.floor(Number(e.target.value))))
                     )
                   }
                   className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-2.5 text-white outline-none focus:border-cyan-500 text-sm"


### PR DESCRIPTION
Closes #426

**Root cause**: Number(sieveLimit) preserves decimals passed to new Array(n+1). JavaScript array lengths must be integers, causing RangeError.

**Fix**: Added Math.floor() around the Number conversion and step={1} attribute to the input element to discourage decimal entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sieve visualization now enforces integer limits and input stepping, preventing fractional or out-of-range values from affecting the algorithm. This improves accuracy, prevents unexpected behavior when adjusting the sieve limit, and yields more reliable, stable visualization results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->