### PR TITLE
fix(metadata): update repository and issue tracker URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: AlgoScope Discussions via GitHub Issues
-    url: https://github.com/Yuvraj-Sarathe/AlgoScope/issues
+    url: https://github.com/algoscope-hq/AlgoScope/issues
     about: Use issues for bugs, ideas, and project discussion.

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
   "main": "eslint.config.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Yuvraj-Sarathe/AlgoScope.git"
+    "url": "git+https://github.com/algoscope-hq/AlgoScope.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/Yuvraj-Sarathe/AlgoScope/issues"
+    "url": "https://github.com/algoscope-hq/AlgoScope/issues"
   },
-  "homepage": "https://github.com/Yuvraj-Sarathe/AlgoScope#readme"
+  "homepage": "https://github.com/algoscope-hq/AlgoScope#readme"
 }


### PR DESCRIPTION
### Related Issue
- Closes: #543 

---

### Description

Updated outdated repository metadata links to use the current official AlgoScope repository.

Previously, some project configuration files still referenced the old repository (`Yuvraj-Sarathe/AlgoScope`) while other project resources such as the README, Navbar, Footer, and contributor links correctly pointed to `algoscope-hq/AlgoScope`.

This inconsistency could redirect users to the wrong repository when reporting issues or viewing project metadata.

Changes made:
- Updated repository URLs in `package.json`
- Updated issue tracker URLs in `.github/ISSUE_TEMPLATE/config.yml`
- Replaced outdated `Yuvraj-Sarathe/AlgoScope` references
- Standardized all metadata to use:
  - `https://github.com/algoscope-hq/AlgoScope`
  - `https://github.com/algoscope-hq/AlgoScope/issues`
- Improved consistency across project configuration files

---

### How Has This Been Tested?

- Verified all updated URLs point to the official AlgoScope repository
- Checked issue template configuration links
- Checked repository metadata in `package.json`
- Confirmed no outdated repository references remain in the modified files
- Verified configuration files remain valid after the changes

---

### Screenshots (if applicable)

N/A

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URLs in project metadata and issue templates to reflect new repository organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->