### PR TITLE
fix: filter test case seeding check to current algorithm instead of global db emptiness

### DIFF
--- a/src/components/testCaseManager/TestCaseManager.jsx
+++ b/src/components/testCaseManager/TestCaseManager.jsx
@@ -39,10 +39,11 @@ export default function TestCaseManager({
 
   const load = useCallback(async () => {
     const data = await fetchCases()
+    const currentAlgoCases = data.filter((tc) => tc.algorithm === algorithm)
 
     if (
       !search &&
-      data.length === 0 &&
+      currentAlgoCases.length === 0 &&
       sampleCases.length > 0 &&
       !hasSeededSamples.current
     ) {
@@ -56,7 +57,7 @@ export default function TestCaseManager({
     }
 
     setTestCases(data)
-  }, [fetchCases, sampleCases, search])
+  }, [fetchCases, sampleCases, search, algorithm])
 
   useEffect(() => {
     if (!isOpen) return


### PR DESCRIPTION
Closes #478

## Bug Description
Currently, `TestCaseManager` is designed to auto-seed sample test cases (e.g., `Nearly Sorted Array` for sorting) when a user first visits a visualizer page. However, because the IndexedDB store is globally shared across all algorithms and defaults to showing all test cases (`activeTab === 'all'`), the auto-seeding logic fails for all subsequent algorithms if a user has already seeded/saved test cases for any other algorithm.

## Technical Root Cause
Inside `TestCaseManager.jsx`, the conditional check in the `load` callback checks `data.length === 0` to decide whether it should seed the current algorithm's sample cases:

```javascript
if (
  !search &&
  data.length === 0 && // <- Evaluates to false if ANY other algorithm has seeded cases
  sampleCases.length > 0 &&
  !hasSeededSamples.current
) { ... }
```

If any algorithm has already seeded or saved test cases into the database, `data.length` is greater than `0`, preventing subsequent visualizer pages from ever triggering their own seeding logic.

## Solution
Modified the check inside the `load` callback to filter the fetched test cases specifically for the current `algorithm` before determining if the database is empty:

```javascript
const currentAlgoCases = data.filter((tc) => tc.algorithm === algorithm)

if (
  !search &&
  currentAlgoCases.length === 0 && // <- Check if test cases for the CURRENT algorithm are empty
  sampleCases.length > 0 &&
  !hasSeededSamples.current
) { ... }
```

Additionally, `algorithm` was added to the `useCallback` dependency array of `load` to ensure it updates correctly when navigating between different visualizer pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of test case loading when switching between algorithms. The application now better distinguishes between cases where the current algorithm has no test cases versus when test cases haven't been loaded at all, ensuring sample cases load appropriately based on your current algorithm selection and search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->