### PR TITLE
fix: add tooltip and clearer terminal text for non-JS languages in Practice Sandbox

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -155,6 +155,7 @@ const CodeEditor = ({
           <button
             onClick={() => isJavaScript && onRun && onRun(value)}
             disabled={!isJavaScript || isRunning || isDisabled}
+            title={!isJavaScript ? 'Code execution is currently only supported for JavaScript' : ''}
             className={`px-6 py-2 text-sm font-bold text-white transition-all duration-300 rounded-xl active:scale-95 transform hover:-translate-y-0.5 ${
               isJavaScript && !isRunning && !isDisabled
                 ? 'bg-cyan-600 hover:bg-cyan-500 hover:shadow-[0_0_15px_rgba(6,182,212,0.4)]'

--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -49,8 +49,8 @@ const Terminal = React.forwardRef(function Terminal({ logs, onClear }, ref) {
       >
         {logs.length === 0 ? (
           <p className="text-slate-600 italic text-xs">
-            No output yet. Click &quot;Run Code&quot; to execute your
-            JavaScript.
+            No output yet. Select JavaScript and click &quot;Run Code&quot; to execute
+            (Python, Java, C++ execution coming soon).
           </p>
         ) : (
           logs.map((log, i) => (


### PR DESCRIPTION
## Description

The CodeEditor component already disabled the Run Code button for non-JavaScript languages (showing 'Coming Soon' text). However, it was missing a tooltip explaining why the button is disabled, and the terminal placeholder text assumed JavaScript only.

## Changes

- Added a 	itle attribute to the Run Code button when a non-JS language is selected, explaining that execution is currently only supported for JavaScript
- Updated the terminal placeholder text in PracticePage to clarify that Python, Java, and C++ execution is coming soon

## Related Issue

Fixes #477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run button now displays a tooltip indicating execution limitations when using non-JavaScript languages.
  * Terminal console empty state now provides clearer guidance to select JavaScript and run code, with a note about upcoming Python, Java, and C++ support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->