### PR TITLE
fix: filter test case seeding check to current algorithm instead of global db emptiness

### DIFF
--- a/src/components/testCaseManager/TestCaseManager.jsx
+++ b/src/components/testCaseManager/TestCaseManager.jsx
@@ -39,10 +39,13 @@ export default function TestCaseManager({
 
   const load = useCallback(async () => {
     const data = await fetchCases()
+    const currentAlgoCases = algorithm
+      ? data.filter((tc) => tc.algorithm === algorithm)
+      : data
 
     if (
       !search &&
-      data.length === 0 &&
+      currentAlgoCases.length === 0 &&
       sampleCases.length > 0 &&
       !hasSeededSamples.current
     ) {


### PR DESCRIPTION
## Description

The TestCaseManager's auto-seeding logic checked data.length === 0 on the globally returned test case array. Once any algorithm seeded its cases, the IndexedDB was no longer empty, preventing all subsequent algorithms from ever seeding their own sample cases.

## Fix

Changed the check from data.length === 0 to currentAlgoCases.length === 0, filtering the fetched cases to only those belonging to the current algorithm before deciding whether to seed. If no lgorithm is provided, it falls back to the global check.

## Related Issue

Fixes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test case initialization logic to correctly identify and load sample test cases when filtering is applied, ensuring the appropriate cases are available for your current selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->