### PR TITLE
fix: show auth config notice on Sign In button when Clerk key is missing

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -323,15 +323,17 @@ export const Navbar = () => {
                   </SignedIn>
                 </>
               ) : (
-                <>
+                <div className="relative group">
                   <button
-                    title="Auth not configured"
                     disabled
-                    className="theme-button-primary relative group overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 text-slate-700 dark:text-slate-200 px-6 py-2 text-sm font-bold transition-all duration-300 shadow-md opacity-50 cursor-not-allowed"
+                    className="theme-button-primary rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 text-slate-500 dark:text-slate-500 px-6 py-2 text-sm font-bold opacity-50 cursor-not-allowed"
                   >
                     Sign In
                   </button>
-                </>
+                  <div className="absolute right-0 top-full mt-2 w-64 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+                    Authentication not configured. Set <code className="font-mono text-amber-800 dark:text-amber-200">VITE_CLERK_PUBLISHABLE_KEY</code> in your <code className="font-mono text-amber-800 dark:text-amber-200">.env</code> file.
+                  </div>
+                </div>
               )}
             </div>
           </div>
@@ -454,13 +456,17 @@ export const Navbar = () => {
                     </SignInButton>
                   </SignedOut>
                 ) : (
-                  <button
-                    title="Auth not configured"
-                    disabled
-                    className="w-full rounded-xl bg-slate-100 dark:bg-slate-900 px-4 py-2.5 text-sm font-semibold text-slate-500 border border-slate-200 dark:border-slate-800 transition-all duration-300 opacity-50 cursor-not-allowed"
-                  >
-                    Sign In
-                  </button>
+                  <div className="relative group w-full">
+                    <button
+                      disabled
+                      className="w-full rounded-xl bg-slate-100 dark:bg-slate-900 px-4 py-2.5 text-sm font-semibold text-slate-400 border border-slate-200 dark:border-slate-800 opacity-50 cursor-not-allowed"
+                    >
+                      Sign In
+                    </button>
+                    <div className="absolute left-0 bottom-full mb-2 w-full rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+                      Auth not configured. Set VITE_CLERK_PUBLISHABLE_KEY in .env
+                    </div>
+                  </div>
                 )}
 
                 <a


### PR DESCRIPTION
## Description

When VITE_CLERK_PUBLISHABLE_KEY is not configured, the Sign In button now shows a hover-visible warning tooltip with a clear message.

## Related Issue

Fixes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Sign In button with a helpful hover tooltip that displays when authentication is not configured. This tooltip provides users with clear setup instructions and configuration guidance, featuring improved visual styling and better formatting. The enhancement ensures consistent, helpful information is displayed across all device types and screen layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->