### PR TITLE
feat: add monotonic stack visualizer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,9 @@ const SlidingWindowVisualizerPage = lazy(
 const TwoPointerVisualizerPage = lazy(
   () => import('./components/twoPointer/TwoPointerVisualizer')
 )
+const StackVisualizerPage = lazy(
+  () => import('./components/monotonicStack/StackVisualizerPage')
+)
 const PracticePage = lazy(() => import('./components/PracticePage'))
 const AboutAlgoScope = lazy(() => import('./components/about/About'))
 const Favorites = lazy(() => import('./components/Favorites'))
@@ -259,6 +262,14 @@ const router = createBrowserRouter([
     element: (
       <AppLayout notesKey="algo-notes-string-algorithms">
         <StringAlgoVisualizerPage />
+      </AppLayout>
+    ),
+  },
+  {
+    path: '/monotonic-stack',
+    element: (
+      <AppLayout notesKey="algo-notes-stack">
+        <StackVisualizerPage />
       </AppLayout>
     ),
   },

--- a/src/algorithms/monotonicStack/largestRectangleSteps.js
+++ b/src/algorithms/monotonicStack/largestRectangleSteps.js
@@ -212,6 +212,22 @@ export function resolveLargestRectangleLine(language, lineKey) {
 }
 
 export function generateLargestRectangleSteps(inputArray) {
+  if (!inputArray || inputArray.length === 0) {
+    return [
+      createStep({
+        lineKey: 'function',
+        type: 'start',
+        array: [],
+        stack: [],
+        message: 'Empty input provided.',
+        variables: { n: 0, maxArea: 0 },
+        duration: 700,
+      }),
+    ]
+  }
+  if (inputArray.some((h) => typeof h !== 'number' || h < 0)) {
+    throw new Error('All heights must be non-negative numbers')
+  }
   const heights = [...inputArray]
   const steps = []
   const n = heights.length

--- a/src/algorithms/monotonicStack/largestRectangleSteps.js
+++ b/src/algorithms/monotonicStack/largestRectangleSteps.js
@@ -1,0 +1,334 @@
+import { createStep } from '../../lib/utils'
+
+export const largestRectangleSources = {
+  javascript: {
+    code: `function largestRectangleArea(heights) {
+  let maxArea = 0;
+  const stack = [];
+  const n = heights.length;
+
+  for (let i = 0; i <= n; i++) {
+    while (stack.length > 0 && (i === n || heights[i] < heights[stack[stack.length - 1]])) {
+      const h = heights[stack.pop()];
+      const w = stack.length === 0 ? i : i - stack[stack.length - 1] - 1;
+      maxArea = Math.max(maxArea, h * w);
+    }
+    if (i < n) stack.push(i);
+  }
+  return maxArea;
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 10,
+      push: 12,
+      complete: 14,
+    },
+  },
+  python: {
+    code: `def largestRectangleArea(heights):
+    maxArea = 0
+    stack = []
+    n = len(heights)
+
+    for i in range(n + 1):
+        while stack and (i == n or heights[i] < heights[stack[-1]]):
+            h = heights[stack.pop()]
+            w = i if not stack else i - stack[-1] - 1
+            maxArea = max(maxArea, h * w)
+        if i < n: stack.append(i)
+        
+    return maxArea`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 10,
+      push: 11,
+      complete: 13,
+    },
+  },
+  java: {
+    code: `public int largestRectangleArea(int[] heights) {
+    int maxArea = 0;
+    Stack<Integer> stack = new Stack<>();
+    int n = heights.length;
+
+    for (int i = 0; i <= n; i++) {
+        while (!stack.isEmpty() && (i == n || heights[i] < heights[stack.peek()])) {
+            int h = heights[stack.pop()];
+            int w = stack.isEmpty() ? i : i - stack.peek() - 1;
+            maxArea = Math.max(maxArea, h * w);
+        }
+        if (i < n) stack.push(i);
+    }
+    return maxArea;
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 10,
+      push: 12,
+      complete: 14,
+    },
+  },
+  cpp: {
+    code: `int largestRectangleArea(vector<int>& heights) {
+    int maxArea = 0;
+    stack<int> st;
+    int n = heights.size();
+
+    for (int i = 0; i <= n; i++) {
+        while (!st.empty() && (i == n || heights[i] < heights[st.top()])) {
+            int h = heights[st.top()]; 
+            st.pop();
+            int w = st.empty() ? i : i - st.top() - 1;
+            maxArea = max(maxArea, h * w);
+        }
+        if (i < n) st.push(i);
+    }
+    return maxArea;
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 11,
+      push: 13,
+      complete: 15,
+    },
+  },
+  c: {
+    code: `int largestRectangleArea(int* heights, int heightsSize) {
+    int maxArea = 0;
+    int* stack = (int*)malloc((heightsSize + 1) * sizeof(int));
+    int top = -1;
+
+    for (int i = 0; i <= heightsSize; i++) {
+        while (top >= 0 && (i == heightsSize || heights[i] < heights[stack[top]])) {
+            int h = heights[stack[top--]];
+            int w = (top == -1) ? i : i - stack[top] - 1;
+            if (h * w > maxArea) maxArea = h * w;
+        }
+        if (i < heightsSize) stack[++top] = i;
+    }
+    free(stack);
+    return maxArea;
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 10,
+      push: 12,
+      complete: 15,
+    },
+  },
+  go: {
+    code: `func largestRectangleArea(heights []int) int {
+    maxArea := 0
+    stack := []int{}
+    n := len(heights)
+
+    for i := 0; i <= n; i++ {
+        for len(stack) > 0 && (i == n || heights[i] < heights[stack[len(stack)-1]]) {
+            topIdx := stack[len(stack)-1]
+            stack = stack[:len(stack)-1]
+            h := heights[topIdx]
+            
+            w := i
+            if len(stack) > 0 { w = i - stack[len(stack)-1] - 1 }
+            
+            if h * w > maxArea { maxArea = h * w }
+        }
+        if i < n { stack = append(stack, i) }
+    }
+    return maxArea
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 15,
+      push: 17,
+      complete: 19,
+    },
+  },
+  rust: {
+    code: `pub fn largest_rectangle_area(heights: Vec<i32>) -> i32 {
+    let mut max_area = 0;
+    let mut stack: Vec<usize> = Vec::new();
+    let n = heights.len();
+
+    for i in 0..=n {
+        while !stack.is_empty() && (i == n || heights[i] < heights[*stack.last().unwrap()]) {
+            let h = heights[stack.pop().unwrap()];
+            let w = if stack.is_empty() { i } else { i - stack.last().unwrap() - 1 };
+            max_area = max_area.max(h * w as i32);
+        }
+        if i < n { stack.push(i); }
+    }
+    max_area
+}`,
+    lineMap: {
+      function: 1,
+      setup: 2,
+      outerLoop: 6,
+      whileLoop: 7,
+      popAndCalc: 8,
+      updateMax: 10,
+      push: 12,
+      complete: 14,
+    },
+  },
+}
+
+export function getLargestRectangleSource(language = 'javascript') {
+  const lang = language.toLowerCase()
+  return largestRectangleSources[lang] ?? largestRectangleSources.javascript
+}
+
+export function resolveLargestRectangleLine(language, lineKey) {
+  if (!lineKey) return undefined
+  const source = getLargestRectangleSource(language)
+  return (
+    source.lineMap[lineKey] ??
+    largestRectangleSources.javascript.lineMap[lineKey]
+  )
+}
+
+export function generateLargestRectangleSteps(inputArray) {
+  const heights = [...inputArray]
+  const steps = []
+  const n = heights.length
+
+  const stack = []
+  let maxArea = 0
+
+  steps.push(
+    createStep({
+      lineKey: 'function',
+      type: 'start',
+      array: heights,
+      stack: [...stack],
+      message: 'Largest Rectangle in Histogram starts.',
+      variables: { n, maxArea },
+      duration: 700,
+    })
+  )
+
+  for (let i = 0; i <= n; i++) {
+    const currentHeight = i === n ? 0 : heights[i]
+
+    steps.push(
+      createStep({
+        lineKey: 'outerLoop',
+        type: 'outer-loop',
+        array: heights,
+        stack: [...stack],
+        indices: i < n ? [i] : [],
+        message:
+          i === n
+            ? 'Reached end of array. Flushing remaining stack.'
+            : `Process bar at index ${i} (height: ${currentHeight}).`,
+        variables: { i, maxArea },
+        duration: 600,
+      })
+    )
+
+    while (
+      stack.length > 0 &&
+      (i === n || currentHeight < heights[stack[stack.length - 1]])
+    ) {
+      steps.push(
+        createStep({
+          lineKey: 'whileLoop',
+          type: 'compare',
+          array: heights,
+          stack: [...stack],
+          indices: [i, stack[stack.length - 1]],
+          message: `Current height ${currentHeight} < stack top ${heights[stack[stack.length - 1]]}. Monotonic property broken.`,
+          variables: { i, maxArea },
+          duration: 700,
+        })
+      )
+
+      const topIndex = stack.pop()
+      const h = heights[topIndex]
+      const w = stack.length === 0 ? i : i - stack[stack.length - 1] - 1
+      const area = h * w
+
+      steps.push(
+        createStep({
+          lineKey: 'popAndCalc',
+          type: 'calculate',
+          array: heights,
+          stack: [...stack],
+          indices: [topIndex],
+          message: `Pop index ${topIndex}. Height = ${h}, Width = ${w}, Area = ${area}.`,
+          variables: { i, h, w, area, maxArea },
+          duration: 850,
+        })
+      )
+
+      if (area > maxArea) {
+        maxArea = area
+        steps.push(
+          createStep({
+            lineKey: 'updateMax',
+            type: 'update',
+            array: heights,
+            stack: [...stack],
+            message: `New Max Area found: ${maxArea}!`,
+            variables: { i, maxArea },
+            duration: 800,
+          })
+        )
+      }
+    }
+
+    if (i < n) {
+      stack.push(i)
+      steps.push(
+        createStep({
+          lineKey: 'push',
+          type: 'push',
+          array: heights,
+          stack: [...stack],
+          indices: [i],
+          message: `Push index ${i} to stack. Stack is monotonically increasing.`,
+          variables: { i, maxArea },
+          duration: 650,
+        })
+      )
+    }
+  }
+
+  steps.push(
+    createStep({
+      lineKey: 'complete',
+      type: 'complete',
+      array: heights,
+      stack: [...stack],
+      message: `Finished! Maximum Rectangle Area is ${maxArea}.`,
+      variables: { maxArea },
+      duration: 900,
+    })
+  )
+
+  return steps
+}

--- a/src/algorithms/monotonicStack/maximalRectangleSteps.js
+++ b/src/algorithms/monotonicStack/maximalRectangleSteps.js
@@ -1,0 +1,442 @@
+import { createStep } from '../../lib/utils'
+
+export const maximalRectangleSources = {
+  javascript: {
+    code: `function maximalRectangle(matrix) {
+  if (matrix.length === 0) return 0;
+  let maxArea = 0;
+  const cols = matrix[0].length;
+  const heights = new Array(cols).fill(0);
+
+  for (let row = 0; row < matrix.length; row++) {
+    for (let col = 0; col < cols; col++) {
+      heights[col] = matrix[row][col] === '1' ? heights[col] + 1 : 0;
+    }
+
+    const stack = [];
+    for (let i = 0; i <= cols; i++) {
+      while (stack.length > 0 && (i === cols || heights[i] < heights[stack[stack.length - 1]])) {
+        const h = heights[stack.pop()];
+        const w = stack.length === 0 ? i : i - stack[stack.length - 1] - 1;
+        maxArea = Math.max(maxArea, h * w);
+      }
+      if (i < cols) stack.push(i);
+    }
+  }
+  return maxArea;
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 6,
+      updateHeights: 8,
+      stackSetup: 11,
+      stackLoop: 12,
+      whileLoop: 13,
+      popAndCalc: 14,
+      updateMax: 16,
+      push: 18,
+      complete: 21,
+    },
+  },
+  python: {
+    code: `def maximalRectangle(matrix):
+    if not matrix: return 0
+    maxArea = 0
+    cols = len(matrix[0])
+    heights = [0] * cols
+
+    for row in range(len(matrix)):
+        for col in range(cols):
+            heights[col] = heights[col] + 1 if matrix[row][col] == '1' else 0
+
+        stack = []
+        for i in range(cols + 1):
+            while stack and (i == cols or heights[i] < heights[stack[-1]]):
+                h = heights[stack.pop()]
+                w = i if not stack else i - stack[-1] - 1
+                maxArea = max(maxArea, h * w)
+            if i < cols: stack.append(i)
+            
+    return maxArea`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 11,
+      stackLoop: 12,
+      whileLoop: 13,
+      popAndCalc: 14,
+      updateMax: 16,
+      push: 17,
+      complete: 19,
+    },
+  },
+  java: {
+    code: `public int maximalRectangle(char[][] matrix) {
+    if (matrix.length == 0) return 0;
+    int maxArea = 0;
+    int cols = matrix[0].length;
+    int[] heights = new int[cols];
+
+    for (int row = 0; row < matrix.length; row++) {
+        for (int col = 0; col < cols; col++) {
+            heights[col] = matrix[row][col] == '1' ? heights[col] + 1 : 0;
+        }
+
+        Stack<Integer> stack = new Stack<>();
+        for (int i = 0; i <= cols; i++) {
+            while (!stack.isEmpty() && (i == cols || heights[i] < heights[stack.peek()])) {
+                int h = heights[stack.pop()];
+                int w = stack.isEmpty() ? i : i - stack.peek() - 1;
+                maxArea = Math.max(maxArea, h * w);
+            }
+            if (i < cols) stack.push(i);
+        }
+    }
+    return maxArea;
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 12,
+      stackLoop: 13,
+      whileLoop: 14,
+      popAndCalc: 15,
+      updateMax: 17,
+      push: 19,
+      complete: 22,
+    },
+  },
+  cpp: {
+    code: `int maximalRectangle(vector<vector<char>>& matrix) {
+    if (matrix.empty()) return 0;
+    int maxArea = 0;
+    int cols = matrix[0].size();
+    vector<int> heights(cols, 0);
+
+    for (int row = 0; row < matrix.size(); row++) {
+        for (int col = 0; col < cols; col++) {
+            heights[col] = matrix[row][col] == '1' ? heights[col] + 1 : 0;
+        }
+
+        stack<int> st;
+        for (int i = 0; i <= cols; i++) {
+            while (!st.empty() && (i == cols || heights[i] < heights[st.top()])) {
+                int h = heights[st.top()]; 
+                st.pop();
+                int w = st.empty() ? i : i - st.top() - 1;
+                maxArea = max(maxArea, h * w);
+            }
+            if (i < cols) st.push(i);
+        }
+    }
+    return maxArea;
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 12,
+      stackLoop: 13,
+      whileLoop: 14,
+      popAndCalc: 15,
+      updateMax: 18,
+      push: 20,
+      complete: 23,
+    },
+  },
+  c: {
+    code: `int maximalRectangle(char** matrix, int matrixSize, int* matrixColSize) {
+    if (matrixSize == 0) return 0;
+    int maxArea = 0;
+    int cols = matrixColSize[0];
+    int* heights = (int*)calloc(cols, sizeof(int));
+
+    for (int row = 0; row < matrixSize; row++) {
+        for (int col = 0; col < cols; col++) {
+            heights[col] = matrix[row][col] == '1' ? heights[col] + 1 : 0;
+        }
+
+        int* stack = (int*)malloc((cols + 1) * sizeof(int));
+        int top = -1;
+        for (int i = 0; i <= cols; i++) {
+            while (top >= 0 && (i == cols || heights[i] < heights[stack[top]])) {
+                int h = heights[stack[top--]];
+                int w = (top == -1) ? i : i - stack[top] - 1;
+                if (h * w > maxArea) maxArea = h * w;
+            }
+            if (i < cols) stack[++top] = i;
+        }
+        free(stack);
+    }
+    free(heights);
+    return maxArea;
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 12,
+      stackLoop: 14,
+      whileLoop: 15,
+      popAndCalc: 16,
+      updateMax: 18,
+      push: 20,
+      complete: 25,
+    },
+  },
+  go: {
+    code: `func maximalRectangle(matrix [][]byte) int {
+    if len(matrix) == 0 { return 0 }
+    maxArea := 0
+    cols := len(matrix[0])
+    heights := make([]int, cols)
+
+    for row := 0; row < len(matrix); row++ {
+        for col := 0; col < cols; col++ {
+            if matrix[row][col] == '1' { heights[col]++ } else { heights[col] = 0 }
+        }
+
+        stack := []int{}
+        for i := 0; i <= cols; i++ {
+            for len(stack) > 0 && (i == cols || heights[i] < heights[stack[len(stack)-1]]) {
+                topIdx := stack[len(stack)-1]
+                stack = stack[:len(stack)-1]
+                h := heights[topIdx]
+                
+                w := i
+                if len(stack) > 0 { w = i - stack[len(stack)-1] - 1 }
+                
+                if h * w > maxArea { maxArea = h * w }
+            }
+            if i < cols { stack = append(stack, i) }
+        }
+    }
+    return maxArea
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 12,
+      stackLoop: 13,
+      whileLoop: 14,
+      popAndCalc: 15,
+      updateMax: 20,
+      push: 22,
+      complete: 26,
+    },
+  },
+  rust: {
+    code: `pub fn maximal_rectangle(matrix: Vec<Vec<char>>) -> i32 {
+    if matrix.is_empty() { return 0; }
+    let mut max_area = 0;
+    let cols = matrix[0].len();
+    let mut heights = vec![0; cols];
+
+    for row in 0..matrix.len() {
+        for col in 0..cols {
+            heights[col] = if matrix[row][col] == '1' { heights[col] + 1 } else { 0 };
+        }
+
+        let mut stack: Vec<usize> = Vec::new();
+        for i in 0..=cols {
+            while !stack.is_empty() && (i == cols || heights[i] < heights[*stack.last().unwrap()]) {
+                let h = heights[stack.pop().unwrap()];
+                let w = if stack.is_empty() { i } else { i - stack.last().unwrap() - 1 };
+                max_area = max_area.max(h * w as i32);
+            }
+            if i < cols { stack.push(i); }
+        }
+    }
+    max_area
+}`,
+    lineMap: {
+      setup: 2,
+      rowLoop: 7,
+      updateHeights: 9,
+      stackSetup: 12,
+      stackLoop: 13,
+      whileLoop: 14,
+      popAndCalc: 15,
+      updateMax: 17,
+      push: 19,
+      complete: 23,
+    },
+  },
+}
+
+export function getMaximalRectangleSource(language = 'javascript') {
+  const lang = language.toLowerCase()
+  return maximalRectangleSources[lang] ?? maximalRectangleSources.javascript
+}
+
+export function resolveMaximalRectangleLine(language, lineKey) {
+  if (!lineKey) return undefined
+  const source = getMaximalRectangleSource(language)
+  return (
+    source.lineMap[lineKey] ??
+    maximalRectangleSources.javascript.lineMap[lineKey]
+  )
+}
+
+export function generateMaximalRectangleSteps(matrixInput) {
+  const steps = []
+  if (!matrixInput || matrixInput.length === 0) return steps
+
+  const matrix = matrixInput.map((row) => row.map((val) => String(val)))
+  const rows = matrix.length
+  const cols = matrix[0].length
+  const heights = new Array(cols).fill(0)
+  let maxArea = 0
+
+  steps.push(
+    createStep({
+      lineKey: 'setup',
+      type: 'start',
+      matrix,
+      currentRow: -1,
+      array: [...heights],
+      stack: [],
+      message: 'Starting Maximal Rectangle. Initializing empty heights array.',
+      variables: { rows, cols, maxArea },
+      duration: 800,
+    })
+  )
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      heights[col] = matrix[row][col] === '1' ? heights[col] + 1 : 0
+    }
+
+    steps.push(
+      createStep({
+        lineKey: 'updateHeights',
+        type: 'active',
+        matrix,
+        currentRow: row,
+        array: [...heights],
+        stack: [],
+        message: `Row ${row}: Updated heights array. Cells with '0' reset height to 0.`,
+        variables: { row, maxArea },
+        duration: 1000,
+      })
+    )
+
+    const stack = []
+
+    for (let i = 0; i <= cols; i++) {
+      const currentHeight = i === cols ? 0 : heights[i]
+
+      steps.push(
+        createStep({
+          lineKey: 'stackLoop',
+          type: 'outer-loop',
+          matrix,
+          currentRow: row,
+          array: [...heights],
+          stack: [...stack],
+          indices: i < cols ? [i] : [],
+          message:
+            i === cols
+              ? `Row ${row} ended. Flushing remaining stack.`
+              : `Row ${row}: Process column ${i} (height: ${currentHeight}).`,
+          variables: { row, col: i, maxArea },
+          duration: 600,
+        })
+      )
+
+      while (
+        stack.length > 0 &&
+        (i === cols || currentHeight < heights[stack[stack.length - 1]])
+      ) {
+        steps.push(
+          createStep({
+            lineKey: 'whileLoop',
+            type: 'compare',
+            matrix,
+            currentRow: row,
+            array: [...heights],
+            stack: [...stack],
+            indices: [i, stack[stack.length - 1]],
+            message: `Height ${currentHeight} < stack top ${heights[stack[stack.length - 1]]}. Monotonic property broken.`,
+            variables: { row, col: i, maxArea },
+            duration: 700,
+          })
+        )
+
+        const topIndex = stack.pop()
+        const h = heights[topIndex]
+        const w = stack.length === 0 ? i : i - stack[stack.length - 1] - 1
+        const area = h * w
+
+        steps.push(
+          createStep({
+            lineKey: 'popAndCalc',
+            type: 'calculate',
+            matrix,
+            currentRow: row,
+            array: [...heights],
+            stack: [...stack],
+            indices: [topIndex],
+            message: `Pop col ${topIndex}. Height = ${h}, Width = ${w}, Area = ${area}.`,
+            variables: { row, h, w, area, maxArea },
+            duration: 850,
+          })
+        )
+
+        if (area > maxArea) {
+          maxArea = area
+          steps.push(
+            createStep({
+              lineKey: 'updateMax',
+              type: 'update',
+              matrix,
+              currentRow: row,
+              array: [...heights],
+              stack: [...stack],
+              message: `New Max Area found: ${maxArea}!`,
+              variables: { row, maxArea },
+              duration: 800,
+            })
+          )
+        }
+      }
+
+      if (i < cols) {
+        stack.push(i)
+        steps.push(
+          createStep({
+            lineKey: 'push',
+            type: 'push',
+            matrix,
+            currentRow: row,
+            array: [...heights],
+            stack: [...stack],
+            indices: [i],
+            message: `Push col ${i} to stack.`,
+            variables: { row, maxArea },
+            duration: 650,
+          })
+        )
+      }
+    }
+  }
+
+  steps.push(
+    createStep({
+      lineKey: 'complete',
+      type: 'complete',
+      matrix,
+      currentRow: -1,
+      array: [...heights],
+      stack: [],
+      message: `Finished! Maximal Rectangle Area is ${maxArea}.`,
+      variables: { maxArea },
+      duration: 900,
+    })
+  )
+
+  return steps
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -124,12 +124,6 @@ const algorithmLinks = [
     href: '/dp-journey',
     difficulty: 'Advanced',
   },
-  { name: 'Practice Sandbox', href: '/practice', difficulty: 'Intermediate' },
-  {
-    name: 'Guess the Algorithm',
-    href: '/challenge',
-    difficulty: 'Intermediate',
-  },
   {
     name: 'Sliding Window',
     href: '/sliding-window',
@@ -139,6 +133,17 @@ const algorithmLinks = [
     name: 'Two Pointer Approach',
     href: '/two-pointer',
     difficulty: 'Advanced',
+  },
+  {
+    name: 'Monotonic Stack',
+    href: '/monotonic-stack',
+    difficulty: 'Advanced',
+  },
+  { name: 'Practice Sandbox', href: '/practice', difficulty: 'Intermediate' },
+  {
+    name: 'Guess the Algorithm',
+    href: '/challenge',
+    difficulty: 'Intermediate',
   },
 ]
 

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -206,6 +206,22 @@ const ALGORITHMS = [
     route: '/adt?type=stack',
   },
   {
+    id: 'monotonic-stack',
+    name: 'Monotonic Stack',
+    category: 'Data Structures',
+    route: '/monotonic-stack',
+    keywords: [
+      'monotonic stack',
+      'stack',
+      'largest rectangle in histogram',
+      'histogram',
+      'rectangle',
+      'maximal rectangle',
+      '2d-matrix mode',
+      '2d matrix',
+    ],
+  },
+  {
     id: 'queue',
     name: 'Queue',
     category: 'Data Structures',

--- a/src/components/monotonicStack/StackVisualizer.jsx
+++ b/src/components/monotonicStack/StackVisualizer.jsx
@@ -1,0 +1,556 @@
+import React, { useState, useMemo } from 'react'
+import SpeedSlider from '../SpeedSlider.jsx'
+import CodePanel from '../visualizer/CodePanel'
+import { useStepPlayback } from '../visualizer/useStepPlayback'
+import ComplexityCard from '../ComplexityCard'
+import Tooltip from '../Tooltip'
+import TestCaseManager from '../testCaseManager/TestCaseManager'
+import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
+import ComplexityGraph from '../ComplexityGraph'
+
+import * as largestRectangle from '../../algorithms/monotonicStack/largestRectangleSteps'
+import * as maximalRectangle from '../../algorithms/monotonicStack/maximalRectangleSteps'
+
+const STATE_COLORS = {
+  compare: { bg: '#2563eb', border: '#60a5fa' },
+  calculate: { bg: '#f59e0b', border: '#d97706' },
+  push: { bg: '#8b5cf6', border: '#7c3aed' },
+  active: { bg: '#10b981', border: '#059669' },
+}
+
+const STATE_STYLE_PRESETS = {
+  compare: {
+    bar: {
+      boxShadow: '0 0 18px rgba(59, 130, 246, 0.55)',
+      transform: 'translateY(-4px)',
+    },
+  },
+  calculate: { bar: { boxShadow: '0 0 15px rgba(245, 158, 11, 0.45)' } },
+  push: { bar: { boxShadow: '0 0 15px rgba(139, 92, 246, 0.5)' } },
+  active: { bar: { boxShadow: '0 0 15px rgba(16, 185, 129, 0.5)' } },
+}
+
+const SAMPLE_CASES = {
+  histogram: [
+    { name: 'Classic Peak', algorithm: 'histogram', input: '2, 1, 5, 6, 2, 3' },
+    {
+      name: 'Strictly Increasing',
+      algorithm: 'histogram',
+      input: '1, 2, 3, 4, 5',
+    },
+    {
+      name: 'Strictly Decreasing',
+      algorithm: 'histogram',
+      input: '5, 4, 3, 2, 1',
+    },
+  ],
+  matrix: [
+    {
+      name: 'Classic Matrix',
+      algorithm: 'matrix',
+      input: '10100\n10111\n11111\n10010',
+    },
+    { name: 'Solid Block', algorithm: 'matrix', input: '111\n111\n111' },
+    { name: 'Checkerboard', algorithm: 'matrix', input: '101\n010\n101' },
+  ],
+}
+
+export default function StackVisualizer() {
+  const [mode, setMode] = useState('histogram')
+  const [speed, setSpeed] = useState(1)
+  const [language, setLanguage] = useState('javascript')
+  const [isStepMode, setIsStepMode] = useState(false)
+  const [customInput, setCustomInput] = useState('')
+  const [inputError, setInputError] = useState('')
+
+  const [baseArray, setBaseArray] = useState([2, 1, 5, 6, 2, 3])
+  const [baseMatrix, setBaseMatrix] = useState([
+    ['1', '0', '1', '0', '0'],
+    ['1', '0', '1', '1', '1'],
+    ['1', '1', '1', '1', '1'],
+    ['1', '0', '0', '1', '0'],
+  ])
+
+  const {
+    currentStep,
+    currentStepIndex,
+    steps,
+    hasSteps,
+    isComplete,
+    isPlaying,
+    loadSteps,
+    clear: clearPlayback,
+    pause: pausePlayback,
+    play: playPlayback,
+    replay: replayPlayback,
+    stepForward,
+    stepBackward,
+  } = useStepPlayback({ speed })
+
+  const handleModeSwitch = (newMode) => {
+    if (newMode === mode) return
+    setMode(newMode)
+    clearPlayback()
+    setCustomInput('')
+    setInputError('')
+  }
+
+  const handleVisualize = () => {
+    clearPlayback()
+    if (mode === 'histogram') {
+      loadSteps(largestRectangle.generateLargestRectangleSteps(baseArray), {
+        autoPlay: !isStepMode,
+      })
+    } else {
+      loadSteps(maximalRectangle.generateMaximalRectangleSteps(baseMatrix), {
+        autoPlay: !isStepMode,
+      })
+    }
+  }
+
+  const handleReset = () => {
+    clearPlayback()
+    setBaseArray([2, 1, 5, 6, 2, 3])
+    setBaseMatrix([
+      ['1', '0', '1', '0', '0'],
+      ['1', '0', '1', '1', '1'],
+      ['1', '1', '1', '1', '1'],
+      ['1', '0', '0', '1', '0'],
+    ])
+    setCustomInput('')
+    setInputError('')
+    setIsStepMode(false)
+  }
+
+  useKeyboardShortcuts({
+    onPlayPause: () => {
+      if (isPlaying) pausePlayback()
+      else if (hasSteps && !isComplete) playPlayback()
+    },
+    onStepForward: () => {
+      if (!isPlaying && !isComplete && hasSteps) stepForward()
+    },
+    onStepBackward: () => {
+      if (!isPlaying && currentStepIndex > 0) stepBackward()
+    },
+    onReset: handleReset,
+    onSpeedUp: () => setSpeed((s) => Math.min(3, +(s + 0.25).toFixed(2))),
+    onSlowDown: () => setSpeed((s) => Math.max(0.25, +(s - 0.25).toFixed(2))),
+  })
+
+  const handleApplyCustomInput = () => {
+    setInputError('')
+    const input = customInput.trim()
+    if (!input) return setInputError('Please enter some data.')
+
+    if (mode === 'histogram') {
+      const parts = input
+        .replace(/\[|\]/g, '')
+        .split(/[\s,]+/)
+        .filter(Boolean)
+      const parsedNumbers = parts.map(Number)
+      if (parsedNumbers.some(Number.isNaN))
+        return setInputError('Invalid input. Numbers only.')
+      if (parsedNumbers.length > 50)
+        return setInputError('Limit to 50 numbers.')
+      setBaseArray(parsedNumbers)
+    } else {
+      const rows = input.split('\n').filter((r) => r.trim() !== '')
+      const parsedMatrix = rows.map((r) => r.trim().split(''))
+      const colCount = parsedMatrix[0].length
+      if (parsedMatrix.some((r) => r.length !== colCount))
+        return setInputError('All rows must have the same length.')
+      if (parsedMatrix.some((r) => r.some((val) => val !== '0' && val !== '1')))
+        return setInputError('Matrix must only contain 0s and 1s.')
+      setBaseMatrix(parsedMatrix)
+    }
+    clearPlayback()
+  }
+
+  const isRunning = isPlaying
+  const activeIndices = currentStep?.indices ?? []
+  const currentStack = currentStep?.stack ?? []
+
+  const visualMatrix =
+    mode === 'matrix' ? (currentStep?.matrix ?? baseMatrix) : null
+  const currentRow = currentStep?.currentRow ?? -1
+  const visualArray =
+    mode === 'histogram'
+      ? (currentStep?.array ?? baseArray)
+      : (currentStep?.array ?? new Array(baseMatrix[0].length).fill(0))
+
+  const maxVal =
+    mode === 'histogram'
+      ? Math.max(...visualArray, 1)
+      : Math.max(visualMatrix.length, 1)
+  const MAX_BAR_HEIGHT = mode === 'matrix' ? 140 : 180
+
+  const currentAlgoSource = useMemo(() => {
+    return mode === 'histogram'
+      ? largestRectangle.getLargestRectangleSource(language)
+      : maximalRectangle.getMaximalRectangleSource(language)
+  }, [mode, language])
+
+  const activeLine = useMemo(() => {
+    if (!currentStep?.lineKey) return undefined
+    return mode === 'histogram'
+      ? largestRectangle.resolveLargestRectangleLine(
+          language,
+          currentStep.lineKey
+        )
+      : maximalRectangle.resolveMaximalRectangleLine(
+          language,
+          currentStep.lineKey
+        )
+  }, [mode, currentStep, language])
+
+  const getStateClass = (index) => {
+    if (!hasSteps) return ''
+    if (activeIndices.includes(index)) {
+      if (currentStep?.type === 'calculate') return 'calculate'
+      if (currentStep?.type === 'push') return 'push'
+      if (currentStep?.type === 'compare') return 'compare'
+      return 'active'
+    }
+    return ''
+  }
+
+  const getBarStyle = (index, value) => {
+    const scaledHeight = (value / maxVal) * MAX_BAR_HEIGHT
+    const stateClass = getStateClass(index)
+    const color = stateClass ? STATE_COLORS[stateClass] : null
+    const preset = stateClass ? STATE_STYLE_PRESETS[stateClass]?.bar : {}
+    return {
+      height: `${scaledHeight === 0 ? 4 : scaledHeight}px`,
+      background: color ? color.bg : 'rgba(6, 182, 212, 0.8)',
+      borderColor: color ? color.border : undefined,
+      ...preset,
+    }
+  }
+
+  return (
+    <div className="flex flex-col p-2 sm:p-4 lg:p-5">
+      <div className="w-full flex flex-col items-center">
+        <div className="grid w-full gap-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(340px,0.7fr)] overflow-hidden">
+          {/* LEFT COLUMN */}
+          <div className="flex min-w-0 min-h-0 flex-col gap-4">
+            {/* Main Visualizer Panel */}
+            <div className="rounded-2xl border border-slate-700/80 bg-slate-900/55 p-3 sm:p-4 shadow-xl flex flex-col gap-4">
+              <div className="flex items-center justify-between gap-3">
+                <h3 className="text-base font-semibold text-slate-200">
+                  {mode === 'histogram'
+                    ? 'Largest Rectangle in Histogram'
+                    : 'Maximal Rectangle'}
+                </h3>
+                <div className="rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs font-medium text-cyan-200">
+                  {currentStep?.type
+                    ? currentStep.type.replace('-', ' ')
+                    : 'Ready'}
+                </div>
+              </div>
+
+              {/* Mode Toggle Switch */}
+              <div className="flex bg-slate-950/80 rounded-xl p-1 border border-slate-700/80 w-full mb-2 shadow-inner">
+                <button
+                  onClick={() => handleModeSwitch('histogram')}
+                  className={`flex-1 py-2.5 text-xs sm:text-sm font-semibold rounded-lg transition-all duration-300 ${mode === 'histogram' ? 'bg-cyan-600 text-white shadow-md' : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'}`}
+                >
+                  1D Histogram Mode
+                </button>
+                <button
+                  onClick={() => handleModeSwitch('matrix')}
+                  className={`flex-1 py-2.5 text-xs sm:text-sm font-semibold rounded-lg transition-all duration-300 ${mode === 'matrix' ? 'bg-cyan-600 text-white shadow-md' : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800'}`}
+                >
+                  2D Matrix Mode
+                </button>
+              </div>
+
+              {/* Conditionally Render 2D Matrix */}
+              {mode === 'matrix' && (
+                <div className="flex flex-col items-center justify-center p-4 rounded-xl border border-slate-700/50 bg-slate-800/30">
+                  <p className="text-[10px] uppercase tracking-widest text-slate-400 mb-2">
+                    Binary Matrix
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    {visualMatrix.map((row, rIdx) => (
+                      <div key={rIdx} className="flex gap-1">
+                        {row.map((cell, cIdx) => (
+                          <div
+                            key={`${rIdx}-${cIdx}`}
+                            className={`w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center font-mono text-sm sm:text-base rounded-md border transition-all duration-300 ${
+                              currentRow === rIdx
+                                ? 'bg-cyan-900/60 border-cyan-400 text-cyan-100 shadow-[0_0_10px_rgba(6,182,212,0.3)]'
+                                : cell === '1'
+                                  ? 'bg-slate-700 border-slate-500 text-slate-200'
+                                  : 'bg-slate-900 border-slate-800 text-slate-600'
+                            }`}
+                          >
+                            {cell}
+                          </div>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div
+                className={`flex gap-4 ${mode === 'matrix' ? 'h-[180px] lg:h-[200px]' : 'h-[250px] lg:h-[280px]'}`}
+              >
+                <div
+                  id="container"
+                  className="flex-1 flex items-end justify-center gap-1.5 sm:gap-2 overflow-hidden rounded-2xl border border-slate-700 p-2 sm:p-4 bg-slate-800/40"
+                >
+                  {visualArray.map((val, idx) => (
+                    <div
+                      key={idx}
+                      className={`bar flex-1 max-w-[42px] rounded-t-md transition-all duration-500 border border-cyan-900/50 shadow-[0_0_10px_rgba(6,182,212,0.2)] w-6 sm:w-8 ${getStateClass(idx)}`}
+                      style={getBarStyle(idx, val)}
+                    >
+                      <div className="bar-val text-xs text-white text-center pb-1">
+                        {val}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="w-24 sm:w-32 flex flex-col rounded-2xl border border-slate-700 p-2 bg-slate-800/40 relative">
+                  <h4 className="text-[10px] sm:text-xs font-semibold text-center text-slate-400 mb-2 uppercase tracking-widest border-b border-slate-700 pb-2">
+                    Stack (Idx)
+                  </h4>
+                  <div className="flex-1 flex flex-col-reverse justify-start items-center gap-1.5 overflow-y-auto custom-scrollbar">
+                    {currentStack.map((stackItem, i) => {
+                      const isTop = i === currentStack.length - 1
+                      return (
+                        <div
+                          key={`${i}-${stackItem}`}
+                          className={`w-full py-1.5 text-center text-sm font-mono rounded shadow-sm transition-all duration-300 ${
+                            isTop
+                              ? 'bg-cyan-600 border-cyan-400 text-white scale-[1.02]'
+                              : 'bg-slate-700 border-slate-600 text-cyan-100'
+                          } border`}
+                        >
+                          {stackItem}
+                        </div>
+                      )
+                    })}
+                    {currentStack.length === 0 && (
+                      <span className="text-xs text-slate-500 my-auto">
+                        Empty
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <ComplexityCard algorithm={mode} />
+            <ComplexityGraph algorithm={mode} />
+            {/* Step Insight & Code Panel */}
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+              <div className="rounded-2xl border border-slate-700/80 bg-slate-900/70 p-4 shadow-xl">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-400/80">
+                  Step Insight
+                </p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-100">
+                  {currentStep?.message ?? 'Select mode and hit Start.'}
+                </h3>
+
+                <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                  <div className="rounded-xl border border-slate-700 bg-slate-950/70 p-3">
+                    <p className="text-[10px] uppercase tracking-[0.2em] text-slate-400">
+                      Max Area Found
+                    </p>
+                    <p className="mt-1 font-mono text-2xl text-emerald-400">
+                      {currentStep?.variables?.maxArea ?? 0}
+                    </p>
+                  </div>
+                  <div className="rounded-xl border border-slate-700 bg-slate-950/70 p-3">
+                    <p className="text-[10px] uppercase tracking-[0.2em] text-slate-400">
+                      Variables
+                    </p>
+                    <p className="mt-1 font-mono text-sm text-slate-100 break-words">
+                      {currentStep?.variables
+                        ? Object.entries(currentStep.variables)
+                            .filter(([key]) => key !== 'maxArea')
+                            .map(([key, value]) => `${key}: ${value}`)
+                            .join(' | ')
+                        : 'n/a'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="min-w-0">
+                <CodePanel
+                  title="Implementation"
+                  code={currentAlgoSource?.code ?? ''}
+                  language={language}
+                  activeLine={activeLine}
+                  onLanguageChange={setLanguage}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* RIGHT COLUMN - Controls */}
+          <div className="flex min-w-0 flex-col gap-4">
+            <div className="rounded-2xl border border-slate-700/80 bg-slate-900/60 p-4 shadow-xl">
+              <div className="space-y-4">
+                <TestCaseManager
+                  algorithm={mode}
+                  currentInput={
+                    mode === 'histogram'
+                      ? baseArray.join(',')
+                      : baseMatrix.map((r) => r.join('')).join('\n')
+                  }
+                  sampleCases={SAMPLE_CASES[mode]}
+                  onLoad={(input) => {
+                    if (mode === 'histogram') {
+                      setBaseArray(input.split(',').map(Number))
+                    } else {
+                      setBaseMatrix(input.split('\n').map((r) => r.split('')))
+                    }
+                    setCustomInput(input)
+                    clearPlayback()
+                  }}
+                />
+
+                <div className="rounded-xl border border-slate-700/50 bg-slate-900/50 px-3 py-2">
+                  <SpeedSlider
+                    value={speed}
+                    onChange={(e, v) => setSpeed(v)}
+                    min={0.25}
+                    max={3}
+                    step={0.05}
+                  />
+                </div>
+
+                <div className="flex rounded-xl overflow-hidden border border-slate-700 mb-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsStepMode(false)
+                      clearPlayback()
+                    }}
+                    className={`flex-1 py-2 text-xs font-semibold transition-all ${!isStepMode ? 'bg-cyan-600 text-white' : 'bg-slate-800 text-slate-400 hover:text-slate-200'}`}
+                  >
+                    Auto
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsStepMode(true)
+                      clearPlayback()
+                    }}
+                    className={`flex-1 py-2 text-xs font-semibold transition-all ${isStepMode ? 'bg-cyan-600 text-white' : 'bg-slate-800 text-slate-400 hover:text-slate-200'}`}
+                  >
+                    Step
+                  </button>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                  <button
+                    type="button"
+                    onClick={handleVisualize}
+                    disabled={isRunning}
+                    className="w-full text-sm font-bold rounded-xl bg-cyan-600 px-6 py-3 text-white transition-all hover:-translate-y-0.5 hover:bg-cyan-500 hover:shadow-[0_0_15px_rgba(6,182,212,0.4)] disabled:opacity-50 disabled:transform-none"
+                  >
+                    {isRunning
+                      ? 'Playing...'
+                      : hasSteps
+                        ? 'Restart Run'
+                        : 'Start Run'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleReset}
+                    disabled={isRunning}
+                    className="w-full text-sm font-bold rounded-xl bg-slate-700 px-6 py-3 text-white transition-all hover:-translate-y-0.5 hover:bg-slate-600 hover:shadow-lg disabled:opacity-50 disabled:transform-none"
+                  >
+                    Reset
+                  </button>
+                </div>
+
+                <div className="pt-4 border-t border-slate-700/50">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80">
+                    Custom Input
+                  </p>
+                  <textarea
+                    value={customInput}
+                    onChange={(e) => setCustomInput(e.target.value)}
+                    disabled={isRunning}
+                    placeholder={
+                      mode === 'histogram'
+                        ? 'Example: 2, 1, 5, 6, 2, 3'
+                        : 'Example:\n10100\n10111\n11111'
+                    }
+                    className="w-full rounded-xl border border-slate-700 bg-slate-900/80 p-3 text-sm font-mono text-white h-24 resize-none transition duration-300 focus:border-cyan-500 focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleApplyCustomInput}
+                    disabled={isRunning}
+                    className="mt-3 w-full text-sm font-bold rounded-xl bg-cyan-600 px-6 py-2.5 text-white transition-all hover:bg-cyan-500 disabled:opacity-50"
+                  >
+                    Apply Data
+                  </button>
+                  {inputError && (
+                    <p className="mt-2 text-xs text-red-400">{inputError}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {hasSteps && (
+              <div className="rounded-2xl border border-cyan-500/20 bg-slate-900/60 p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80">
+                      Playback
+                    </p>
+                    <p className="text-sm text-slate-300">
+                      Step {currentStepIndex + 1} of {steps.length}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-4 gap-2">
+                  <button
+                    type="button"
+                    onClick={isPlaying ? pausePlayback : playPlayback}
+                    disabled={isComplete && !isPlaying}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-1 py-2 text-xs sm:text-sm font-medium text-slate-100 hover:border-cyan-500"
+                  >
+                    {isPlaying ? 'Pause' : 'Play'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={stepBackward}
+                    disabled={isPlaying || currentStepIndex <= 0}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-1 py-2 text-xs sm:text-sm font-medium text-slate-100 hover:border-cyan-500"
+                  >
+                    Back
+                  </button>
+                  <button
+                    type="button"
+                    onClick={stepForward}
+                    disabled={isPlaying || isComplete}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-1 py-2 text-xs sm:text-sm font-medium text-slate-100 hover:border-cyan-500"
+                  >
+                    Step
+                  </button>
+                  <button
+                    type="button"
+                    onClick={replayPlayback}
+                    className="w-full rounded-xl border border-slate-700 bg-slate-800 px-1 py-2 text-xs sm:text-sm font-medium text-slate-100 hover:border-cyan-500"
+                  >
+                    Replay
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/monotonicStack/StackVisualizerPage.jsx
+++ b/src/components/monotonicStack/StackVisualizerPage.jsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import StackVisualizer from './StackVisualizer'
+import { motion } from 'framer-motion'
+import DifficultyBadge from '../DifficultyBadge'
+import LearningPathSuggestions from '../LearningPathSuggestions'
+
+export default function StackVisualizerPage() {
+  return (
+    <motion.div
+      className="w-full bg-slate-950/50 mx-auto min-h-screen shadow-2xl rounded-xl sm:rounded-2xl border border-white/10 backdrop-blur-xl"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 1, ease: 'easeInOut' }}
+    >
+      {/* Header */}
+      <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-0 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80">
+            Stack Visualizer
+          </p>
+          <DifficultyBadge size="xs" />
+        </div>
+      </div>
+
+      {/* Main Visualizer Component */}
+      <motion.div
+        initial={{ opacity: 0, x: -10 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.22 }}
+      >
+        <StackVisualizer />
+      </motion.div>
+
+      {/* Footer / Learning Paths */}
+      <div className="px-4 sm:px-6 pb-6 pt-2">
+        <LearningPathSuggestions />
+      </div>
+    </motion.div>
+  )
+}

--- a/src/data/complexityMap.js
+++ b/src/data/complexityMap.js
@@ -199,4 +199,16 @@ export const complexityMap = {
     worst: 'O(n + m)',
     space: 'O(n + m)',
   },
+  histogram: {
+    best: 'O(N)',
+    average: 'O(N)',
+    worst: 'O(N)',
+    space: 'O(N)',
+  },
+  matrix: {
+    best: 'O(R * C)',
+    average: 'O(R * C)',
+    worst: 'O(R * C)',
+    space: 'O(C)',
+  },
 }

--- a/src/data/difficultyMap.js
+++ b/src/data/difficultyMap.js
@@ -11,6 +11,7 @@ export const ROUTE_DIFFICULTIES = {
   '/dynamic-programming': 'Intermediate',
   '/dp-journey': 'Advanced',
   '/backtracking': 'Advanced',
+  '/monotonic-stack': 'Advanced',
 }
 
 export const NEXT_TOPICS_MAP = {

--- a/src/data/visualizerData.js
+++ b/src/data/visualizerData.js
@@ -32,6 +32,15 @@ export const ALGORITHMS = [
     difficulty: 'Beginner',
   },
   {
+    id: 'monotonic-stack',
+    title: 'Monotonic Stack',
+    description:
+      'Visualize the Largest Rectangle in Histogram & Maximal Rectangle using a Monotonic Stack to track elements efficiently.',
+    color: 'theme-card border-amber-500/30 hover:border-amber-400',
+    link: '/monotonic-stack',
+    difficulty: 'Advanced',
+  },
+  {
     id: 'abstract-data-types',
     title: 'Abstract Data Types',
     description:


### PR DESCRIPTION
## Pull Request Summary

<!--
Use a Conventional Commit PR title so release-please can classify this change.
Examples:
- feat: add heap sort visualization
- fix: reset shortest-path target selection
- docs: update Clerk setup instructions
-->

### What changed?
Added a comprehensive Monotonic Stack visualizer to AlgoScope. This includes:
- **1D Histogram Mode:** Visualizes the "Largest Rectangle in Histogram" algorithm.
- **2D Matrix Mode:** Visualizes the "Maximal Rectangle" algorithm.
- **Multi-language Support:** Added step-generation and code panel logic for 7 languages (JavaScript, Python, Java, C++, C, Go, Rust).
- **Integration:** Wired the new `/monotonic-stack` route into `App.jsx`, added it to the `Navbar` (under "Explore"), and updated the `SearchBar` and `complexityMap.js`.
- **Test Cases:** Added multiple test cases for both the problems like Strictly Increasing, Decreasing, Classic Peak, Simple Block or Checkerboard

### Why is this needed?
Monotonic Stacks are a tricky concept. This PR adds a highly requested advanced data structure visualization, helping users interactively grasp how a stack maintains a monotonic property to efficiently calculate areas in both 1D and 2D arrays.

Closes #686 

## Type of Change

<!-- Select every category that applies. These should align with the Conventional Commit type in the PR title. -->

- [x] `feat` - New user-facing feature or algorithm capability
- [ ] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes

<!--
release-please builds releases from Conventional Commits, and CHANGELOG.md follows Keep a Changelog sections.
Choose the section that best describes this PR and write one contributor-facing bullet.
Use "Not required" only for changes that should not appear in release notes.
-->

Release note category:

- [x] Added
- [ ] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:

- Added an interactive Monotonic Stack visualizer featuring Largest Rectangle in Histogram and Maximal Rectangle algorithms.

## Testing and Verification

<!-- Check every verification step that was completed. If a step is skipped, explain why below. -->

- [x] `npm ci` or `npm install`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:

<!-- Example: "Skipped npm run build because this PR only updates markdown." -->

## UI Evidence

<!-- Required for UI, animation, routing, or visualizer changes. Add screenshots, GIFs, or short screen recordings. -->

Before:

After:
<img width="1459" height="830" alt="Screenshot 2026-06-23 at 11 00 31 AM" src="https://github.com/user-attachments/assets/b06a2572-a863-4cd0-8c4f-f960c9122d4a" />
<img width="1016" height="829" alt="Screenshot 2026-06-23 at 11 00 42 AM" src="https://github.com/user-attachments/assets/cb311d13-abda-40c1-9c44-db9acf6942b0" />
<img width="1457" height="824" alt="Screenshot 2026-06-23 at 11 00 52 AM" src="https://github.com/user-attachments/assets/302ff3f5-51fd-4dbf-833f-3fa623257042" />
<img width="1400" height="838" alt="Screenshot 2026-06-23 at 11 00 59 AM" src="https://github.com/user-attachments/assets/7745b6d7-49e4-4d1a-ba56-03aecb4dfab2" />
<img width="447" height="488" alt="Screenshot 2026-06-23 at 11 01 37 AM" src="https://github.com/user-attachments/assets/9bdeaa21-ef7d-44f6-b840-1100eb8a5d75" />
<img width="247" height="748" alt="Screenshot 2026-06-23 at 11 05 54 AM" src="https://github.com/user-attachments/assets/8b05800a-00df-4855-b704-523f13a5616b" />
<img width="673" height="210" alt="Screenshot 2026-06-23 at 11 06 14 AM" src="https://github.com/user-attachments/assets/225514c1-01e4-45c0-9bf6-76068caaea14" />


## CI/CD and Deployment Impact

<!-- Select all that apply so maintainers can assess release, Docker, and routing impact. -->

- [ ] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [x] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

Deployment notes:

<!-- Include any required secrets, environment variables, release steps, migration notes, or rollback concerns. -->

## Reviewer Checklist

<!-- Keep this section for maintainers and reviewers. -->

- [ ] PR title follows Conventional Commits and matches the selected change type
- [ ] Scope is focused and unrelated changes are excluded
- [ ] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [ ] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched Monotonic Stack algorithm visualizer with step-by-step animation for largest rectangle histogram and maximal rectangle matrix problems
  * Included playback controls, custom input validation, and synchronized code highlighting
  * Integrated into algorithm search and main navigation menus with complexity information and difficulty ratings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->