### PR TITLE
feat: add EmptyState component and apply to unsupported visualizers

### DIFF
--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,17 @@
+import { motion } from 'framer-motion'
+
+export default function EmptyState({ title = 'Coming Soon', message, icon = '🚧' }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="flex flex-col items-center justify-center py-24 px-6 text-center"
+    >
+      <span className="text-6xl mb-6">{icon}</span>
+      <h3 className="text-2xl font-bold text-white mb-3">{title}</h3>
+      <p className="text-slate-400 max-w-md leading-relaxed">
+        {message || 'This visualizer is being built. Check back soon for interactive examples and step-by-step animations.'}
+      </p>
+    </motion.div>
+  )
+}

--- a/src/components/operatingSystems/DiskSchedulingPage.jsx
+++ b/src/components/operatingSystems/DiskSchedulingPage.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
+import EmptyState from '../EmptyState'
 
 export default function DiskSchedulingPage() {
   return (
     <div className="min-h-screen px-6 py-12">
-      <h1>Disk Scheduling</h1>
-      <p>Coming Soon</p>
+      <h1 className="text-3xl font-bold text-white mb-8 text-center">Disk Scheduling</h1>
+      <EmptyState
+        icon="💾"
+        title="Under Development"
+        message="The Disk Scheduling visualizer is coming soon! We're building interactive simulations for SCAN, C-SCAN, SSTF, and other disk scheduling algorithms."
+      />
     </div>
   )
 }

--- a/src/components/operatingSystems/PageReplacementPage.jsx
+++ b/src/components/operatingSystems/PageReplacementPage.jsx
@@ -1,10 +1,15 @@
 import React from 'react'
+import EmptyState from '../EmptyState'
 
 export default function PageReplacementPage() {
   return (
     <div className="min-h-screen px-6 py-12">
-      <h1>Page Replacement</h1>
-      <p>Coming Soon</p>
+      <h1 className="text-3xl font-bold text-white mb-8 text-center">Page Replacement</h1>
+      <EmptyState
+        icon="🔄"
+        title="Under Development"
+        message="The Page Replacement visualizer is coming soon! We're building interactive simulations for FIFO, LRU, Optimal, and other page replacement algorithms."
+      />
     </div>
   )
 }

--- a/src/input.css
+++ b/src/input.css
@@ -82,6 +82,24 @@ html {
   scroll-behavior: smooth;
 }
 
+*:focus-visible {
+  outline: 2px solid #22d3ee;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, rgba(51,65,85,0.3) 25%, rgba(51,65,85,0.5) 50%, rgba(51,65,85,0.3) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 8px;
+}
+
 :root {
     --theme-bg: #020617;
     --theme-bg-soft: rgba(15, 23, 42, 0.72);

--- a/src/input.css
+++ b/src/input.css
@@ -78,7 +78,11 @@
 }
 
 @layer base {
-  :root {
+html {
+  scroll-behavior: smooth;
+}
+
+:root {
     --theme-bg: #020617;
     --theme-bg-soft: rgba(15, 23, 42, 0.72);
     --theme-surface: rgba(15, 23, 42, 0.66);


### PR DESCRIPTION
Fixes #709, #718, #719, #721

- Add EmptyState component for unsupported visualizers (#709)
- Add smooth scroll behavior to page (#718)
- Add skeleton loading animation CSS (#719) 
- Add visible focus-visible indicator for keyboard navigation (#721)