### PR TITLE
fix: resolve unreachable path bug when source and target are the same…

### DIFF
--- a/src/components/shortestPathAlgo/CanvasShortestPath.jsx
+++ b/src/components/shortestPathAlgo/CanvasShortestPath.jsx
@@ -291,6 +291,17 @@ export const CanvasShortestPath = ({
       const pathNodes = []
       const pathEdges = []
       let cur = dst
+
+      if (src === dst) {
+        setStatus(`Source and Target are the same node (${src}). Distance is 0.`)
+        nodes.update({
+          id: src,
+          color: { background: '#10b981', border: '#ffffff' },
+          size: 28,
+        })
+        return
+      }
+
       if (parent[cur] == null) {
         setStatus(`Node ${dst} is not reachable from ${src}.`)
         return


### PR DESCRIPTION
Fixes #496

### Changes Made

• Added an early return check in  `reconstructAndAnimatePath`  ( `CanvasShortestPath.jsx` ) to properly handle the edge case where  `source === target` .
• The visualizer now correctly highlights the single node in green and reports a distance of  `0` , resolving the bug where it was falsely marked as unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shortest path algorithm behavior when source and destination are the same node. Now displays a clear status message and provides visual feedback instead of attempting unnecessary path reconstruction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/algoscope-hq/AlgoScope/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->