### PR TITLE
fix: hide overlapping data labels on complexity graph

### DIFF
--- a/src/components/ComplexityGraph.jsx
+++ b/src/components/ComplexityGraph.jsx
@@ -74,6 +74,7 @@ export default function ComplexityGraph({ algorithm }) {
               dataKey="performance"
               stroke={algorithmColors[algorithm]}
               strokeWidth={3}
+              dot={false}
             />
           </LineChart>
         </ResponsiveContainer>


### PR DESCRIPTION
Removes the default dot markers from the Line chart in ComplexityGraph. Data values remain accessible via the existing interactive Tooltip hover, keeping the visualization clean while preserving all information.

Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed point markers from the performance data line in the Complexity Graph for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->