### PR TITLE
fix: close explore dropdown when search modal opens

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import {
   SignedIn,
@@ -180,10 +180,10 @@ export const Navbar = () => {
     localStorage.setItem('algo-history', JSON.stringify(history))
   }, [history])
 
-  const closeExploreMenu = () => {
-    setExploreOpen(false)
-    setHoveredTab((current) => (current === 'explore' ? null : current))
-  }
+  const closeExploreMenu = useCallback(() => {
+  setExploreOpen(false)
+  setHoveredTab((current) => (current === 'explore' ? null : current))
+  }, [])
 
   const handleExploreKeyDown = (event) => {
     if (event.key === 'Enter' || event.key === ' ') {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -226,7 +226,7 @@ export const Navbar = () => {
             data-tour="search-bar"
             className="hidden md:flex flex-1 justify-center max-w-xs mx-4 z-10"
           >
-            <SearchBar />
+            <SearchBar onOpen={closeExploreMenu} />
           </div>
 
           <div className="hidden md:flex items-center gap-6">
@@ -552,7 +552,7 @@ export const Navbar = () => {
               <div className="flex-grow overflow-y-auto space-y-6 pr-2">
                 {/* Search */}
                 <div className="w-full">
-                  <SearchBar />
+                  <SearchBar onOpen={closeExploreMenu} />
                 </div>
 
                 {/* Nav list */}

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -346,7 +346,7 @@ const ALGORITHMS = [
   },
 ]
 
-const SearchBar = () => {
+const SearchBar = ({ onOpen }) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [results, setResults] = useState([])
@@ -412,9 +412,10 @@ const SearchBar = () => {
   }
 
   const openModal = React.useCallback(() => {
-    previousFocusRef.current = document.activeElement
-    setIsModalOpen(true)
-  }, [])
+  previousFocusRef.current = document.activeElement
+  setIsModalOpen(true)
+  onOpen?.()
+}, [onOpen])
 
   const handleCloseModal = React.useCallback(() => {
     setIsModalOpen(false)


### PR DESCRIPTION
## Pull Request Summary

### What changed?
Added an optional `onOpen` prop to the `SearchBar` component. 
When the search modal opens, it now calls `onOpen?.()` which 
triggers `closeExploreMenu` in `Navbar.jsx`. `SearchBar` instances in `Navbar.jsx` now pass 
`closeExploreMenu` as the `onOpen` prop. Files affected: 
`src/components/SearchBar.jsx` and `src/components/Navbar.jsx`.

### Why is this needed?
Previously, when the Explore dropdown was open and the user 
clicked the Search button, the Explore dropdown stayed open 
behind the search modal. Both UI elements were visible at the 
same time causing visual overlap and confusing user experience. 
The SearchBar had no way to communicate with Navbar to close 
the dropdown.

Closes #629 

## Type of Change
- [ ] `feat` - New user-facing feature or algorithm capability
- [x] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes
Release note category:
- [ ] Added
- [ ] Changed
- [x] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:
- Fixed Explore dropdown not closing when Search modal is opened

## Testing and Verification
- [x] `npm ci` or `npm install`
- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:
Skipped format:check and lint as this is a small focused fix. 
Manually tested the following:
1. Open Explore dropdown → click Search → dropdown closes ✅
2. Open Explore dropdown → press Ctrl+K → dropdown closes ✅
3. Search modal works normally after fix ✅

## UI Evidence
Before:
<img width="1600" height="988" alt="bug algo" src="https://github.com/user-attachments/assets/d7749667-4433-45e3-8f93-e0266fcab177" />


After:

https://github.com/user-attachments/assets/1d9c7985-05fd-4627-82a0-5dc3763c3e2d



## CI/CD and Deployment Impact
- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:
No deployment impact. Small component-level bug fix only.

## Reviewer Checklist
<!-- Keep this section for maintainers and reviewers. -->
- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Fixed search/menu interaction: activating search now automatically closes the “Explore” menu (desktop and mobile) to prevent overlap and improve navigation clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->