### PR TITLE
fix: integrate useKeyboardShortcuts into Sorting, ShortestPath, and Backtracking visualizers

### DIFF
--- a/src/components/backtrackingAlgo/VisualizerPage.jsx
+++ b/src/components/backtrackingAlgo/VisualizerPage.jsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 import ComplexityCard from '../ComplexityCard'
 import CodePanel from '../visualizer/CodePanel'
 import { CanvasNQueens } from './CanvasNQueens'
@@ -145,6 +146,13 @@ function SoloMode() {
 
   const handleVisualize = () => setTrigger((t) => t + 1)
   const handleReset = () => setTrigger(0)
+
+  useKeyboardShortcuts({
+    onPlayPause: handleVisualize,
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
 
   const handleAlgoChange = (a) => {
     setAlgo(a)

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -8,6 +8,7 @@ import { MenuSetAlgoShortestPath } from './MenuSetAlgoShortestPath'
 import { motion } from 'framer-motion'
 import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 import { shortestPathSources } from '../../algorithms/searching/shortestPathSources'
 import ComplexityCard from '../ComplexityCard'
 import ComparisonMode from './ComparisonMode'
@@ -77,6 +78,13 @@ export const ShortestPathPage = () => {
     setTarget(null)
     setRunKey(null)
   }
+
+  useKeyboardShortcuts({
+    onPlayPause: handleRun,
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
 
   const canRun =
     viewMode === 'grid'

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import TestCaseManager from '../testCaseManager/TestCaseManager'
@@ -185,6 +186,22 @@ export default function Visualizer() {
     stepForward,
     stepBackward,
   } = useStepPlayback({ speed })
+
+  useKeyboardShortcuts({
+    onPlayPause: () => {
+      if (isPlaying) pausePlayback()
+      else if (hasSteps && !isComplete) playPlayback()
+    },
+    onStepForward: () => {
+      if (!isPlaying && !isComplete && hasSteps) stepForward()
+    },
+    onStepBackward: () => {
+      if (!isPlaying && currentStepIndex > 0) stepBackward()
+    },
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
 
   const algorithmOptions = {
     simple: ['bubble', 'selection', 'insertion'],


### PR DESCRIPTION
## Description

Integrates useKeyboardShortcuts into the three remaining core visualizer pages that were missing keyboard control support.

## Changes

### Sorting Visualizer (sortingAlgo/Visualizer.jsx)
- Added useKeyboardShortcuts hook, following the same pattern as ArraySearch Visualizer
- Space toggles Play/Pause, Arrow keys step through visualization, R resets, +/- adjust speed

### Shortest Path Page (shortestPathAlgo/ShortestPathPage.jsx)
- Added useKeyboardShortcuts hook with play/pause triggering handleRun, R resetting state, +/- for speed
- No step forward/backward (component uses trigger-based execution via unKey)

### Backtracking Visualizer (acktrackingAlgo/VisualizerPage.jsx)
- Added useKeyboardShortcuts hook inside SoloMode with play/pause triggering handleVisualize, R resetting trigger, +/- for speed
- No step forward/backward (component uses trigger-based execution)

## Related Issue

Fixes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut controls to visualizations: play/pause, reset, and speed adjustment (±0.25 increments, clamped between 0.25–3.0) across multiple algorithm visualizers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->