### PR TITLE
feat: close search modal on backdrop click

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -560,13 +560,12 @@ const SearchBar = () => {
       {/* Search Modal */}
       <AnimatePresence>
         {isModalOpen && (
-          <div className="fixed inset-0 z-[100] flex items-start justify-center pt-20 px-4">
+          <div className="fixed inset-0 z-[100] flex items-start justify-center pt-20 px-4" onClick={handleCloseModal}>
             {/* Backdrop */}
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              onClick={handleCloseModal}
               className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm"
             />
 
@@ -576,6 +575,7 @@ const SearchBar = () => {
               role="dialog"
               aria-modal="true"
               aria-labelledby="search-dialog-title"
+              onClick={(e) => e.stopPropagation()}
               initial={{ opacity: 0, scale: 0.95, y: -20 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: -20 }}


### PR DESCRIPTION
Fixes #523

- Moved `handleCloseModal` to the outer wrapper div so clicking the backdrop or any area outside the modal closes it
- Added `stopPropagation` to the inner modal content so clicks inside the modal don't bubble up and trigger close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search modal click behavior: the modal now closes only when clicking outside the dialog, preventing accidental dismissals from interactions within the modal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->