### PR TITLE
fix: batch - footer logo scaling, hamburger quick links

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -75,11 +75,11 @@ const Footer = () => {
         <div className="lg:col-span-1 theme-media-surface border theme-border rounded-xl p-6 flex flex-col justify-between space-y-8">
           <div className="space-y-4">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 theme-media-surface rounded-xl flex items-center justify-center p-1.5 border theme-border backdrop-blur shadow-inner">
+              <div className="w-12 h-12 theme-media-surface rounded-xl flex items-center justify-center p-1 border theme-border backdrop-blur shadow-inner">
                 <img
                   src="/logo3.png"
                   alt="AlgoScope"
-                  className="w-full h-full object-contain"
+                  className="w-full h-full object-contain scale-110"
                   onError={(e) => (e.target.style.display = 'none')}
                 />
               </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -570,6 +570,54 @@ export const Navbar = () => {
                   <SearchBar onOpen={closeExploreMenu} />
                 </div>
 
+                {/* Quick Links */}
+                <div>
+                  <h3 className="text-xs font-semibold uppercase tracking-widest text-slate-500 mb-3 px-2">
+                    Quick Access
+                  </h3>
+                  <ul className="space-y-1">
+                    <li>
+                      <Link
+                        to="/favorites"
+                        onClick={() => setOpen(false)}
+                        className={`block rounded-lg px-4 py-2.5 text-sm transition-all duration-200 border-l-2 ${
+                          pathname === '/favorites'
+                            ? 'bg-indigo-50/80 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 border-indigo-600 dark:border-indigo-500 font-semibold'
+                            : 'text-slate-600 dark:text-slate-400 border-transparent hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700'
+                        }`}
+                      >
+                        Favorites
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        to="/practice"
+                        onClick={() => setOpen(false)}
+                        className={`block rounded-lg px-4 py-2.5 text-sm transition-all duration-200 border-l-2 ${
+                          pathname === '/practice'
+                            ? 'bg-indigo-50/80 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 border-indigo-600 dark:border-indigo-500 font-semibold'
+                            : 'text-slate-600 dark:text-slate-400 border-transparent hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700'
+                        }`}
+                      >
+                        Practice
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        to="/challenge"
+                        onClick={() => setOpen(false)}
+                        className={`block rounded-lg px-4 py-2.5 text-sm transition-all duration-200 border-l-2 ${
+                          pathname === '/challenge'
+                            ? 'bg-indigo-50/80 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 border-indigo-600 dark:border-indigo-500 font-semibold'
+                            : 'text-slate-600 dark:text-slate-400 border-transparent hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700'
+                        }`}
+                      >
+                        Challenge
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
+
                 {/* Nav list */}
                 <div>
                   <h3 className="text-xs font-semibold uppercase tracking-widest text-slate-500 mb-3 px-2">


### PR DESCRIPTION
Fixes #52, #696

### Changes:
- **#52**: Footer logo container w-10→w-12, added scale-110 for better visibility
- **#696**: Added Favorites, Practice, Challenge links to the mobile hamburger menu drawer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Quick Access" section in mobile navigation with shortcuts to Favorites, Practice, and Challenge

* **Style**
  * Enhanced footer logo display with improved sizing and visual styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->