### PR TITLE
fix: prevent Practice page auth bypass via back button using ProtectedRoute with useAuth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react'
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom'
-import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/clerk-react'
+import { useAuth } from '@clerk/clerk-react'
 // import DPVisualizer from "./components/dynamicProgramming/DPVisualizer";
 
 const HAS_CLERK = Boolean(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY)
@@ -68,6 +68,13 @@ const PageLoader = () => (
   </div>
 )
 
+const ProtectedRoute = ({ children }) => {
+  const { isLoaded, isSignedIn } = useAuth()
+  if (!isLoaded) return <PageLoader />
+  if (!isSignedIn) return <Navigate to="/" replace />
+  return children
+}
+
 function App() {
   const route = createBrowserRouter([
     {
@@ -116,19 +123,12 @@ function App() {
         <Suspense fallback={<PageLoader />}>
           <AppLayout>
             {HAS_CLERK ? (
-              <>
-                <SignedIn>
-                  <PracticePage />
-                </SignedIn>
-                <SignedOut>
-                  <RedirectToSignIn />
-                </SignedOut>
-              </>
+              <ProtectedRoute>
+                <PracticePage />
+              </ProtectedRoute>
             ) : import.meta.env.DEV ? (
-              // Allow access to PracticePage only in development when Clerk is not configured
               <PracticePage />
             ) : (
-              // In non-dev environments without Clerk, redirect to home (or show unauthorized)
               <Navigate to="/" replace />
             )}
           </AppLayout>


### PR DESCRIPTION
## Description

The Practice page was briefly accessible to unauthenticated users before Clerk redirect kicked in, causing a browser history entry that allowed back-button bypass.

## Fix

Replaced SignedIn/SignedOut/RedirectToSignIn with a ProtectedRoute component using Clerk's useAuth() hook:

1. Waits for isLoaded===true (shows PageLoader during Clerk init)
2. If not signed in, immediately redirects to home via Navigate
3. Only renders PracticePage when authenticated

## Related Issue

Fixes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced route protection to require authentication for accessing restricted areas of the app. Unauthenticated users are now properly redirected to ensure secure access control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->