### PR TITLE
fix: reset mouse drag state on window mouseup to prevent stuck drawing outside grid

### DIFF
--- a/src/components/shortestPathAlgo/GridVisualizer.jsx
+++ b/src/components/shortestPathAlgo/GridVisualizer.jsx
@@ -303,6 +303,12 @@ const GridVisualizer = ({ algorithm, runKey, speed }) => {
     gridRef.current = grid
   }, [grid])
 
+  useEffect(() => {
+    const handleWindowMouseUp = () => setMousePressed(false)
+    window.addEventListener('mouseup', handleWindowMouseUp)
+    return () => window.removeEventListener('mouseup', handleWindowMouseUp)
+  }, [])
+
   const clearTimers = useCallback(() => {
     timeouts.current.forEach((timer) => clearTimeout(timer))
     timeouts.current = []


### PR DESCRIPTION
## Description

When drawing walls/weights on the grid, releasing the mouse button outside the grid container or browser window left \mousePressed\ stuck as \	rue\. Moving back over the grid would continue drawing unintentionally.

## Fix

Added a \useEffect\ that listens for \mouseup\ on \window\. This ensures the drag state is always reset regardless of where the mouse button is released (inside the grid, outside the container, or outside the browser window).

The cleanup function removes the listener on unmount to prevent memory leaks.

## Related Issue

Fixes #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the grid visualization to stop drawing when the mouse button is released outside the grid area, preventing unintended shapes from being created during extended drag operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->