### PR TITLE
fix: shorten Two Pointer description and add empty state for unsupported visualizers

### DIFF
--- a/src/components/sortingAlgo/Visualizer.jsx
+++ b/src/components/sortingAlgo/Visualizer.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
+import { usePersistedState } from '../../lib/usePersistedState'
 import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider.jsx'
 import CodePanel from '../visualizer/CodePanel'
@@ -155,7 +156,7 @@ const STATE_STYLE_PRESETS = {
 export default function Visualizer() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [baseArray, setBaseArray] = useState([50, 120, 70, 30, 200, 90, 160])
-  const [speed, setSpeed] = useState(1)
+  const [speed, setSpeed] = usePersistedState('algo-speed-sorting', 1)
   const [language, setLanguage] = useState('javascript')
   const [algorithmType, setAlgorithmType] = useState('simple')
   const [customInput, setCustomInput] = useState('')

--- a/src/components/stringAlgo/VisualizerPage.jsx
+++ b/src/components/stringAlgo/VisualizerPage.jsx
@@ -30,7 +30,7 @@ function SoloMode() {
   const [patternInput, setPatternInput] = useState(DEFAULTS.kmp.pattern)
   const [activeText, setActiveText] = useState('')
   const [activePattern, setActivePattern] = useState('')
-  const [speed, setSpeed] = useState(1)
+  const [speed, setSpeed] = usePersistedState('algo-speed-string', 1)
   const [language, setLanguage] = useState('javascript')
 
   const handleAlgorithmChange = (algo) => {

--- a/src/components/stringAlgo/VisualizerPage.jsx
+++ b/src/components/stringAlgo/VisualizerPage.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
+import { usePersistedState } from '../../lib/usePersistedState'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useSearchParams } from 'react-router-dom'
 import SpeedSlider from '../SpeedSlider'

--- a/src/data/visualizerData.js
+++ b/src/data/visualizerData.js
@@ -125,7 +125,7 @@ export const ALGORITHMS = [
     id: 'two-pointer',
     title: 'Two Pointer Approach',
     description:
-      'Place two pointers at opposite ends and converge them inward — at each step, move the pointer that can not improve the answer, eliminating half the remaining pairs in O(n) instead of checking all pairs in O(n²).',
+      'Use two pointers converging inward to solve pair-sum and container problems in O(n) time.',
     color: 'theme-card border-rose-500/30 hover:border-rose-400',
     link: '/two-pointer',
     difficulty: 'Intermediate',

--- a/src/lib/usePersistedState.js
+++ b/src/lib/usePersistedState.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+
+export function usePersistedState(key, defaultValue) {
+  const [value, setValue] = useState(() => {
+    if (typeof window === 'undefined') return defaultValue
+    try {
+      const stored = localStorage.getItem(key)
+      return stored !== null ? JSON.parse(stored) : defaultValue
+    } catch {
+      return defaultValue
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value))
+    } catch {
+      // Storage full or unavailable
+    }
+  }, [key, value])
+
+  return [value, setValue]
+}


### PR DESCRIPTION
Fixes #712, #706

- Shortened Two Pointer Approach description for consistent card sizing (#712)
- Persist animation speed in localStorage across page refreshes (#706)
- Created usePersistedState hook for reusable localStorage-backed state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sorting and string visualizer speed settings now stay saved between sessions, so users keep their preferred playback speed after refreshing or returning later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->