### PR TITLE
fix: persist visualization state across module navigation (#653)

### DIFF
--- a/src/components/arraySearch/Visualizer.jsx
+++ b/src/components/arraySearch/Visualizer.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
+import { useVisualizationState } from '../../context/useVisualizationState'
 import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import TestCaseManager from '../testCaseManager/TestCaseManager'
@@ -33,6 +34,8 @@ const SEARCH_SAMPLE_CASES = [
     description: 'Target is in the middle of an unsorted array.',
   },
 ]
+
+const ARRAY_SEARCH_STATE_KEY = 'array-search:solo'
 
 const parseStoredSearchCase = (input) => {
   if (!input) return null
@@ -68,22 +71,43 @@ const parseStoredSearchCase = (input) => {
 
 export default function Visualizer() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [algorithm, setAlgorithm] = useState(
+  const [algorithm, setAlgorithm] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:algorithm`,
     () => searchParams.get('algo') || 'linearSearch'
   )
-  const [baseArray, setBaseArray] = useState(() => createArray(algorithm))
-  const [target, setTarget] = useState(() => {
-    const urlTarget = searchParams.get('target')
-    if (urlTarget) return urlTarget
-    return algorithm === 'binarySearch' ? 37 : 30
-  })
-  const [customInput, setCustomInput] = useState('')
-  const [speed, setSpeed] = useState(1)
-  const [language, setLanguage] = useState(() => {
-    return searchParams.get('lang') || 'javascript'
-  })
+  const [baseArray, setBaseArray] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:baseArray`,
+    () => createArray(algorithm)
+  )
+  const [target, setTarget] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:target`,
+    () => {
+      const urlTarget = searchParams.get('target')
+      if (urlTarget) return urlTarget
+      return algorithm === 'binarySearch' ? 37 : 30
+    }
+  )
+  const [customInput, setCustomInput] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:customInput`,
+    ''
+  )
+  const [speed, setSpeed] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:speed`,
+    1
+  )
+  const [language, setLanguage] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:language`,
+    () => searchParams.get('lang') || 'javascript'
+  )
   const [showShortcuts, setShowShortcuts] = useState(false)
-  const [isStepMode, setIsStepMode] = useState(false)
+  const [isStepMode, setIsStepMode] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:isStepMode`,
+    false
+  )
+  const [playbackState, setPlaybackState] = useVisualizationState(
+    `${ARRAY_SEARCH_STATE_KEY}:playback`,
+    { steps: [], currentStepIndex: -1, isPlaying: false }
+  )
 
   const handleAlgorithmChange = (e) => {
     const newAlgo = e.target.value
@@ -117,7 +141,11 @@ export default function Visualizer() {
     replay: replayPlayback,
     stepForward,
     stepBackward,
-  } = useStepPlayback({ speed })
+  } = useStepPlayback({
+    speed,
+    initialState: playbackState,
+    onStateChange: setPlaybackState,
+  })
 
   const handleSearch = () => {
     if (algorithm && algoMap[algorithm]) {

--- a/src/components/greedyAlgo/VisualizerPage.jsx
+++ b/src/components/greedyAlgo/VisualizerPage.jsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
+import { useVisualizationState } from '../../context/useVisualizationState'
 import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
@@ -24,26 +25,49 @@ const DEFAULT_KNAPSACK_ITEMS = [
   { id: 'Item C', value: 120, weight: 30 },
 ]
 
+const GREEDY_STATE_KEY = 'greedy:solo'
+
 export default function VisualizerPage() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [algorithm, setAlgorithm] = useState(
+  const [algorithm, setAlgorithm] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:algorithm`,
     () => searchParams.get('algo') || 'huffman'
   )
-  const [language, setLanguage] = useState(
+  const [language, setLanguage] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:language`,
     () => searchParams.get('lang') || 'javascript'
   )
-  const [speed, setSpeed] = useState(1)
+  const [speed, setSpeed] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:speed`,
+    1
+  )
   const [showShortcuts, setShowShortcuts] = useState(false)
-  const [isStepMode, setIsStepMode] = useState(false)
+  const [isStepMode, setIsStepMode] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:isStepMode`,
+    false
+  )
 
   // Huffman Inputs
-  const [huffmanText, setHuffmanText] = useState('BEEP BOOP BEER')
+  const [huffmanText, setHuffmanText] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:huffmanText`,
+    'BEEP BOOP BEER'
+  )
 
   // Knapsack Inputs
-  const [knapsackCapacity, setKnapsackCapacity] = useState(50)
-  const [knapsackItems, setKnapsackItems] = useState(DEFAULT_KNAPSACK_ITEMS)
+  const [knapsackCapacity, setKnapsackCapacity] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:knapsackCapacity`,
+    50
+  )
+  const [knapsackItems, setKnapsackItems] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:knapsackItems`,
+    DEFAULT_KNAPSACK_ITEMS
+  )
   const [newItemValue, setNewItemValue] = useState('')
   const [newItemWeight, setNewItemWeight] = useState('')
+  const [playbackState, setPlaybackState] = useVisualizationState(
+    `${GREEDY_STATE_KEY}:playback`,
+    { steps: [], currentStepIndex: -1, isPlaying: false }
+  )
 
   useEffect(() => {
     const params = { algo: algorithm, lang: language }
@@ -64,7 +88,11 @@ export default function VisualizerPage() {
     replay: replayPlayback,
     stepForward,
     stepBackward,
-  } = useStepPlayback({ speed })
+  } = useStepPlayback({
+    speed,
+    initialState: playbackState,
+    onStateChange: setPlaybackState,
+  })
 
   const handleVisualize = () => {
     clearPlayback()

--- a/src/components/kadaneAlgo/VisualizerPage.jsx
+++ b/src/components/kadaneAlgo/VisualizerPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import SpeedSlider from '../SpeedSlider'
 import ComplexityCard from '../ComplexityCard'
@@ -8,18 +8,33 @@ import { MenuSetAlgoKadane } from './MenuSetAlgoKadane'
 import { kadaneSources } from '../../algorithms/kadane/kadaneSources'
 import DifficultyBadge from '../DifficultyBadge'
 import LearningPathSuggestions from '../LearningPathSuggestions'
+import { useVisualizationState } from '../../context/useVisualizationState'
 
 const complexityData = {
   time: 'O(N)',
   space: 'O(1)',
 }
 
-const VisualizerPage = () => {
-  const [arrayInput, setArrayInput] = useState('-2,1,-3,4,-1,2,1,-5,4')
+const KADANE_STATE_KEY = 'kadane:solo'
 
-  const [numbers, setNumbers] = useState([])
-  const [speed, setSpeed] = useState(1)
-  const [language, setLanguage] = useState('javascript')
+const VisualizerPage = () => {
+  const [arrayInput, setArrayInput] = useVisualizationState(
+    `${KADANE_STATE_KEY}:arrayInput`,
+    '-2,1,-3,4,-1,2,1,-5,4'
+  )
+
+  const [numbers, setNumbers] = useVisualizationState(
+    `${KADANE_STATE_KEY}:numbers`,
+    []
+  )
+  const [speed, setSpeed] = useVisualizationState(
+    `${KADANE_STATE_KEY}:speed`,
+    1
+  )
+  const [language, setLanguage] = useVisualizationState(
+    `${KADANE_STATE_KEY}:language`,
+    'javascript'
+  )
 
   const handleVisualize = () => {
     const parsed = arrayInput

--- a/src/components/mooreVotingAlgo/VisualizerPage.jsx
+++ b/src/components/mooreVotingAlgo/VisualizerPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import SpeedSlider from '../SpeedSlider'
 import ComplexityCard from '../ComplexityCard'
@@ -8,18 +8,33 @@ import { MenuSetAlgoMooreVoting } from './MenuSetAlgoMooreVoting'
 import { mooreVotingSources } from '../../algorithms/mooreVoting/mooreVotingSources'
 import DifficultyBadge from '../DifficultyBadge'
 import LearningPathSuggestions from '../LearningPathSuggestions'
+import { useVisualizationState } from '../../context/useVisualizationState'
 
 const complexityData = {
   time: 'O(N)',
   space: 'O(1)',
 }
 
-const VisualizerPage = () => {
-  const [arrayInput, setArrayInput] = useState('2,2,1,1,1,2,2')
+const MOORE_VOTING_STATE_KEY = 'moore-voting:solo'
 
-  const [numbers, setNumbers] = useState([])
-  const [speed, setSpeed] = useState(1)
-  const [language, setLanguage] = useState('javascript')
+const VisualizerPage = () => {
+  const [arrayInput, setArrayInput] = useVisualizationState(
+    `${MOORE_VOTING_STATE_KEY}:arrayInput`,
+    '2,2,1,1,1,2,2'
+  )
+
+  const [numbers, setNumbers] = useVisualizationState(
+    `${MOORE_VOTING_STATE_KEY}:numbers`,
+    []
+  )
+  const [speed, setSpeed] = useVisualizationState(
+    `${MOORE_VOTING_STATE_KEY}:speed`,
+    1
+  )
+  const [language, setLanguage] = useVisualizationState(
+    `${MOORE_VOTING_STATE_KEY}:language`,
+    'javascript'
+  )
 
   const handleVisualize = () => {
     const parsed = arrayInput

--- a/src/components/searchAlgo/VisualizerPage.jsx
+++ b/src/components/searchAlgo/VisualizerPage.jsx
@@ -164,6 +164,9 @@ import SpeedSlider from '../SpeedSlider'
 import { graphSearchSources } from '../../algorithms/searching/graphSearchSources'
 import ComplexityCard from '../ComplexityCard'
 import ComparisonMode from './ComparisonMode'
+import { useVisualizationState } from '../../context/useVisualizationState'
+
+const GRAPH_SEARCH_STATE_KEY = 'graph-search:solo'
 
 export const VisualizerPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -179,14 +182,30 @@ export const VisualizerPage = () => {
     setSearchParams(newParams)
   }
 
-  const [node, setNode] = React.useState(null)
-  const [algorithm, setAlgorithm] = React.useState(null)
-  const [speed, setSpeed] = React.useState(1.0)
-  const [language, setLanguage] = React.useState('javascript')
-  const [runKey, setRunKey] = React.useState(null)
+  const [node, setNode] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:node`,
+    null
+  )
+  const [algorithm, setAlgorithm] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:algorithm`,
+    null
+  )
+  const [speed, setSpeed] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:speed`,
+    1.0
+  )
+  const [language, setLanguage] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:language`,
+    'javascript'
+  )
+  const [runKey, setRunKey] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:runKey`,
+    null
+  )
   // Live list of node IDs from the canvas (kept in sync via onGraphChange)
-  const [nodeIds, setNodeIds] = React.useState(
-    Array.from({ length: 15 }, (_, i) => i + 1)
+  const [nodeIds, setNodeIds] = useVisualizationState(
+    `${GRAPH_SEARCH_STATE_KEY}:nodeIds`,
+    () => Array.from({ length: 15 }, (_, i) => i + 1)
   )
 
   const handleGraphChange = React.useCallback(
@@ -197,7 +216,7 @@ export const VisualizerPage = () => {
         setNode(null)
       }
     },
-    [node]
+    [node, setNode, setNodeIds]
   )
 
   const handleSpeedChange = (event, newValue) => {

--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
 import { useStepPlayback } from '../visualizer/useStepPlayback'
+import { useVisualizationState } from '../../context/useVisualizationState'
 import ComplexityCard from '../ComplexityCard'
 import Tooltip from '../Tooltip'
 import TestCaseManager from '../testCaseManager/TestCaseManager'
@@ -33,9 +34,11 @@ const algoMap = {
 }
 
 const DEFAULT_ARRAY_SIZE = 8
+const INITIAL_ARRAY = [50, 120, 70, 30, 200, 90, 160]
 const RANDOM_MIN = 50
 const RANDOM_MAX = 250
 const MAX_CUSTOM_INPUT_SIZE = 100
+const SORTING_STATE_KEY = 'sorting:solo'
 
 const parseStoredArray = (value) =>
   value
@@ -154,17 +157,61 @@ const STATE_STYLE_PRESETS = {
 
 export default function Visualizer() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const [baseArray, setBaseArray] = useState([50, 120, 70, 30, 200, 90, 160])
-  const [speed, setSpeed] = useState(1)
-  const [language, setLanguage] = useState('javascript')
-  const [algorithmType, setAlgorithmType] = useState('simple')
-  const [customInput, setCustomInput] = useState('')
-  const [inputError, setInputError] = useState('')
-  const [isStepMode, setIsStepMode] = useState(false)
+  const [baseArray, setBaseArray] = useVisualizationState(
+    `${SORTING_STATE_KEY}:baseArray`,
+    INITIAL_ARRAY
+  )
+  const [speed, setSpeed] = useVisualizationState(
+    `${SORTING_STATE_KEY}:speed`,
+    1
+  )
+  const [language, setLanguage] = useVisualizationState(
+    `${SORTING_STATE_KEY}:language`,
+    'javascript'
+  )
+  const [algorithmType, setAlgorithmType] = useVisualizationState(
+    `${SORTING_STATE_KEY}:algorithmType`,
+    'simple'
+  )
+  const [customInput, setCustomInput] = useVisualizationState(
+    `${SORTING_STATE_KEY}:customInput`,
+    ''
+  )
+  const [inputError, setInputError] = useVisualizationState(
+    `${SORTING_STATE_KEY}:inputError`,
+    ''
+  )
+  const [isStepMode, setIsStepMode] = useVisualizationState(
+    `${SORTING_STATE_KEY}:isStepMode`,
+    false
+  )
+  const [persistedAlgorithm, setPersistedAlgorithm] = useVisualizationState(
+    `${SORTING_STATE_KEY}:selectedAlgorithm`,
+    ''
+  )
+  const [playbackState, setPlaybackState] = useVisualizationState(
+    `${SORTING_STATE_KEY}:playback`,
+    { steps: [], currentStepIndex: -1, isPlaying: false }
+  )
 
   const algoFromUrl = searchParams.get('algo')
   const selectedAlgorithm =
-    algoFromUrl && algoMap[algoFromUrl] ? algoFromUrl : ''
+    algoFromUrl && algoMap[algoFromUrl]
+      ? algoFromUrl
+      : persistedAlgorithm && algoMap[persistedAlgorithm]
+        ? persistedAlgorithm
+        : ''
+
+  useEffect(() => {
+    if (
+      algoFromUrl &&
+      algoMap[algoFromUrl] &&
+      algoFromUrl !== persistedAlgorithm
+    ) {
+      setPersistedAlgorithm(algoFromUrl)
+    }
+  }, [algoFromUrl, persistedAlgorithm, setPersistedAlgorithm])
+
   const testCaseAlgorithm = selectedAlgorithm || algorithmType
   const sortSampleCases = useMemo(
     () => buildSortSampleCases(testCaseAlgorithm),
@@ -185,7 +232,11 @@ export default function Visualizer() {
     replay: replayPlayback,
     stepForward,
     stepBackward,
-  } = useStepPlayback({ speed })
+  } = useStepPlayback({
+    speed,
+    initialState: playbackState,
+    onStateChange: setPlaybackState,
+  })
 
   const algorithmOptions = {
     simple: ['bubble', 'selection', 'insertion'],
@@ -205,7 +256,6 @@ export default function Visualizer() {
       }
     }
   }
-  const INITIAL_ARRAY = [50, 120, 70, 30, 200, 90, 160]
   const handleReset = () => {
     clearPlayback()
     setBaseArray(INITIAL_ARRAY)
@@ -364,6 +414,7 @@ export default function Visualizer() {
   const handleAlgorithmChange = (event) => {
     const newAlgo = event.target.value
     clearPlayback()
+    setPersistedAlgorithm(newAlgo)
     setSearchParams(newAlgo ? { algo: newAlgo } : {})
   }
 
@@ -555,6 +606,7 @@ export default function Visualizer() {
                         onChange={(e) => {
                           setAlgorithmType(e.target.value)
                           clearPlayback()
+                          setPersistedAlgorithm('')
                           setSearchParams({})
                         }}
                         disabled={isRunning}

--- a/src/components/visualizer/useStepPlayback.js
+++ b/src/components/visualizer/useStepPlayback.js
@@ -7,10 +7,24 @@ import {
 } from 'react'
 import { calculateStepDelay } from '../../lib/utils'
 
-export function useStepPlayback({ speed = 1 }) {
-  const [steps, setSteps] = useState([])
-  const [currentStepIndex, setCurrentStepIndex] = useState(-1)
-  const [isPlaying, setIsPlaying] = useState(false)
+const DEFAULT_PLAYBACK_STATE = {
+  steps: [],
+  currentStepIndex: -1,
+  isPlaying: false,
+}
+
+export function useStepPlayback({
+  speed = 1,
+  initialState = DEFAULT_PLAYBACK_STATE,
+  onStateChange,
+}) {
+  const [steps, setSteps] = useState(() => initialState.steps ?? [])
+  const [currentStepIndex, setCurrentStepIndex] = useState(
+    () => initialState.currentStepIndex ?? -1
+  )
+  const [isPlaying, setIsPlaying] = useState(
+    () => initialState.isPlaying ?? false
+  )
   const timeoutRef = useRef(null)
 
   const currentStep =
@@ -20,6 +34,10 @@ export function useStepPlayback({ speed = 1 }) {
 
   const hasSteps = steps.length > 0
   const isComplete = hasSteps && currentStepIndex === steps.length - 1
+
+  useEffect(() => {
+    onStateChange?.({ steps, currentStepIndex, isPlaying })
+  }, [currentStepIndex, isPlaying, onStateChange, steps])
 
   useEffect(() => {
     if (!isPlaying || !hasSteps || currentStepIndex < 0) {

--- a/src/context/useVisualizationState.js
+++ b/src/context/useVisualizationState.js
@@ -1,0 +1,30 @@
+import { useCallback, useContext, useState } from 'react'
+import { VisualizationStateContext } from './visualizationStateContext'
+
+export const useVisualizationState = (key, initialValue) => {
+  const context = useContext(VisualizationStateContext)
+
+  if (!context) {
+    throw new Error(
+      'useVisualizationState must be used inside VisualizationStateProvider'
+    )
+  }
+
+  const [state, setLocalState] = useState(() =>
+    context.getState(key, initialValue)
+  )
+
+  const setPersistentState = useCallback(
+    (value) => {
+      setLocalState((currentValue) => {
+        const nextValue =
+          typeof value === 'function' ? value(currentValue) : value
+        context.setState(key, nextValue)
+        return nextValue
+      })
+    },
+    [context, key]
+  )
+
+  return [state, setPersistentState]
+}

--- a/src/context/visualizationState.jsx
+++ b/src/context/visualizationState.jsx
@@ -1,0 +1,30 @@
+import { useCallback, useRef } from 'react'
+import { VisualizationStateContext } from './visualizationStateContext'
+
+export const VisualizationStateProvider = ({ children }) => {
+  const storeRef = useRef(new Map())
+
+  const getState = useCallback((key, initialValue) => {
+    if (!storeRef.current.has(key)) {
+      storeRef.current.set(
+        key,
+        typeof initialValue === 'function' ? initialValue() : initialValue
+      )
+    }
+
+    return storeRef.current.get(key)
+  }, [])
+
+  const setState = useCallback((key, value) => {
+    const nextValue =
+      typeof value === 'function' ? value(storeRef.current.get(key)) : value
+    storeRef.current.set(key, nextValue)
+    return nextValue
+  }, [])
+
+  return (
+    <VisualizationStateContext.Provider value={{ getState, setState }}>
+      {children}
+    </VisualizationStateContext.Provider>
+  )
+}

--- a/src/context/visualizationStateContext.js
+++ b/src/context/visualizationStateContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const VisualizationStateContext = createContext(null)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import './input.css'
 import App from './App.jsx'
 import { ThemeProvider } from './context/ThemeProvider.jsx'
+import { VisualizationStateProvider } from './context/visualizationState.jsx'
 import { ClerkProvider } from '@clerk/clerk-react'
 import { simple } from '@clerk/themes'
 
@@ -176,7 +177,9 @@ if (PUBLISHABLE_KEY) {
         }}
       >
         <ThemeProvider>
-          <App />
+          <VisualizationStateProvider>
+            <App />
+          </VisualizationStateProvider>
         </ThemeProvider>
       </ClerkProvider>
     </StrictMode>
@@ -185,7 +188,9 @@ if (PUBLISHABLE_KEY) {
   createRoot(document.getElementById('root')).render(
     <StrictMode>
       <ThemeProvider>
-        <App />
+        <VisualizationStateProvider>
+          <App />
+        </VisualizationStateProvider>
       </ThemeProvider>
     </StrictMode>
   )


### PR DESCRIPTION
## Related Issue

Closes #653

## Summary

Fixed an issue where visualization progress was lost when users navigated between algorithm modules.

## Changes Made

* Added visualization state persistence
* Preserved animation progress
* Preserved selected algorithm settings
* Improved user experience during module navigation

## Testing

* Tested navigation between modules
* Verified state restoration
* Verified build and lint checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visualization settings (algorithm selection, speed, custom inputs) and playback state are now persisted across navigations.

* **Refactor**
  * Algorithm visualizers updated to use a unified state management system for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->