### PR TITLE
Fix: Stale path highlights persist when modifying grid after algorithm execution

### DIFF
--- a/src/components/shortestPathAlgo/GridVisualizer.jsx
+++ b/src/components/shortestPathAlgo/GridVisualizer.jsx
@@ -339,6 +339,7 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
 
   const handleMouseInteraction = (row, col) => {
     if (running) return
+    clearPath()
     setGrid((prev) => {
       const node = prev[row][col]
       if (node.isStart || node.isEnd) return prev


### PR DESCRIPTION
Closes #448

**Root cause**: `handleMouseInteraction` in `GridVisualizer.jsx` modified grid cells (adding walls/weights/erasing) without clearing previous path and visited highlights, so stale visualization artifacts persisted.

**Fix**: Added a `clearPath()` call at the start of `handleMouseInteraction`, before any grid modification. This ensures visited/path flags are reset whenever the user draws on the grid after an algorithm run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where previously drawn path visualization states would persist on the grid when users initiated new drawing or dragging operations. Path visualization now properly clears before applying new grid edits, ensuring a cleaner interaction experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->