### PR TITLE
fix: add Dynamic Programming and Backtracking submodules to SearchBar, Navbar Explore, and Home

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -77,7 +77,6 @@ const ALGORITHMS = [
     title: 'Dynamic Programming',
     description:
       'LCS, 0/1 Knapsack, Coin Change, and LIS — watch the DP table fill step by step.',
-    path: '/dynamic-programming', // or "to" depending on your card schema
     color: 'theme-card border-rose-500/30 hover:border-rose-400',
     link: '/dynamic-programming',
   },

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -102,6 +102,7 @@ const algorithmLinks = [
   { name: 'Array Search', href: '/ldssearch' },
   { name: "Kadane's Algorithm", href: '/kadane' },
   { name: "Moore's Voting Algorithm", href: '/moore-voting' },
+  { name: 'Dynamic Programming', href: '/dynamic-programming' },
   { name: 'Math Theory', href: '/math-theory' },
   { name: 'String Algorithms', href: '/string-algorithms' },
   { name: 'Backtracking', href: '/backtracking' },

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -188,6 +188,15 @@ const ALGORITHMS = [
     category: 'General',
     route: '/about',
   },
+  // Dynamic Programming
+  {
+    id: 'dp',
+    name: 'Dynamic Programming',
+    category: 'Dynamic Programming',
+    route: '/dynamic-programming',
+    keywords: ['dp', 'dynamic programming', 'lcs', 'knapsack', 'coin change', 'lis'],
+  },
+
   // Backtracking
   {
     id: 'nqueens',
@@ -202,6 +211,20 @@ const ALGORITHMS = [
       'recursion',
       'constraint',
     ],
+  },
+  {
+    id: 'sudoku',
+    name: 'Sudoku Solver',
+    category: 'Backtracking',
+    route: '/backtracking?algo=sudoku',
+    keywords: ['sudoku', 'backtracking', 'puzzle', 'constraint satisfaction'],
+  },
+  {
+    id: 'hanoi',
+    name: 'Tower of Hanoi',
+    category: 'Backtracking',
+    route: '/backtracking?algo=hanoi',
+    keywords: ['hanoi', 'tower of hanoi', 'recursion', 'backtracking'],
   },
 
   // Math Theory


### PR DESCRIPTION
## Description

The SearchBar, Navbar Explore dropdown, and Home page were missing several algorithm entries.

## Changes

### SearchBar (SearchBar.jsx)
- Added **Dynamic Programming** visualizer entry (route: /dynamic-programming) with relevant keywords
- Added **Sudoku Solver** backtracking submodule entry
- Added **Tower of Hanoi** backtracking submodule entry

### Navbar Explore (Navbar.jsx)
- Added **Dynamic Programming** link to the explore dropdown

### Home (Home.jsx)
- Removed extraneous unused path property from the Dynamic Programming card entry

## Related Issue

Fixes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dynamic Programming to the navigation menu for easy access
  * Expanded search functionality to include Dynamic Programming and Backtracking algorithms (Sudoku, Tower of Hanoi)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->