### PR TITLE
fix: Navbar Practice and Challenge links now highlight on active rout

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -242,7 +242,11 @@ export const Navbar = () => {
               >
                 <Link
                   to="/practice"
-                  className="relative text-sm font-medium text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-4 py-1.5 rounded-lg transition-all duration-300 z-10"
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                    pathname === '/practice'
+                      ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
+                      : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
+                  }`}
                 >
                   Practice
                 </Link>
@@ -265,7 +269,11 @@ export const Navbar = () => {
               >
                 <Link
                   to="/challenge"
-                  className="relative text-sm font-medium text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-4 py-1.5 rounded-lg transition-all duration-300 z-10"
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                    pathname === '/challenge'
+                      ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
+                      : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
+                  }`}
                 >
                   Challenge
                 </Link>


### PR DESCRIPTION
### What changed?

Modified the top-level desktop "Practice" and "Challenge" links in `src/components/Navbar.jsx` to conditionally apply active styling (`text-indigo-600 dark:text-indigo-300 font-semibold`) when `pathname` matches the route, matching the pattern already used in the dropdown and mobile drawer.

### Why is this needed?

When navigating to `/practice` or `/challenge`, the top-level navbar links remained styled with idle link colors (`text-slate-400`), providing no visual feedback about the current location.

Closes #433

## Type of Change

- [x] `fix` - Bug fix or regression fix

## Release Notes

- [x] Fixed

- Navbar Practice and Challenge links now highlight with indigo text when on their active routes

## Testing and Verification

- [ ] `npm ci` or `npm install`
- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [ ] Responsive testing for affected views
- [ ] No new console errors or warnings

Skipped or additional testing notes:

npm install timed out locally, so lint/build could not be run. Only `src/components/Navbar.jsx` was modified (10 insertions, 2 deletions) — no dependencies changed.

## UI Evidence

**Before:** Practice and Challenge links stay grey (`text-slate-400`) when on `/practice` or `/challenge`.

**After:** Active link shows `text-indigo-600 dark:text-indigo-300 font-semibold`, matching the dropdown active style.

## CI/CD and Deployment Impact

- [x] No deployment impact expected

## Reviewer Checklist

- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [x] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation links for Practice and Challenge now show active styling when viewing those sections, providing clearer visual feedback about your current location in the app and reducing confusion when switching between routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->