### PR TITLE
Fix: Hero section meta items lack visual separators and wrap awkwardly

### DIFF
--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -110,11 +110,14 @@ export function Hero() {
 
             <motion.div
               variants={item}
-              className="mt-7 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t theme-border pt-5 text-[10px] theme-text-muted sm:mt-8 sm:justify-start sm:gap-x-5 sm:pt-6 sm:text-[11px]"
+              className="mt-7 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 border-t theme-border pt-5 text-[10px] theme-text-muted sm:mt-8 sm:justify-start sm:gap-x-2 sm:pt-6 sm:text-[11px] md:flex-nowrap"
             >
               <Meta n="9+" t="visualizers" />
+              <span aria-hidden="true" className="theme-text-muted">·</span>
               <span>Runs in browser</span>
+              <span aria-hidden="true" className="theme-text-muted">·</span>
               <span>Open source</span>
+              <span aria-hidden="true" className="theme-text-muted">·</span>
               <span>Free to use</span>
             </motion.div>
           </motion.div>


### PR DESCRIPTION
Closes #475

**Root cause**: The meta items below CTA buttons had no visual separator between them. Combined with flex-wrap and large gap-x-4, "Free to use" wrapped to a second line awkwardly.

**Fix**: 
- Added dot separators with aria-hidden between each item
- Reduced gap-x-4 to gap-x-2 to minimize unnecessary whitespace  
- Added md:flex-nowrap so items stay on one line on tablet and above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced spacing in the hero/footer metadata row for a tighter layout.
  * Inserted middle-dot visual separators between metadata items; separators are non-announced to avoid interfering with assistive technologies.
  * Tweaked responsive gap values for more consistent appearance across screen sizes, improving readability and visual clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->