### PR TITLE
fix: remove duplicate Target dropdown and use dynamic nodeIds for Source

### DIFF
--- a/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
+++ b/src/components/shortestPathAlgo/MenuSelectNodesShortestPath.jsx
@@ -36,8 +36,6 @@ export const MenuSelectNodesShortestPath = ({
   algorithm,
   nodeIds = [],
 }) => {
-  const nodeOptions = Array.from({ length: 9 }, (_, i) => i + 1)
-
   if (algorithm === 'kruskal') {
     return (
       <div className="space-y-4">
@@ -76,7 +74,7 @@ export const MenuSelectNodesShortestPath = ({
               <option value="">
                 {algorithm === 'prim' ? 'Choose Start Node' : 'Choose Source'}
               </option>
-              {nodeOptions.map((n) => (
+              {nodeIds.map((n) => (
                 <option key={n} value={n}>
                   {n}
                 </option>
@@ -93,12 +91,13 @@ export const MenuSelectNodesShortestPath = ({
               className="w-full"
             >
               <select
+                id="sp-target-select"
                 value={target ?? ''}
                 onChange={(e) => setTarget(e.target.value || null)}
                 className="w-full bg-slate-800 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm appearance-none cursor-pointer"
               >
                 <option value="">Choose Target</option>
-                {nodeOptions.map((n) => (
+                {nodeIds.map((n) => (
                   <option key={n} value={n}>
                     {n}
                   </option>
@@ -108,29 +107,6 @@ export const MenuSelectNodesShortestPath = ({
             <ChevronIcon />
           </div>
         )}
-
-        <div className="relative">
-          <Tooltip
-            content="Choose the target node"
-            position="top"
-            className="w-full"
-          >
-            <select
-              id="sp-target-select"
-              value={target ?? ''}
-              onChange={(e) => setTarget(e.target.value || null)}
-              className="w-full bg-slate-800 text-white text-sm border border-slate-700 rounded-xl pl-4 pr-10 py-3 transition duration-300 focus:outline-none focus:border-cyan-500 hover:border-slate-500 shadow-sm appearance-none cursor-pointer"
-            >
-              <option value="">Choose Target</option>
-              {nodeIds.map((n) => (
-                <option key={n} value={n}>
-                  {n}
-                </option>
-              ))}
-            </select>
-          </Tooltip>
-          <ChevronIcon />
-        </div>
       </div>
 
       {nodeIds.length === 0 && (


### PR DESCRIPTION
## Summary

Removes a duplicate Target dropdown in the Shortest Path controls and updates the Source dropdown to use dynamic node IDs from the canvas.

### Changes
- **Removed** the first Target dropdown (hardcoded \
odeOptions\ 1-9, was redundant)
- **Kept** only the dynamic Target dropdown (uses \
odeIds\ from canvas), properly wrapped in \lgorithm !== 'prim'\ check
- **Updated** Source dropdown to use \
odeIds\ instead of hardcoded \
odeOptions\ — users can now select dynamically created nodes
- **Removed** unused \
odeOptions\ constant

### Before
- Two identical Target dropdowns stacked (one hardcoded, one dynamic)
- Source dropdown limited to nodes 1-9 even if more were added

### After
- Single Target dropdown, properly conditionally rendered
- Source dropdown reflects all nodes on the canvas

Closes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Node selection dropdowns in shortest path algorithms now correctly display all nodes currently on the canvas, replacing the previously fixed list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->