### PR TITLE
fix: add FRONTEND_URL to .env.example (closes #642)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ NODE_ENV=development
 # - To enable Clerk for local development, set this to your Clerk publishable key:
 #   VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 VITE_CLERK_PUBLISHABLE_KEY=
+
+# Required in production: the URL of the deployed frontend (used for CORS)
+FRONTEND_URL=https://your-frontend-url.com


### PR DESCRIPTION
Fixes #642

## Summary

`FRONTEND_URL` is required in production by `api/index.js` to configure CORS trusted origins, but it was missing from `.env.example`. This caused a confusing fatal crash for developers following the Quick Start guide.

## Changes
- Added `FRONTEND_URL` to `.env.example` with a comment explaining its purpose and usage in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration template with a new `FRONTEND_URL` setting required for production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->