### PR TITLE
fix: correct array search algorithm names in global search

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -141,13 +141,13 @@ const ALGORITHMS = [
     id: 'linear',
     name: 'Linear Search',
     category: 'Array Search',
-    route: '/ldssearch?algo=linear',
+    route: '/ldssearch?algo=linearSearch',
   },
   {
     id: 'binary',
     name: 'Binary Search',
     category: 'Array Search',
-    route: '/ldssearch?algo=binary',
+    route: '/ldssearch?algo=binarySearch',
   },
   {
     id: 'kadane',


### PR DESCRIPTION
Fixes #541

Changed `algo=linear` → `algo=linearSearch` and `algo=binary` → `algo=binarySearch` in SearchBar.jsx so the URL params match the algoMap keys expected by the Array Search visualizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Search algorithm routing parameters have been refined for improved consistency in URL naming conventions across Linear Search and Binary Search features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->