### PR TITLE
fix: integrate useKeyboardShortcuts into Sorting, Shortest Path, and Backtracking visualizers

### DIFF
--- a/src/components/backtrackingAlgo/VisualizerPage.jsx
+++ b/src/components/backtrackingAlgo/VisualizerPage.jsx
@@ -12,6 +12,8 @@ import { CanvasGraphColoring } from './CanvasGraphColoring'
 import { MenuSetAlgoBacktracking } from './MenuSetAlgoBacktracking'
 import { ComparisonMode } from './ComparisonMode'
 import { getBacktrackingSource } from '../../algorithms/backtracking/backtrackingSources'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
+
 
 export default function VisualizerPage() {
   useEffect(() => {
@@ -149,10 +151,18 @@ function SoloMode() {
   const handleVisualize = () => setTrigger((t) => t + 1)
   const handleReset = () => setTrigger(0)
 
+  useKeyboardShortcuts({
+    onPlayPause: handleVisualize,
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
+
   const handleAlgoChange = (a) => {
     setAlgo(a)
     setTrigger(0)
   }
+
 
   const currentSource = useMemo(
     () => getBacktrackingSource(algo, language),

--- a/src/components/backtrackingAlgo/VisualizerPage.jsx
+++ b/src/components/backtrackingAlgo/VisualizerPage.jsx
@@ -14,7 +14,6 @@ import { ComparisonMode } from './ComparisonMode'
 import { getBacktrackingSource } from '../../algorithms/backtracking/backtrackingSources'
 import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 
-
 export default function VisualizerPage() {
   useEffect(() => {
     document.title = 'Backtracking | AlgoScope'
@@ -162,7 +161,6 @@ function SoloMode() {
     setAlgo(a)
     setTrigger(0)
   }
-
 
   const currentSource = useMemo(
     () => getBacktrackingSource(algo, language),

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -11,6 +11,8 @@ import SpeedSlider from '../SpeedSlider'
 import { shortestPathSources } from '../../algorithms/searching/shortestPathSources'
 import ComplexityCard from '../ComplexityCard'
 import ComparisonMode from './ComparisonMode'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
+
 
 export const ShortestPathPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -86,6 +88,16 @@ export const ShortestPathPage = () => {
         : algorithm === 'prim'
           ? !!algorithm && !!source
           : !!algorithm && !!source && !!target
+
+  useKeyboardShortcuts({
+    onPlayPause: () => {
+      if (canRun) handleRun()
+    },
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
+
 
   const currentSource = useMemo(() => {
     if (!algorithm) return ''

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -13,7 +13,6 @@ import ComplexityCard from '../ComplexityCard'
 import ComparisonMode from './ComparisonMode'
 import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 
-
 export const ShortestPathPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -97,7 +96,6 @@ export const ShortestPathPage = () => {
     onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
     onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
   })
-
 
   const currentSource = useMemo(() => {
     if (!algorithm) return ''

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -7,6 +7,8 @@ import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import TestCaseManager from '../testCaseManager/TestCaseManager'
 import RecursiveTree from './RecursiveTree.jsx'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
+
 
 import * as bubble from '../../algorithms/sorting/bubbleSortSteps'
 import * as selection from '../../algorithms/sorting/selectionSortSteps'
@@ -212,6 +214,23 @@ export default function Visualizer() {
     setInputError('')
     setIsStepMode(false)
   }
+
+  useKeyboardShortcuts({
+    onPlayPause: () => {
+      if (isPlaying) pausePlayback()
+      else if (hasSteps && !isComplete) playPlayback()
+    },
+    onStepForward: () => {
+      if (!isPlaying && !isComplete && hasSteps) stepForward()
+    },
+    onStepBackward: () => {
+      if (!isPlaying && currentStepIndex > 0) stepBackward()
+    },
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
+
 
   const handleApplyCustomArray = () => {
     setInputError('')

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -9,7 +9,6 @@ import TestCaseManager from '../testCaseManager/TestCaseManager'
 import RecursiveTree from './RecursiveTree.jsx'
 import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 
-
 import * as bubble from '../../algorithms/sorting/bubbleSortSteps'
 import * as selection from '../../algorithms/sorting/selectionSortSteps'
 import * as insertion from '../../algorithms/sorting/insertionSortSteps'
@@ -230,7 +229,6 @@ export default function Visualizer() {
     onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
     onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
   })
-
 
   const handleApplyCustomArray = () => {
     setInputError('')


### PR DESCRIPTION
Fixes #479 

## Description

This PR integrates the custom `useKeyboardShortcuts` hook across all remaining core visualizers (**Sorting**, **Shortest Path**, and **Backtracking**). This ensures full keyboard-based accessibility consistency (Space for Play/Pause/Run, Arrow keys for manual stepping where applicable, `R` for reset, and speed tuning with `+`/`-`) across all major visualizer entry points on the platform.

### Proposed Changes

1. **Sorting Visualizer** (`src/components/sortingAlgo/Visualizer.jsx`)
   - Imported and instantiated `useKeyboardShortcuts` to capture keyboard triggers.
   - Standardized keys: `Space` for play/pause, `ArrowRight`/`ArrowLeft` for stepping when paused, `R` to reset the array, and `+`/`-` to increase/decrease animation speed.

2. **Shortest Path Visualizer** (`src/components/shortestPathAlgo/ShortestPathPage.jsx`)
   - Imported and instantiated `useKeyboardShortcuts`.
   - Mapped `Space` to run the search animation (if valid inputs are configured), `R` to reset, and `+`/`-` to alter visual playback speed.

3. **Backtracking Visualizer** (`src/components/backtrackingAlgo/VisualizerPage.jsx`)
   - Imported and instantiated `useKeyboardShortcuts` within the `SoloMode` component.
   - Linked `Space` to start the backtracking simulation, `R` to reset, and `+`/`-` to configure speed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts added across all algorithm visualizers for faster control.
  * Controls: play/pause, reset, speed adjustment (0.25x–3x), and step forward/backward where supported.
  * Shortcuts respect visualizer state (e.g., play only when runnable; stepping disabled while playing or when at sequence bounds) and work in solo/play modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->