### PR TITLE
fix: highlight navbar Explore button when on algorithm sub-pages

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -150,6 +150,9 @@ export const Navbar = () => {
 
   const { pathname } = useLocation()
   const isExploreMenuOpen = hoveredTab === 'explore' || exploreOpen
+  const isExploreActive = algorithmLinks.some(
+    (link) => link.href !== '/practice' && link.href !== '/challenge' && pathname.startsWith(link.href)
+  )
 
   const [history, setHistory] = useState(() => {
     try {
@@ -259,7 +262,11 @@ export const Navbar = () => {
                     setHoveredTab('explore')
                   }}
                   onKeyDown={handleExploreKeyDown}
-                  className="relative text-sm font-medium text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 px-4 py-1.5 rounded-lg transition-all duration-300 z-10 cursor-pointer"
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 cursor-pointer ${
+                    isExploreActive
+                      ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
+                      : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
+                  }`}
                 >
                   Explore
                 </button>


### PR DESCRIPTION
## Description

The `Explore` dropdown button in the navbar never showed as active when navigating to algorithm pages like `/search`, `/sort`, `/adt`, etc. Only the individual dropdown items were highlighted (via exact path match).

**Changes:**
- Added `isExploreActive` check that compares `pathname` against all algorithm routes
- Applied the same active styling (`text-indigo-600` + `font-semibold`) to the Explore button when on an algorithm page
- Excluded `/practice` and `/challenge` (which have their own top-level nav tabs) from the Explore active check

**Fixes** #655

## GSSoC
- Closes #655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Explore" navigation button now correctly displays as active when viewing algorithm-related pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->