### PR TITLE
fix: replace execSync with execFileSync in append-file-tree.cjs for shell injection safety

### DIFF
--- a/scripts/append-file-tree.cjs
+++ b/scripts/append-file-tree.cjs
@@ -1,13 +1,13 @@
 // scripts/append-file-tree.js
 const fs = require('fs')
 const path = require('path')
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const semver = require('semver') // install this: npm install semver
 
 // ----------------------- helpers -----------------------
 function getAllTagsSortedByVersionDesc() {
   try {
-    const raw = execSync('git tag', { encoding: 'utf8' }).trim()
+    const raw = execFileSync('git', ['tag'], { encoding: 'utf8' }).trim()
     if (!raw) return []
     const tags = raw.split('\n').filter((t) => {
       const v = t.replace(/^v/, '')
@@ -27,7 +27,7 @@ function getChangedFilesTree(fromTag, toTag) {
   let changedFiles = []
   try {
     if (fromTag) {
-      const diff = execSync(`git diff --name-status ${fromTag} ${toTag}`, {
+      const diff = execFileSync('git', ['diff', '--name-status', fromTag, toTag], {
         encoding: 'utf8',
       })
       changedFiles = diff
@@ -38,7 +38,7 @@ function getChangedFilesTree(fromTag, toTag) {
           return { status, file: rest.join('\t') }
         })
     } else {
-      const all = execSync(`git ls-tree -r ${toTag} --name-only`, {
+      const all = execFileSync('git', ['ls-tree', '-r', toTag, '--name-only'], {
         encoding: 'utf8',
       })
         .split('\n')
@@ -125,8 +125,8 @@ function extractManualEntries(changelogContent) {
 function generateAutoSection(tag, previousTag) {
   let gitLog = ''
   try {
-    const range = previousTag ? `${previousTag}..${tag}` : tag
-    gitLog = execSync(`git log --pretty=format:"%s" ${range}`, {
+    const rangeArg = previousTag ? `${previousTag}..${tag}` : tag
+    gitLog = execFileSync('git', ['log', '--pretty=format:%s', rangeArg], {
       encoding: 'utf8',
     }).trim()
   } catch {
@@ -195,7 +195,7 @@ for (let i = 0; i < allTags.length; i++) {
   // get commit date for this tag
   let date
   try {
-    date = execSync(`git log -1 --format=%as ${tag}`, {
+    date = execFileSync('git', ['log', '-1', '--format=%as', tag], {
       encoding: 'utf8',
     }).trim()
   } catch {


### PR DESCRIPTION
## Description

Refactored \scripts/append-file-tree.cjs\ to use \child_process.execFileSync\ instead of \execSync\ for all git commands. This eliminates shell injection vectors and shell-syntax breakage when tag/branch names contain special characters or spaces.

## Changes

- Replaced \const { execSync } = require('child_process')\ with \const { execFileSync } = require('child_process')\
- Converted all 5 shell-constructed git commands to array-argument form using \execFileSync('git', [...args])\:
  - \git tag\ → \execFileSync('git', ['tag'])\
  - \git diff --name-status\ → \execFileSync('git', ['diff', '--name-status', ...])\
  - \git ls-tree -r\ → \execFileSync('git', ['ls-tree', '-r', ...])\
  - \git log --pretty=format:%s\ → \execFileSync('git', ['log', '--pretty=format:%s', ...])\
  - \git log -1 --format=%as\ → \execFileSync('git', ['log', '-1', '--format=%as', ...])\

## Related Issue

Fixes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script command execution to use improved git command handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->