### PR TITLE
fix: add tooltip and clearer terminal text for non-JS languages in Pr…

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -155,6 +155,11 @@ const CodeEditor = ({
           <button
             onClick={() => isJavaScript && onRun && onRun(value)}
             disabled={!isJavaScript || isRunning || isDisabled}
+            title={
+              !isJavaScript
+                ? 'Code execution is currently only supported for JavaScript'
+                : ''
+            }
             className={`px-6 py-2 text-sm font-bold text-white transition-all duration-300 rounded-xl active:scale-95 transform hover:-translate-y-0.5 ${
               isJavaScript && !isRunning && !isDisabled
                 ? 'bg-cyan-600 hover:bg-cyan-500 hover:shadow-[0_0_15px_rgba(6,182,212,0.4)]'

--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -49,8 +49,8 @@ const Terminal = React.forwardRef(function Terminal({ logs, onClear }, ref) {
       >
         {logs.length === 0 ? (
           <p className="text-slate-600 italic text-xs">
-            No output yet. Click &quot;Run Code&quot; to execute your
-            JavaScript.
+            No output yet. Select JavaScript and click &quot;Run Code&quot; to
+            execute (Python, Java, C++ execution coming soon).
           </p>
         ) : (
           logs.map((log, i) => (


### PR DESCRIPTION
Closes #477

### Description of Changes
This PR improves the user experience in the Practice Sandbox when non-JavaScript languages (Python, Java, C++) are selected. It provides clear, actionable feedback to prevent any confusion about unsupported language execution.

1. **Run Button Tooltip (`src/components/CodeEditor.jsx`)**
   - Added a native HTML `title` tooltip on the disabled Run button when a non-JS language is selected: *"Code execution is currently only supported for JavaScript"*.
   - Ensured the UI state correctly disables the button without throwing syntax errors.

2. **Terminal Console Placeholder Text (`src/components/PracticePage.jsx`)**
   - Updated the default terminal placeholder from a generic JS statement to a informative state: *"No output yet. Select JavaScript and click 'Run Code' to execute (Python, Java, C++ execution coming soon)."*

### Verification & Quality Checks
- Ran `npm run lint` which passed with **0 warnings/errors**.
- Ran `npm run format:check` to ensure the codebase remains formatted according to the project's Prettier standards.
- Double-checked that the component compiles and loads cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Run Code" button now displays contextual tooltips explaining JavaScript-only code execution support.
  * Terminal empty state provides clearer guidance for running code and announces upcoming language support (Python, Java, C++).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->