### PR TITLE
feat: add AI assistant to practice mode

### DIFF
--- a/src/components/AIAssistantPanel.jsx
+++ b/src/components/AIAssistantPanel.jsx
@@ -1,0 +1,384 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useAIAssistant } from './useAIAssistant'
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+const SparkleIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M5 3l.5 2L7 5.5 5.5 6 5 8l-.5-2L3 5.5 4.5 5 5 3zm9 0l.5 2 1.5.5-1.5.5-.5 2-.5-2L12 5.5l1.5-.5L14 3zm-4 6l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
+  </svg>
+)
+
+const HintIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+  </svg>
+)
+
+const BookIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+  </svg>
+)
+
+const SendIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+  </svg>
+)
+
+const XIcon = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+)
+
+const ChevronIcon = ({ open }) => (
+  <svg className={`w-4 h-4 transition-transform ${open ? 'rotate-180' : ''}`}
+    fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+)
+
+const StopIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+    <rect x="6" y="6" width="12" height="12" rx="2" />
+  </svg>
+)
+
+// ─── Typing indicator ─────────────────────────────────────────────────────────
+
+const TypingIndicator = () => (
+  <div className="flex items-center gap-1 px-4 py-3">
+    {[0, 1, 2].map((i) => (
+      <motion.div key={i} className="w-1.5 h-1.5 rounded-full bg-cyan-400"
+        animate={{ y: [0, -4, 0] }}
+        transition={{ duration: 0.6, repeat: Infinity, delay: i * 0.15 }} />
+    ))}
+  </div>
+)
+
+// ─── Single message bubble ─────────────────────────────────────────────────────
+
+const MessageBubble = ({ message }) => {
+  const isUser = message.role === 'user'
+  return (
+    <motion.div
+      className={`flex gap-2 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      {/* Avatar */}
+      <div className={`w-6 h-6 rounded-full flex-shrink-0 flex items-center justify-center text-[10px] font-bold mt-0.5
+        ${isUser
+          ? 'bg-slate-700 text-slate-300'
+          : 'bg-gradient-to-br from-cyan-500 to-purple-600 text-white'}`}>
+        {isUser ? 'U' : 'AI'}
+      </div>
+
+      {/* Bubble */}
+      <div className={`max-w-[82%] rounded-2xl px-3 py-2.5 text-sm leading-relaxed
+        ${isUser
+          ? 'bg-slate-700/70 text-slate-200 rounded-tr-sm'
+          : message.isError
+            ? 'bg-red-950/60 border border-red-800/50 text-red-300 rounded-tl-sm'
+            : 'bg-slate-800/80 border border-slate-700/50 text-slate-200 rounded-tl-sm'}`}>
+        {message.content}
+        <div className={`text-[10px] mt-1.5 ${isUser ? 'text-slate-500 text-right' : 'text-slate-600'}`}>
+          {message.timestamp?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+// ─── Hint progress dots ────────────────────────────────────────────────────────
+
+const HintProgress = ({ level }) => (
+  <div className="flex items-center gap-1.5">
+    <span className="text-[10px] text-slate-500 font-mono uppercase tracking-wider">Hints</span>
+    {[1, 2, 3].map((n) => (
+      <div key={n} className={`w-2 h-2 rounded-full transition-all duration-300
+        ${n <= level
+          ? 'bg-cyan-400 shadow-[0_0_6px_rgba(6,182,212,0.7)]'
+          : 'bg-slate-700'}`} />
+    ))}
+  </div>
+)
+
+// ─── Quick action chips ────────────────────────────────────────────────────────
+
+const QuickChips = ({ onSend, disabled }) => {
+  const chips = [
+    'Why did my algorithm fail?',
+    'Explain time complexity here',
+    'What should I try next?',
+    'How does this data structure work?',
+  ]
+  return (
+    <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+      {chips.map((chip) => (
+        <button key={chip} onClick={() => onSend(chip)} disabled={disabled}
+          className="text-[10px] px-2.5 py-1 rounded-full border border-slate-700 text-slate-400
+            hover:border-cyan-500/50 hover:text-cyan-400 hover:bg-cyan-500/5 transition-all
+            disabled:opacity-40 disabled:cursor-not-allowed">
+          {chip}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ─── Main AIAssistantPanel ─────────────────────────────────────────────────────
+
+const AIAssistantPanel = ({ code = '', executionMode = 'single', language = 'javascript' }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const [showQuickChips, setShowQuickChips] = useState(true)
+  const messagesEndRef = useRef(null)
+  const inputRef = useRef(null)
+
+  const handleOpen = useCallback(() => setIsOpen(true), [])
+
+  const {
+    messages,
+    isLoading,
+    hintLevel,
+    requestHint,
+    explainAlgorithm,
+    sendMessage,
+    resetHints,
+    clearMessages,
+    cancelRequest,
+  } = useAIAssistant({ isOpen, onOpen: handleOpen })
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, isLoading])
+
+  // Focus input when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 200)
+    }
+  }, [isOpen])
+
+  const handleSend = (text) => {
+    const trimmed = (text || inputValue).trim()
+    if (!trimmed || isLoading) return
+    setShowQuickChips(false)
+    sendMessage(trimmed, code, executionMode, language)
+    setInputValue('')
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const handleHint = () => {
+    if (hintLevel >= 3 || isLoading) return
+    setShowQuickChips(false)
+    requestHint(code, executionMode, language)
+  }
+
+  const handleExplain = () => {
+    setShowQuickChips(false)
+    explainAlgorithm(null, code)
+  }
+
+  const handleClear = () => {
+    clearMessages()
+    resetHints()
+    setShowQuickChips(true)
+  }
+
+  // Determine algorithm name from code for context
+  const algoHint = code?.slice(0, 200)?.match(/function\s+(\w+)/)?.[1] || 'algorithm'
+
+  return (
+    <>
+      {/* ── Floating trigger button ── */}
+      <AnimatePresence>
+        {!isOpen && (
+          <motion.button
+            onClick={() => setIsOpen(true)}
+            className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-3 rounded-2xl
+              bg-gradient-to-r from-cyan-600 to-purple-600 text-white text-sm font-bold
+              shadow-[0_0_24px_rgba(6,182,212,0.4)] hover:shadow-[0_0_32px_rgba(6,182,212,0.6)]
+              hover:-translate-y-0.5 active:scale-95 transition-all"
+            initial={{ opacity: 0, scale: 0.8, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.8, y: 20 }}
+            title="AI Assistant (Ctrl+H)"
+          >
+            <SparkleIcon />
+            <span>AI Assistant</span>
+            <span className="text-[10px] opacity-60 font-mono">Ctrl+H</span>
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      {/* ── Slide-in panel ── */}
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            className="fixed bottom-0 right-0 z-50 flex flex-col
+              w-full sm:w-[420px] h-[600px] sm:h-[620px] sm:bottom-6 sm:right-6
+              bg-slate-950 border border-slate-700/60 sm:rounded-3xl
+              shadow-[0_0_60px_rgba(0,0,0,0.8)] overflow-hidden"
+            initial={{ opacity: 0, y: 40, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 40, scale: 0.95 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3.5
+              bg-slate-900/80 border-b border-slate-800 flex-shrink-0">
+              <div className="flex items-center gap-2.5">
+                <div className="w-7 h-7 rounded-xl bg-gradient-to-br from-cyan-500 to-purple-600
+                  flex items-center justify-center shadow-[0_0_12px_rgba(6,182,212,0.4)]">
+                  <SparkleIcon />
+                </div>
+                <div>
+                  <div className="text-sm font-bold text-white leading-none">AI Assistant</div>
+                  <div className="text-[10px] text-slate-500 mt-0.5 font-mono">AlgoScope Tutor</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <HintProgress level={hintLevel} />
+                {messages.length > 0 && (
+                  <button onClick={handleClear}
+                    className="text-[10px] text-slate-600 hover:text-slate-400 transition-colors px-1.5 py-1
+                      rounded-lg hover:bg-slate-800 font-mono uppercase tracking-wider">
+                    Clear
+                  </button>
+                )}
+                <button onClick={() => setIsOpen(false)}
+                  className="p-1.5 rounded-xl text-slate-500 hover:text-white hover:bg-slate-800 transition-all">
+                  <XIcon />
+                </button>
+              </div>
+            </div>
+
+            {/* Action buttons */}
+            <div className="flex gap-2 px-3 py-2.5 border-b border-slate-800/60 flex-shrink-0">
+              <button onClick={handleHint}
+                disabled={hintLevel >= 3 || isLoading}
+                className={`flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-xl text-xs font-bold
+                  transition-all active:scale-95
+                  ${hintLevel >= 3 || isLoading
+                    ? 'bg-slate-800/50 text-slate-600 cursor-not-allowed'
+                    : 'bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/20 hover:border-cyan-500/50'}`}>
+                <HintIcon />
+                {hintLevel >= 3 ? 'Max Hints' : `Hint ${hintLevel + 1}/3`}
+              </button>
+              <button onClick={handleExplain} disabled={isLoading}
+                className="flex-1 flex items-center justify-center gap-1.5 py-2 px-3 rounded-xl text-xs font-bold
+                  bg-purple-500/10 border border-purple-500/30 text-purple-400
+                  hover:bg-purple-500/20 hover:border-purple-500/50 transition-all active:scale-95
+                  disabled:opacity-50 disabled:cursor-not-allowed">
+                <BookIcon />
+                Explain Algo
+              </button>
+            </div>
+
+            {/* Messages */}
+            <div className="flex-1 overflow-y-auto p-3 space-y-3 custom-scrollbar">
+              {messages.length === 0 && (
+                <motion.div className="flex flex-col items-center justify-center h-full text-center gap-3 pb-4"
+                  initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                  <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-cyan-500/20 to-purple-600/20
+                    border border-cyan-500/20 flex items-center justify-center">
+                    <SparkleIcon />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-slate-300">Your AI tutor is ready</p>
+                    <p className="text-xs text-slate-600 mt-1 max-w-[260px]">
+                      Ask a question, request a hint, or get an algorithm explained — without spoiling the solution.
+                    </p>
+                  </div>
+                  <div className="text-[10px] text-slate-700 font-mono mt-1">
+                    Ctrl+H · anytime
+                  </div>
+                </motion.div>
+              )}
+
+              {messages.map((msg) => (
+                <MessageBubble key={msg.id} message={msg} />
+              ))}
+
+              {isLoading && (
+                <motion.div className="flex gap-2" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                  <div className="w-6 h-6 rounded-full bg-gradient-to-br from-cyan-500 to-purple-600
+                    flex-shrink-0 flex items-center justify-center text-[10px] font-bold text-white mt-0.5">
+                    AI
+                  </div>
+                  <div className="bg-slate-800/80 border border-slate-700/50 rounded-2xl rounded-tl-sm">
+                    <TypingIndicator />
+                  </div>
+                </motion.div>
+              )}
+
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Quick chips */}
+            {showQuickChips && messages.length === 0 && (
+              <QuickChips onSend={handleSend} disabled={isLoading} />
+            )}
+
+            {/* Input */}
+            <div className="px-3 pb-3 pt-2 border-t border-slate-800/60 flex-shrink-0">
+              <div className="flex gap-2 items-end bg-slate-900/60 border border-slate-700/50
+                rounded-2xl px-3 py-2 focus-within:border-cyan-500/40 transition-colors">
+                <textarea
+                  ref={inputRef}
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Ask anything about your code or algorithm…"
+                  rows={1}
+                  disabled={isLoading}
+                  className="flex-1 bg-transparent text-sm text-white placeholder-slate-600 resize-none
+                    focus:outline-none leading-relaxed max-h-24 overflow-y-auto custom-scrollbar
+                    disabled:opacity-50"
+                  style={{ fieldSizing: 'content' }}
+                />
+                {isLoading ? (
+                  <button onClick={cancelRequest}
+                    className="flex-shrink-0 p-1.5 rounded-xl bg-red-500/20 text-red-400
+                      hover:bg-red-500/30 transition-all active:scale-95">
+                    <StopIcon />
+                  </button>
+                ) : (
+                  <button onClick={() => handleSend()}
+                    disabled={!inputValue.trim()}
+                    className="flex-shrink-0 p-1.5 rounded-xl bg-cyan-500/20 text-cyan-400
+                      hover:bg-cyan-500/30 disabled:opacity-30 disabled:cursor-not-allowed
+                      transition-all active:scale-95">
+                    <SendIcon />
+                  </button>
+                )}
+              </div>
+              <p className="text-[9px] text-slate-700 text-center mt-1.5 font-mono">
+                Enter to send · Shift+Enter for newline · Ctrl+H to toggle
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}
+
+export default AIAssistantPanel

--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react'
 import CodeEditor from './CodeEditor'
 import ProfilerGraph from './ProfilerGraph'
 import { motion } from 'framer-motion'
+import AIAssistantPanel from './AIAssistantPanel'
 
 const Terminal = React.forwardRef(function Terminal({ logs, onClear }, ref) {
   const scrollRef = useRef(null)
@@ -101,7 +102,6 @@ const runCodeInWorker = (userCode, inputVal, refSlot) => {
         const originalError = self.console.error;
         const originalPostMessage = self.postMessage;
         
-        // 1. Completely remove communication APIs from prototype chain
         let currentProto = self;
         while (currentProto) {
           ['postMessage', 'close', 'importScripts'].forEach(method => {
@@ -112,7 +112,6 @@ const runCodeInWorker = (userCode, inputVal, refSlot) => {
           currentProto = Object.getPrototypeOf(currentProto);
         }
 
-        // 2. Shadow dangerous globals on the instance
         self.postMessage = undefined;
         self.close = undefined;
         self.importScripts = undefined;
@@ -142,7 +141,6 @@ const runCodeInWorker = (userCode, inputVal, refSlot) => {
         
         const startTime = self.performance.now();
         try {
-          // 3. Wrap execution in an IIFE that shadows common aliases in local scope
           const wrappedCode = "\\n(function(self, globalThis, postMessage, close, importScripts, onmessage) {\\n" + code + "\\n})();\\n";
           const runner = new Function('input', wrappedCode);
           runner(input);
@@ -333,7 +331,6 @@ const PracticePage = () => {
   const [isExecutingA, setIsExecutingA] = useState(false)
   const [isExecutingB, setIsExecutingB] = useState(false)
 
-  // Tri-state execution mode: 'single' | 'compare' | 'profiler'
   const [executionMode, setExecutionMode] = useState('single')
   const isCompareMode = executionMode === 'compare'
   const isProfilerMode = executionMode === 'profiler'
@@ -346,7 +343,6 @@ const PracticePage = () => {
   const [isComparing, setIsComparing] = useState(false)
   const [benchmarkResults, setBenchmarkResults] = useState(null)
 
-  // Profiler state
   const [profilerCode, setProfilerCode] = useState(profilerDefaultCode)
   const [profilerInputSizes, setProfilerInputSizes] = useState(
     '100, 500, 1000, 2500, 5000'
@@ -398,8 +394,14 @@ const PracticePage = () => {
     { label: 'High Contrast', value: 'hc-black' },
   ]
 
+  // Derive the active code to pass to the AI panel
+  const activeCode = isProfilerMode
+    ? profilerCode
+    : isCompareMode
+      ? codeA
+      : code
+
   const handleModeChange = (mode) => {
-    // Terminate all active workers across all modes
     terminateWorker(activeWorkerRef)
     terminateWorker(activeWorkerRefA)
     terminateWorker(activeWorkerRefB)
@@ -450,8 +452,6 @@ const PracticePage = () => {
   }
 
   const scrollConsoleIntoView = () => {
-    // Defer until after this tick so layout / React commit can settle (helps with
-    // tall editor + sticky navbar + scrollIntoView).
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         if (consoleRef.current) {
@@ -631,7 +631,6 @@ const PracticePage = () => {
         return
       }
 
-      // Parse input sizes
       const sizes = profilerInputSizes
         .split(',')
         .map((s) => parseInt(s.trim(), 10))
@@ -665,7 +664,6 @@ const PracticePage = () => {
         datasetGenerators[profilerDatasetType] || datasetGenerators.random
       const collectedData = []
 
-      // Sequential execution — one size at a time for benchmark fairness
       for (let i = 0; i < sizes.length; i++) {
         if (profilerCancelledRef.current || !isMountedRef.current) {
           setProfilerLogs((prev) => [
@@ -711,7 +709,6 @@ const PracticePage = () => {
               content: `  N=${size}: Timeout (3s) — skipping larger sizes.`,
             },
           ])
-          // Stop profiling — larger sizes will also timeout
           break
         } else {
           setProfilerLogs((prev) => [
@@ -798,18 +795,8 @@ const PracticePage = () => {
                   ))}
                 </select>
                 <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-slate-500">
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </div>
               </div>
@@ -832,18 +819,8 @@ const PracticePage = () => {
                   ))}
                 </select>
                 <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-slate-500">
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </div>
               </div>
@@ -936,42 +913,16 @@ const PracticePage = () => {
                 >
                   {isComparing ? (
                     <>
-                      <svg
-                        className="animate-spin h-4 w-4 text-white"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        ></circle>
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                        ></path>
+                      <svg className="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
                       <span>Comparing...</span>
                     </>
                   ) : (
                     <>
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M13 10V3L4 14h7v7l9-11h-7z"
-                        />
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                       </svg>
                       <span>Run Benchmark Compare</span>
                     </>
@@ -1016,18 +967,8 @@ const PracticePage = () => {
                       <option value="reversed">Reverse Sorted Array</option>
                     </select>
                     <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-slate-500">
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M19 9l-7 7-7-7"
-                        />
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                       </svg>
                     </div>
                   </div>
@@ -1038,18 +979,8 @@ const PracticePage = () => {
             {/* Guide Card */}
             <div className="bg-slate-900/40 backdrop-blur-xl border border-white/10 p-8 rounded-[2rem] shadow-xl">
               <h3 className="text-sm font-bold uppercase tracking-widest text-cyan-400/80 mb-6 flex items-center gap-2">
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 Guide
               </h3>
@@ -1058,48 +989,30 @@ const PracticePage = () => {
                   <>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(16,185,129,0.6)]"></div>
-                      <span>
-                        Write an algorithm that processes the <code>input</code>{' '}
-                        array.
-                      </span>
+                      <span>Write an algorithm that processes the <code>input</code> array.</span>
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(16,185,129,0.6)]"></div>
-                      <span>
-                        Configure input sizes and dataset type in the panel
-                        above.
-                      </span>
+                      <span>Configure input sizes and dataset type in the panel above.</span>
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(16,185,129,0.6)]"></div>
-                      <span>
-                        Click &quot;Run Code&quot; to benchmark across all sizes
-                        and see the runtime graph with O(N), O(N log N), and
-                        O(N²) overlays.
-                      </span>
+                      <span>Click &quot;Run Code&quot; to benchmark across all sizes and see the runtime graph with O(N), O(N log N), and O(N²) overlays.</span>
                     </li>
                   </>
                 ) : isCompareMode ? (
                   <>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(6,182,212,0.6)]"></div>
-                      <span>
-                        Write two competing algorithms in Editor A and B.
-                      </span>
+                      <span>Write two competing algorithms in Editor A and B.</span>
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(6,182,212,0.6)]"></div>
-                      <span>
-                        Input parameters in the Shared Input field. They will be
-                        passed as a global variable <code>input</code>.
-                      </span>
+                      <span>Input parameters in the Shared Input field. They will be passed as a global variable <code>input</code>.</span>
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(6,182,212,0.6)]"></div>
-                      <span>
-                        Click &quot;Run Benchmark Compare&quot; to execute both
-                        and get relative performance timing.
-                      </span>
+                      <span>Click &quot;Run Benchmark Compare&quot; to execute both and get relative performance timing.</span>
                     </li>
                   </>
                 ) : (
@@ -1110,25 +1023,25 @@ const PracticePage = () => {
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(6,182,212,0.6)]"></div>
-                      <span>
-                        Professional editor with syntax highlighting,
-                        IntelliSense, and ligatures.
-                      </span>
+                      <span>Professional editor with syntax highlighting, IntelliSense, and ligatures.</span>
                     </li>
                     <li className="flex gap-3">
                       <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(6,182,212,0.6)]"></div>
-                      <span>
-                        Execute JavaScript directly and see results in the
-                        real-time console below.
-                      </span>
+                      <span>Execute JavaScript directly and see results in the real-time console below.</span>
                     </li>
                   </>
                 )}
+                {/* AI Assistant hint */}
+                <li className="flex gap-3">
+                  <div className="w-1.5 h-1.5 rounded-full bg-purple-500 mt-1.5 shrink-0 shadow-[0_0_8px_rgba(168,85,247,0.6)]"></div>
+                  <span>
+                    Stuck? Press <kbd className="px-1.5 py-0.5 rounded bg-slate-800 border border-slate-700 text-xs font-mono text-cyan-400">Ctrl+H</kbd> or click the{' '}
+                    <span className="text-cyan-400 font-medium">AI Assistant</span> button for hints and explanations.
+                  </span>
+                </li>
                 <li className="flex gap-3">
                   <div className="w-1.5 h-1.5 rounded-full bg-slate-600 mt-1.5 shrink-0"></div>
-                  <span className="text-slate-500 italic">
-                    (Coming Soon) Native execution for Python, Java, and C++.
-                  </span>
+                  <span className="text-slate-500 italic">(Coming Soon) Native execution for Python, Java, and C++.</span>
                 </li>
               </ul>
             </div>
@@ -1185,9 +1098,7 @@ const PracticePage = () => {
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <span className="w-2 h-2 rounded-full bg-cyan-500"></span>
-                        <h4 className="text-sm font-bold uppercase tracking-wider text-cyan-400">
-                          Algorithm A
-                        </h4>
+                        <h4 className="text-sm font-bold uppercase tracking-wider text-cyan-400">Algorithm A</h4>
                       </div>
                     </div>
                     <CodeEditor
@@ -1213,9 +1124,7 @@ const PracticePage = () => {
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
                         <span className="w-2 h-2 rounded-full bg-purple-500"></span>
-                        <h4 className="text-sm font-bold uppercase tracking-wider text-purple-400">
-                          Algorithm B
-                        </h4>
+                        <h4 className="text-sm font-bold uppercase tracking-wider text-purple-400">Algorithm B</h4>
                       </div>
                     </div>
                     <CodeEditor
@@ -1245,139 +1154,86 @@ const PracticePage = () => {
                     animate={{ opacity: 1, y: 0 }}
                   >
                     <h3 className="text-sm font-bold uppercase tracking-widest text-cyan-400 mb-6 flex items-center gap-2">
-                      <svg
-                        className="w-4 h-4 text-cyan-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 002 2h2a2 2 0 002-2"
-                        />
+                      <svg className="w-4 h-4 text-cyan-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 002 2h2a2 2 0 002-2" />
                       </svg>
                       Benchmark Results
                     </h3>
 
-                    {/* Comparison metrics */}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-                      {/* Algorithm A Result */}
                       <div className="p-5 bg-slate-950/60 border border-slate-800 rounded-2xl flex flex-col justify-between">
                         <div>
-                          <span className="text-[10px] font-bold uppercase tracking-wider text-cyan-400">
-                            Algorithm A
-                          </span>
+                          <span className="text-[10px] font-bold uppercase tracking-wider text-cyan-400">Algorithm A</span>
                           <div className="text-3xl font-black text-white mt-1">
-                            {benchmarkResults.statusA === 'timeout'
-                              ? 'Timeout (3s)'
-                              : benchmarkResults.statusA === 'error'
-                                ? 'Error'
-                                : `${benchmarkResults.durationA.toFixed(3)} ms`}
+                            {benchmarkResults.statusA === 'timeout' ? 'Timeout (3s)'
+                              : benchmarkResults.statusA === 'error' ? 'Error'
+                              : `${benchmarkResults.durationA.toFixed(3)} ms`}
                           </div>
                         </div>
                         {benchmarkResults.statusA === 'success' && (
-                          <div className="text-xs text-slate-500 mt-2 font-mono">
-                            Completed successfully
-                          </div>
+                          <div className="text-xs text-slate-500 mt-2 font-mono">Completed successfully</div>
                         )}
                       </div>
 
-                      {/* Algorithm B Result */}
                       <div className="p-5 bg-slate-950/60 border border-slate-800 rounded-2xl flex flex-col justify-between">
                         <div>
-                          <span className="text-[10px] font-bold uppercase tracking-wider text-purple-400">
-                            Algorithm B
-                          </span>
+                          <span className="text-[10px] font-bold uppercase tracking-wider text-purple-400">Algorithm B</span>
                           <div className="text-3xl font-black text-white mt-1">
-                            {benchmarkResults.statusB === 'timeout'
-                              ? 'Timeout (3s)'
-                              : benchmarkResults.statusB === 'error'
-                                ? 'Error'
-                                : `${benchmarkResults.durationB.toFixed(3)} ms`}
+                            {benchmarkResults.statusB === 'timeout' ? 'Timeout (3s)'
+                              : benchmarkResults.statusB === 'error' ? 'Error'
+                              : `${benchmarkResults.durationB.toFixed(3)} ms`}
                           </div>
                         </div>
                         {benchmarkResults.statusB === 'success' && (
-                          <div className="text-xs text-slate-500 mt-2 font-mono">
-                            Completed successfully
-                          </div>
+                          <div className="text-xs text-slate-500 mt-2 font-mono">Completed successfully</div>
                         )}
                       </div>
                     </div>
 
-                    {/* Visual Comparison Bars */}
-                    {benchmarkResults.statusA === 'success' &&
-                      benchmarkResults.statusB === 'success' && (
-                        <div className="space-y-4">
-                          <div className="relative pt-1">
-                            <div className="flex mb-4 items-center justify-between text-xs">
-                              <span className="text-slate-400 font-medium">
-                                Relative Speed Ratio
-                              </span>
-                              <span className="font-bold text-cyan-400">
-                                {benchmarkResults.durationA <
-                                benchmarkResults.durationB
-                                  ? `Algorithm A is ${(benchmarkResults.durationB / Math.max(0.001, benchmarkResults.durationA)).toFixed(1)}x faster`
-                                  : benchmarkResults.durationB <
-                                      benchmarkResults.durationA
-                                    ? `Algorithm B is ${(benchmarkResults.durationA / Math.max(0.001, benchmarkResults.durationB)).toFixed(1)}x faster`
-                                    : 'Both algorithms are equally fast'}
-                              </span>
-                            </div>
+                    {benchmarkResults.statusA === 'success' && benchmarkResults.statusB === 'success' && (
+                      <div className="space-y-4">
+                        <div className="relative pt-1">
+                          <div className="flex mb-4 items-center justify-between text-xs">
+                            <span className="text-slate-400 font-medium">Relative Speed Ratio</span>
+                            <span className="font-bold text-cyan-400">
+                              {benchmarkResults.durationA < benchmarkResults.durationB
+                                ? `Algorithm A is ${(benchmarkResults.durationB / Math.max(0.001, benchmarkResults.durationA)).toFixed(1)}x faster`
+                                : benchmarkResults.durationB < benchmarkResults.durationA
+                                  ? `Algorithm B is ${(benchmarkResults.durationA / Math.max(0.001, benchmarkResults.durationB)).toFixed(1)}x faster`
+                                  : 'Both algorithms are equally fast'}
+                            </span>
+                          </div>
 
-                            {(() => {
-                              const maxDuration = Math.max(
-                                benchmarkResults.durationA,
-                                benchmarkResults.durationB,
-                                0.001
-                              )
-                              const widthA =
-                                (benchmarkResults.durationA / maxDuration) * 100
-                              const widthB =
-                                (benchmarkResults.durationB / maxDuration) * 100
-                              return (
-                                <div className="space-y-3 font-mono text-xs">
-                                  <div>
-                                    <div className="flex justify-between mb-1">
-                                      <span className="text-cyan-400">
-                                        Algorithm A
-                                      </span>
-                                      <span className="text-slate-400">
-                                        {benchmarkResults.durationA.toFixed(3)}{' '}
-                                        ms
-                                      </span>
-                                    </div>
-                                    <div className="w-full bg-slate-950 rounded-full h-2.5 border border-slate-800/80 overflow-hidden">
-                                      <div
-                                        className="bg-cyan-500 h-2.5 rounded-full shadow-[0_0_8px_rgba(6,182,212,0.6)]"
-                                        style={{ width: `${widthA}%` }}
-                                      />
-                                    </div>
+                          {(() => {
+                            const maxDuration = Math.max(benchmarkResults.durationA, benchmarkResults.durationB, 0.001)
+                            const widthA = (benchmarkResults.durationA / maxDuration) * 100
+                            const widthB = (benchmarkResults.durationB / maxDuration) * 100
+                            return (
+                              <div className="space-y-3 font-mono text-xs">
+                                <div>
+                                  <div className="flex justify-between mb-1">
+                                    <span className="text-cyan-400">Algorithm A</span>
+                                    <span className="text-slate-400">{benchmarkResults.durationA.toFixed(3)} ms</span>
                                   </div>
-                                  <div>
-                                    <div className="flex justify-between mb-1">
-                                      <span className="text-purple-400">
-                                        Algorithm B
-                                      </span>
-                                      <span className="text-slate-400">
-                                        {benchmarkResults.durationB.toFixed(3)}{' '}
-                                        ms
-                                      </span>
-                                    </div>
-                                    <div className="w-full bg-slate-950 rounded-full h-2.5 border border-slate-800/80 overflow-hidden">
-                                      <div
-                                        className="bg-purple-500 h-2.5 rounded-full shadow-[0_0_8px_rgba(168,85,247,0.6)]"
-                                        style={{ width: `${widthB}%` }}
-                                      />
-                                    </div>
+                                  <div className="w-full bg-slate-950 rounded-full h-2.5 border border-slate-800/80 overflow-hidden">
+                                    <div className="bg-cyan-500 h-2.5 rounded-full shadow-[0_0_8px_rgba(6,182,212,0.6)]" style={{ width: `${widthA}%` }} />
                                   </div>
                                 </div>
-                              )
-                            })()}
-                          </div>
+                                <div>
+                                  <div className="flex justify-between mb-1">
+                                    <span className="text-purple-400">Algorithm B</span>
+                                    <span className="text-slate-400">{benchmarkResults.durationB.toFixed(3)} ms</span>
+                                  </div>
+                                  <div className="w-full bg-slate-950 rounded-full h-2.5 border border-slate-800/80 overflow-hidden">
+                                    <div className="bg-purple-500 h-2.5 rounded-full shadow-[0_0_8px_rgba(168,85,247,0.6)]" style={{ width: `${widthB}%` }} />
+                                  </div>
+                                </div>
+                              </div>
+                            )
+                          })()}
                         </div>
-                      )}
+                      </div>
+                    )}
                   </motion.div>
                 )}
               </div>
@@ -1385,6 +1241,13 @@ const PracticePage = () => {
           </div>
         </div>
       </div>
+
+      {/* ── AI Assistant Panel — floats over the page, never blocks the editor ── */}
+      <AIAssistantPanel
+        code={activeCode}
+        executionMode={executionMode}
+        language={language}
+      />
     </motion.div>
   )
 }

--- a/src/components/useAIAssistant.js
+++ b/src/components/useAIAssistant.js
@@ -1,0 +1,198 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+
+export function useAIAssistant({ isOpen, onOpen }) {
+  const [messages, setMessages] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [hintLevel, setHintLevel] = useState(0)
+  const [currentContext, setCurrentContext] = useState(null)
+  const abortRef = useRef(null)
+
+  // Ctrl+H keyboard shortcut
+  useEffect(() => {
+    const handler = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'h') {
+        const tag = document.activeElement?.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+        e.preventDefault()
+        onOpen?.()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onOpen])
+
+  const buildSystemPrompt = () => `
+You are an expert algorithm tutor embedded in AlgoScope, an interactive algorithm visualizer and practice platform.
+
+Your role is to help students understand algorithms WITHOUT giving away full solutions. You:
+- Give progressive hints (gentle nudge → concept reminder → direct pointer)
+- Explain mistakes as micro-learning moments
+- Use simple, beginner-friendly language
+- Reference the current code/algorithm context when available
+- Keep responses concise (2-4 sentences max for hints, slightly more for explanations)
+- Never write the complete solution for them
+- Use encouraging, patient tone
+
+AlgoScope covers: Sorting (Bubble, Merge, Quick, Heap, etc.), Searching (Binary, Linear, BFS, DFS), 
+Shortest Path (Dijkstra, A*, BFS), Backtracking (N-Queens, Sudoku, Graph Coloring), 
+Dynamic Programming, Kadane's Algorithm, Moore Voting, String Algorithms (KMP, Rabin-Karp, Z), 
+Math Theory (GCD, Sieve, FFT, Fibonacci), Data Structures (Stack, Queue, Heap, DSU, Tree).
+`.trim()
+
+  const callAPI = useCallback(async (userMessage, contextInfo = null) => {
+    setIsLoading(true)
+
+    const systemPrompt = buildSystemPrompt()
+    const contextNote = contextInfo
+      ? `\n\n[Student context: ${contextInfo}]`
+      : ''
+
+    const apiMessages = [
+      ...messages
+        .filter((m) => m.role !== 'system')
+        .slice(-8) // keep last 8 messages for context window
+        .map((m) => ({ role: m.role, content: m.content })),
+      { role: 'user', content: userMessage + contextNote },
+    ]
+
+    const userMsg = {
+      id: Date.now(),
+      role: 'user',
+      content: userMessage,
+      timestamp: new Date(),
+    }
+    setMessages((prev) => [...prev, userMsg])
+
+    try {
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+        body: JSON.stringify({
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 1000,
+          system: systemPrompt,
+          messages: apiMessages,
+        }),
+      })
+
+      const data = await response.json()
+      const text =
+        data.content
+          ?.filter((b) => b.type === 'text')
+          .map((b) => b.text)
+          .join('') || 'Sorry, I could not generate a response. Please try again.'
+
+      const assistantMsg = {
+        id: Date.now() + 1,
+        role: 'assistant',
+        content: text,
+        timestamp: new Date(),
+      }
+      setMessages((prev) => [...prev, assistantMsg])
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        const errMsg = {
+          id: Date.now() + 1,
+          role: 'assistant',
+          content:
+            'I ran into a connection issue. Please check your network and try again.',
+          timestamp: new Date(),
+          isError: true,
+        }
+        setMessages((prev) => [...prev, errMsg])
+      }
+    } finally {
+      setIsLoading(false)
+      abortRef.current = null
+    }
+  }, [messages])
+
+  const requestHint = useCallback(
+    (code, executionMode, language) => {
+      const level = hintLevel + 1
+      setHintLevel(level)
+
+      const hintPrompts = {
+        1: `Give me a gentle nudge hint (Hint 1/3) — just point me in the right direction without revealing the answer.`,
+        2: `Give me a conceptual reminder hint (Hint 2/3) — explain the underlying concept I might be missing.`,
+        3: `Give me a more direct pointer hint (Hint 3/3) — be more specific about what I should do next, but still don't write the full solution.`,
+      }
+
+      const prompt = hintPrompts[Math.min(level, 3)]
+      const context = `Mode: ${executionMode}, Language: ${language}${
+        code ? `, Current code snippet (first 300 chars): ${code.slice(0, 300)}` : ''
+      }`
+
+      callAPI(prompt, context)
+    },
+    [hintLevel, callAPI]
+  )
+
+  const explainAlgorithm = useCallback(
+    (algorithmName, code) => {
+      const context = code
+        ? `Current code (first 300 chars): ${code.slice(0, 300)}`
+        : null
+      callAPI(
+        `Explain the ${algorithmName || 'algorithm I am currently working on'} in simple terms. Focus on the key insight and how it works step by step.`,
+        context
+      )
+    },
+    [callAPI]
+  )
+
+  const explainMistake = useCallback(
+    (errorMessage, code) => {
+      const context = `Error: ${errorMessage}${
+        code ? `, Code (first 300 chars): ${code.slice(0, 300)}` : ''
+      }`
+      callAPI(
+        `I got this error. Instead of just telling me the fix, explain what concept I'm misunderstanding and guide me toward the solution.`,
+        context
+      )
+    },
+    [callAPI]
+  )
+
+  const sendMessage = useCallback(
+    (text, code, executionMode, language) => {
+      const context =
+        code || executionMode
+          ? `Mode: ${executionMode || 'single'}, Language: ${language || 'javascript'}${
+              code ? `, Code (first 300 chars): ${code.slice(0, 300)}` : ''
+            }`
+          : null
+      callAPI(text, context)
+    },
+    [callAPI]
+  )
+
+  const resetHints = useCallback(() => setHintLevel(0), [])
+
+  const clearMessages = useCallback(() => {
+    setMessages([])
+    setHintLevel(0)
+  }, [])
+
+  const cancelRequest = useCallback(() => {
+    abortRef.current?.abort()
+    setIsLoading(false)
+  }, [])
+
+  return {
+    messages,
+    isLoading,
+    hintLevel,
+    requestHint,
+    explainAlgorithm,
+    explainMistake,
+    sendMessage,
+    resetHints,
+    clearMessages,
+    cancelRequest,
+  }
+}


### PR DESCRIPTION
### What changed?
Adds an AI-powered assistant to the Practice Sandbox (`/practice`) via two new components — `useAIAssistant.js` (hook) and `AIAssistantPanel.jsx` (UI) — and updates `PracticePage.jsx` to mount the panel. The assistant floats as a fixed drawer in the bottom-right corner, never blocking the editor or visualizer.

### Why is this needed?
Students using Practice mode had no in-app help when stuck — the only options were leaving the platform to search Google, watch YouTube, or give up entirely. This PR closes that gap by embedding a contextual AI tutor directly into the sandbox.

Closes #571 

## Type of Change
- [x] `feat` - New user-facing feature or algorithm capability

## Release Notes

Release note category:
- [x] Added

Release note entry:
- Added AI Assistant panel to Practice Sandbox with a progressive 3-level hint system, free-form algorithm Q&A chat, and an "Explain Algorithm" button — all context-aware of the student's current code, language, and execution mode. Toggled via floating button or `Ctrl+H`.

## Testing and Verification
- [x] `npm install`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:
`npm run format:check`, `npm run lint`, and `npm run build` were not run locally — maintainers should verify CI passes.

## UI Evidence

**Before:** Practice page had no help system. Students stuck on an algorithm had no in-app guidance.

**After:** A floating "AI Assistant" button (bottom-right) opens a slide-in chat drawer with:
- **Hint 1/3 → 2/3 → 3/3** progressive hints (nudge → concept reminder → direct pointer)
- **Explain Algo** button — context-aware explanation based on current editor code
- **Free-form chat** — ask any algorithm question with full conversation history
- **Quick chip suggestions** on first open
- **Ctrl+H** keyboard shortcut to toggle the panel
- Typing indicator, stop/cancel button, and per-message timestamps
- Fully matches AlgoScope's dark navy / cyan / purple design system

<img width="1900" height="905" alt="Screenshot 2026-06-09 161655" src="https://github.com/user-attachments/assets/f2534184-2c1b-482f-afdc-7d80b9d8e255" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Assistant panel with floating button for guided hints and algorithm explanations
  * Interactive chat interface with message history, quick actions, and typing indicators
  * Keyboard shortcut (Ctrl+H / Cmd+H) for quick access to AI assistance
  * Clear messages and reset hints functionality within the assistant panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->