### PR TITLE
fix: remove deprecated 'node' npm package from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "1.5.0",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
@@ -30,7 +33,6 @@
     "geist": "^1.5.1",
     "helmet": "^8.2.0",
     "lucide-react": "^1.16.0",
-    "node": "^24.16.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.1",


### PR DESCRIPTION
Fixes #552

Removed the deprecated \
ode\ npm package (\^24.16.0\) from \dependencies\ and added an \engines\ field to properly specify the Node.js runtime requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js runtime requirement to version 18.0.0 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->