### PR TITLE
fix: batch - speed persistence, worker guard, code preservation, sidebar, auth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
 import React, { lazy, Suspense } from 'react'
-import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom'
-import { useAuth } from '@clerk/clerk-react'
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+} from 'react-router-dom'
+import { useAuth, RedirectToSignIn } from '@clerk/clerk-react'
 
 const ConceptsOverview = lazy(
   () => import('./components/concepts/ConceptsOverview')
@@ -107,7 +111,7 @@ function ProtectedPracticePage() {
   }
 
   if (!isSignedIn) {
-    return <Navigate to="/" replace />
+    return <RedirectToSignIn />
   }
 
   return <PracticePage />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react'
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom'
-import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/clerk-react'
+import { useAuth } from '@clerk/clerk-react'
 
 const ConceptsOverview = lazy(
   () => import('./components/concepts/ConceptsOverview')
@@ -99,6 +99,20 @@ const PageLoader = () => (
   </div>
 )
 
+function ProtectedPracticePage() {
+  const { isLoaded, isSignedIn } = useAuth()
+
+  if (!isLoaded) {
+    return <PageLoader />
+  }
+
+  if (!isSignedIn) {
+    return <Navigate to="/" replace />
+  }
+
+  return <PracticePage />
+}
+
 const router = createBrowserRouter([
   {
     path: '/',
@@ -137,14 +151,7 @@ const router = createBrowserRouter([
     element: (
       <AppLayout>
         {HAS_CLERK ? (
-          <>
-            <SignedIn>
-              <PracticePage />
-            </SignedIn>
-            <SignedOut>
-              <RedirectToSignIn />
-            </SignedOut>
-          </>
+          <ProtectedPracticePage />
         ) : import.meta.env.DEV ? (
           <PracticePage />
         ) : (

--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -444,14 +444,6 @@ const PracticePage = () => {
 
   const handleLanguageChange = (e) => {
     const selectedLang = languages.find((lang) => lang.value === e.target.value)
-    const prevLang = language
-    if (prevLang !== selectedLang.value) {
-      savedCodeRef.current.single = code
-      if (executionMode === 'compare') {
-        savedCodeRef.current.compareA = codeA
-        savedCodeRef.current.compareB = codeB
-      }
-    }
     setLanguage(selectedLang.value)
     setCode(selectedLang.default)
     if (executionMode === 'compare') {
@@ -520,28 +512,29 @@ const PracticePage = () => {
       ...prev,
       { type: 'info', content: 'Executing user code...' },
     ])
-    const result = await runCodeInWorker(userCode, undefined, activeWorkerRef)
+    try {
+      const result = await runCodeInWorker(userCode, undefined, activeWorkerRef)
 
-    if (!isMountedRef.current) {
+      if (!isMountedRef.current) {
+        return
+      }
+
+      if (result.status === 'cancelled') {
+        return
+      }
+
+      setLogs((prev) => [...prev, ...result.logs])
+      if (result.status === 'error') {
+        setLogs((prev) => [
+          ...prev,
+          { type: 'error', content: `Runtime Error: ${result.error}` },
+        ])
+      }
+      scrollConsoleIntoView()
+    } finally {
+      setIsExecuting(false)
       executionLockRef.current = false
-      return
     }
-
-    if (result.status === 'cancelled') {
-      executionLockRef.current = false
-      return
-    }
-
-    setLogs((prev) => [...prev, ...result.logs])
-    if (result.status === 'error') {
-      setLogs((prev) => [
-        ...prev,
-        { type: 'error', content: `Runtime Error: ${result.error}` },
-      ])
-    }
-    setIsExecuting(false)
-    executionLockRef.current = false
-    scrollConsoleIntoView()
   }
 
   const handleRunCodeA = async (userCode) => {

--- a/src/components/PracticePage.jsx
+++ b/src/components/PracticePage.jsx
@@ -328,6 +328,7 @@ const PracticePage = () => {
   const activeProfilerWorkerRef = useRef(null)
   const isMountedRef = useRef(true)
   const profilerCancelledRef = useRef(false)
+  const executionLockRef = useRef(false)
 
   const [isExecuting, setIsExecuting] = useState(false)
   const [isExecutingA, setIsExecutingA] = useState(false)
@@ -340,6 +341,7 @@ const PracticePage = () => {
 
   const [codeA, setCodeA] = useState('')
   const [codeB, setCodeB] = useState('')
+  const savedCodeRef = useRef({ single: '', compareA: '', compareB: '' })
   const [logsA, setLogsA] = useState([])
   const [logsB, setLogsB] = useState([])
   const [sharedInput, setSharedInput] = useState('35')
@@ -399,7 +401,6 @@ const PracticePage = () => {
   ]
 
   const handleModeChange = (mode) => {
-    // Terminate all active workers across all modes
     terminateWorker(activeWorkerRef)
     terminateWorker(activeWorkerRefA)
     terminateWorker(activeWorkerRefB)
@@ -410,11 +411,22 @@ const PracticePage = () => {
     setIsExecutingB(false)
     setIsComparing(false)
     setIsProfilerRunning(false)
+    executionLockRef.current = false
+
+    savedCodeRef.current.single = code
+
+    if (executionMode === 'compare') {
+      savedCodeRef.current.compareA = codeA
+      savedCodeRef.current.compareB = codeB
+    }
 
     setExecutionMode(mode)
-    if (mode === 'compare') {
-      setCodeA(defaultTemplates[language]?.a || '')
-      setCodeB(defaultTemplates[language]?.b || '')
+
+    if (mode === 'single' && savedCodeRef.current.single) {
+      setCode(savedCodeRef.current.single)
+    } else if (mode === 'compare') {
+      setCodeA(savedCodeRef.current.compareA || defaultTemplates[language]?.a || '')
+      setCodeB(savedCodeRef.current.compareB || defaultTemplates[language]?.b || '')
     }
   }
 
@@ -432,6 +444,14 @@ const PracticePage = () => {
 
   const handleLanguageChange = (e) => {
     const selectedLang = languages.find((lang) => lang.value === e.target.value)
+    const prevLang = language
+    if (prevLang !== selectedLang.value) {
+      savedCodeRef.current.single = code
+      if (executionMode === 'compare') {
+        savedCodeRef.current.compareA = codeA
+        savedCodeRef.current.compareB = codeB
+      }
+    }
     setLanguage(selectedLang.value)
     setCode(selectedLang.default)
     if (executionMode === 'compare') {
@@ -479,6 +499,7 @@ const PracticePage = () => {
   }
 
   const handleRunCode = async (userCode) => {
+    if (executionLockRef.current) return
     if (language !== 'javascript') {
       setLogs((prev) => [
         ...prev,
@@ -493,6 +514,7 @@ const PracticePage = () => {
     if (isExecuting || isExecutingA || isExecutingB || isComparing) {
       return
     }
+    executionLockRef.current = true
     setIsExecuting(true)
     setLogs((prev) => [
       ...prev,
@@ -500,9 +522,13 @@ const PracticePage = () => {
     ])
     const result = await runCodeInWorker(userCode, undefined, activeWorkerRef)
 
-    if (!isMountedRef.current) return
+    if (!isMountedRef.current) {
+      executionLockRef.current = false
+      return
+    }
 
     if (result.status === 'cancelled') {
+      executionLockRef.current = false
       return
     }
 
@@ -514,10 +540,12 @@ const PracticePage = () => {
       ])
     }
     setIsExecuting(false)
+    executionLockRef.current = false
     scrollConsoleIntoView()
   }
 
   const handleRunCodeA = async (userCode) => {
+    if (executionLockRef.current) return
     if (language !== 'javascript') {
       setLogsA((prev) => [
         ...prev,
@@ -532,6 +560,7 @@ const PracticePage = () => {
     if (isExecuting || isExecutingA || isExecutingB || isComparing) {
       return
     }
+    executionLockRef.current = true
     setIsExecutingA(true)
     setLogsA((prev) => [
       ...prev,
@@ -540,9 +569,13 @@ const PracticePage = () => {
     const inputVal = parseSharedInput()
     const result = await runCodeInWorker(userCode, inputVal, activeWorkerRefA)
 
-    if (!isMountedRef.current) return
+    if (!isMountedRef.current) {
+      executionLockRef.current = false
+      return
+    }
 
     if (result.status === 'cancelled') {
+      executionLockRef.current = false
       return
     }
 
@@ -554,9 +587,11 @@ const PracticePage = () => {
       ])
     }
     setIsExecutingA(false)
+    executionLockRef.current = false
   }
 
   const handleRunCodeB = async (userCode) => {
+    if (executionLockRef.current) return
     if (language !== 'javascript') {
       setLogsB((prev) => [
         ...prev,
@@ -571,6 +606,7 @@ const PracticePage = () => {
     if (isExecuting || isExecutingA || isExecutingB || isComparing) {
       return
     }
+    executionLockRef.current = true
     setIsExecutingB(true)
     setLogsB((prev) => [
       ...prev,
@@ -579,9 +615,13 @@ const PracticePage = () => {
     const inputVal = parseSharedInput()
     const result = await runCodeInWorker(userCode, inputVal, activeWorkerRefB)
 
-    if (!isMountedRef.current) return
+    if (!isMountedRef.current) {
+      executionLockRef.current = false
+      return
+    }
 
     if (result.status === 'cancelled') {
+      executionLockRef.current = false
       return
     }
 
@@ -593,9 +633,11 @@ const PracticePage = () => {
       ])
     }
     setIsExecutingB(false)
+    executionLockRef.current = false
   }
 
   const handleCompareBenchmark = async () => {
+    if (executionLockRef.current) return
     if (language !== 'javascript') {
       setLogsA((prev) => [
         ...prev,
@@ -618,6 +660,7 @@ const PracticePage = () => {
     if (isExecuting || isExecutingA || isExecutingB || isComparing) {
       return
     }
+    executionLockRef.current = true
     setIsComparing(true)
     setBenchmarkResults(null)
     setLogsA((prev) => [
@@ -636,10 +679,14 @@ const PracticePage = () => {
       runCodeInWorker(codeB, inputVal, activeWorkerRefB),
     ])
 
-    if (!isMountedRef.current) return
+    if (!isMountedRef.current) {
+      executionLockRef.current = false
+      return
+    }
 
     if (resA.status === 'cancelled' || resB.status === 'cancelled') {
       setIsComparing(false)
+      executionLockRef.current = false
       return
     }
 
@@ -669,10 +716,12 @@ const PracticePage = () => {
     })
 
     setIsComparing(false)
+    executionLockRef.current = false
   }
 
   const handleRunProfiler = useCallback(
     async (userCode) => {
+      if (executionLockRef.current) return
       if (
         isExecuting ||
         isExecutingA ||
@@ -682,6 +731,7 @@ const PracticePage = () => {
       ) {
         return
       }
+      executionLockRef.current = true
 
       // Parse input sizes
       const sizes = profilerInputSizes
@@ -691,6 +741,7 @@ const PracticePage = () => {
         .sort((a, b) => a - b)
 
       if (sizes.length === 0) {
+        executionLockRef.current = false
         setProfilerLogs((prev) => [
           ...prev,
           {
@@ -776,6 +827,7 @@ const PracticePage = () => {
 
       if (isMountedRef.current) {
         setIsProfilerRunning(false)
+        executionLockRef.current = false
         setProfilerProgress('')
         if (collectedData.length > 0) {
           setProfilerLogs((prev) => [

--- a/src/components/SpeedSlider.jsx
+++ b/src/components/SpeedSlider.jsx
@@ -6,8 +6,6 @@ import Tooltip from './Tooltip'
 const audio = new Audio(clickSound)
 audio.volume = 0.2
 
-const STORAGE_KEY = 'algoscope_visualization_speed'
-
 // Define the gradient
 const sliderGradient = 'linear-gradient(to right, #22d3ee, #3b82f6)' // cyan-400 to blue-500
 
@@ -21,9 +19,6 @@ const SpeedSlider = memo(function SpeedSlider({
   const handleChange = (event, newValue) => {
     audio.currentTime = 0
     audio.play().catch(() => {})
-    try {
-      localStorage.setItem(STORAGE_KEY, String(newValue))
-    } catch {}
     onChange(event, newValue)
   }
 

--- a/src/components/SpeedSlider.jsx
+++ b/src/components/SpeedSlider.jsx
@@ -6,6 +6,8 @@ import Tooltip from './Tooltip'
 const audio = new Audio(clickSound)
 audio.volume = 0.2
 
+const STORAGE_KEY = 'algoscope_visualization_speed'
+
 // Define the gradient
 const sliderGradient = 'linear-gradient(to right, #22d3ee, #3b82f6)' // cyan-400 to blue-500
 
@@ -19,6 +21,9 @@ const SpeedSlider = memo(function SpeedSlider({
   const handleChange = (event, newValue) => {
     audio.currentTime = 0
     audio.play().catch(() => {})
+    try {
+      localStorage.setItem(STORAGE_KEY, String(newValue))
+    } catch {}
     onChange(event, newValue)
   }
 

--- a/src/components/searchAlgo/VisualizerPage.jsx
+++ b/src/components/searchAlgo/VisualizerPage.jsx
@@ -153,7 +153,7 @@
 //     </motion.div>
 //   )
 // }
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { CanvasSearching } from './CanvasSearching'
 import CodePanel from '../visualizer/CodePanel'
 import { MenuSelectNodeSearch } from './MenuSelectNodeSearch'
@@ -166,6 +166,17 @@ import ComplexityCard from '../ComplexityCard'
 import ComparisonMode from './ComparisonMode'
 
 export const VisualizerPage = () => {
+  const readPersistedSpeed = () => {
+    try {
+      const stored = localStorage.getItem('algoscope_visualization_speed')
+      const parsed = Number.parseFloat(stored)
+      if (!Number.isFinite(parsed)) return 1.0
+      return Math.min(3, Math.max(0.5, parsed))
+    } catch {
+      return 1.0
+    }
+  }
+
   const [searchParams, setSearchParams] = useSearchParams()
   const mode = searchParams.get('mode') === 'compare' ? 'compare' : 'solo'
 
@@ -181,9 +192,7 @@ export const VisualizerPage = () => {
 
   const [node, setNode] = React.useState(null)
   const [algorithm, setAlgorithm] = React.useState(null)
-  const [speed, setSpeed] = React.useState(
-    () => parseFloat(localStorage.getItem('algoscope_visualization_speed')) || 1.0
-  )
+  const [speed, setSpeed] = React.useState(() => readPersistedSpeed())
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
   // Live list of node IDs from the canvas (kept in sync via onGraphChange)
@@ -205,6 +214,14 @@ export const VisualizerPage = () => {
   const handleSpeedChange = (event, newValue) => {
     setSpeed(newValue)
   }
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('algoscope_visualization_speed', String(speed))
+    } catch {
+      // Ignore storage failures in blocked environments.
+    }
+  }, [speed])
 
   const handleRun = () => {
     if (!algorithm || !node) return

--- a/src/components/searchAlgo/VisualizerPage.jsx
+++ b/src/components/searchAlgo/VisualizerPage.jsx
@@ -181,7 +181,9 @@ export const VisualizerPage = () => {
 
   const [node, setNode] = React.useState(null)
   const [algorithm, setAlgorithm] = React.useState(null)
-  const [speed, setSpeed] = React.useState(1.0)
+  const [speed, setSpeed] = React.useState(
+    () => parseFloat(localStorage.getItem('algoscope_visualization_speed')) || 1.0
+  )
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
   // Live list of node IDs from the canvas (kept in sync via onGraphChange)
@@ -224,28 +226,20 @@ export const VisualizerPage = () => {
 
   return (
     <motion.div
-      className="w-full flex flex-col lg:flex-row p-4 sm:p-6 gap-4 sm:gap-6 bg-slate-950/50 min-h-screen shadow-2xl rounded-2xl border border-white/10 backdrop-blur-xl"
+      className="w-full bg-slate-950/50 min-h-screen shadow-2xl rounded-2xl border border-white/10 backdrop-blur-xl"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 1, ease: 'easeInOut' }}
     >
-      {/* Left Panel: Controls */}
-      <div className="w-full lg:w-1/4 p-4 flex flex-col gap-6 bg-slate-900/80 shadow-xl rounded-xl border border-white/5 backdrop-blur-sm overflow-y-auto">
-        {/* Header */}
-        <div className="border-b border-white/10 pb-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80 text-center mb-1">
-            Graph Search Visualizer
-          </p>
-          <h2 className="text-xl font-bold text-center text-white tracking-tight">
-            Controls
-          </h2>
-        </div>
-
-        {/* Mode Toggle (NEW) */}
+      {/* Header */}
+      <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-2 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80">
+          Graph Search Visualizer
+        </p>
         <div className="flex gap-2">
           <button
             onClick={() => setMode('solo')}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+            className={`px-3 py-1 rounded-lg text-xs font-bold transition-all ${
               mode === 'solo'
                 ? 'bg-cyan-600 text-white'
                 : 'bg-slate-800 text-slate-400'
@@ -253,10 +247,9 @@ export const VisualizerPage = () => {
           >
             Solo
           </button>
-
           <button
             onClick={() => setMode('compare')}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+            className={`px-3 py-1 rounded-lg text-xs font-bold transition-all ${
               mode === 'compare'
                 ? 'bg-cyan-600 text-white'
                 : 'bg-slate-800 text-slate-400'
@@ -265,112 +258,122 @@ export const VisualizerPage = () => {
             Compare
           </button>
         </div>
-
-        {/* How to use stepper (only in solo mode visually relevant, but kept global) */}
-        <div className="bg-slate-950/60 rounded-xl border border-white/5 p-3 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
-            How to use
-          </p>
-          {[
-            { step: '1', label: 'Build your graph (toolbar on canvas)' },
-            { step: '2', label: 'Pick an algorithm' },
-            { step: '3', label: 'Choose a starting node' },
-            { step: '4', label: 'Press Run' },
-          ].map(({ step, label }) => {
-            const done =
-              (step === '1' && nodeIds.length > 0) ||
-              (step === '2' && algorithm) ||
-              (step === '3' && node) ||
-              (step === '4' && runKey !== null)
-
-            return (
-              <div key={step} className="flex items-center gap-3">
-                <span
-                  className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold transition-colors duration-300 ${
-                    done
-                      ? 'bg-cyan-500 text-white'
-                      : 'bg-slate-700 text-slate-400'
-                  }`}
-                >
-                  {done ? '✓' : step}
-                </span>
-                <span
-                  className={`text-sm transition-colors duration-300 ${
-                    done ? 'text-slate-200' : 'text-slate-500'
-                  }`}
-                >
-                  {label}
-                </span>
-              </div>
-            )
-          })}
-        </div>
-
-        {/* Run / Reset buttons */}
-        <div className="flex flex-col gap-2">
-          <button
-            onClick={handleRun}
-            disabled={!canRun || mode === 'compare'}
-            className={`w-full py-3 px-4 rounded-xl text-sm font-bold transition-all duration-300 ${
-              canRun && mode !== 'compare'
-                ? 'bg-cyan-600 hover:bg-cyan-500 text-white shadow-lg shadow-cyan-500/30 hover:scale-[1.02]'
-                : 'bg-slate-800 text-slate-600 cursor-not-allowed border border-slate-700'
-            }`}
-          >
-            ▶ Run
-          </button>
-
-          <button
-            onClick={handleReset}
-            className="w-full py-3 px-4 rounded-xl text-sm font-bold bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 hover:text-white transition-all duration-300"
-          >
-            ↺ Reset
-          </button>
-        </div>
-
-        <MenuSelectAlgorithm
-          algorithm={algorithm}
-          setAlgorithm={setAlgorithm}
-        />
-        <MenuSelectNodeSearch node={node} setNode={setNode} nodeIds={nodeIds} />
-        <SpeedSlider value={speed} onChange={handleSpeedChange} />
       </div>
 
-      {/* Right Panel */}
-      <div className="w-full lg:w-3/4 flex flex-col gap-6">
-        {mode === 'solo' ? (
-          <>
-            <div className="rounded-xl border border-white/10 shadow-lg">
-              <CanvasSearching
-                algorithm={algorithm}
-                vertex={node}
-                speed={speed}
-                runKey={runKey}
-                onGraphChange={handleGraphChange}
-              />
+      {/* Content */}
+      <div className="flex flex-col lg:flex-row p-4 sm:p-6 gap-4 sm:gap-6">
+        {mode === 'solo' && (
+          <div className="w-full lg:w-1/4 p-4 flex flex-col gap-6 bg-slate-900/80 shadow-xl rounded-xl border border-white/5 backdrop-blur-sm overflow-y-auto">
+            <div className="border-b border-white/10 pb-4">
+              <h2 className="text-xl font-bold text-center text-white tracking-tight">
+                Controls
+              </h2>
             </div>
 
-            <ComplexityCard algorithm={algorithm} />
+            <div className="bg-slate-950/60 rounded-xl border border-white/5 p-3 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
+                How to use
+              </p>
+              {[
+                { step: '1', label: 'Build your graph (toolbar on canvas)' },
+                { step: '2', label: 'Pick an algorithm' },
+                { step: '3', label: 'Choose a starting node' },
+                { step: '4', label: 'Press Run' },
+              ].map(({ step, label }) => {
+                const done =
+                  (step === '1' && nodeIds.length > 0) ||
+                  (step === '2' && algorithm) ||
+                  (step === '3' && node) ||
+                  (step === '4' && runKey !== null)
 
-            <div className="w-full">
-              <CodePanel
-                title={
-                  algorithm
-                    ? `${algorithm.toUpperCase()} Implementation`
-                    : 'Code Viewer'
-                }
-                code={
-                  currentSource ||
-                  '// Select an algorithm and node to see implementation'
-                }
-                language={language}
-                onLanguageChange={setLanguage}
-              />
+                return (
+                  <div key={step} className="flex items-center gap-3">
+                    <span
+                      className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold transition-colors duration-300 ${
+                        done
+                          ? 'bg-cyan-500 text-white'
+                          : 'bg-slate-700 text-slate-400'
+                      }`}
+                    >
+                      {done ? '✓' : step}
+                    </span>
+                    <span
+                      className={`text-sm transition-colors duration-300 ${
+                        done ? 'text-slate-200' : 'text-slate-500'
+                      }`}
+                    >
+                      {label}
+                    </span>
+                  </div>
+                )
+              })}
             </div>
-          </>
-        ) : (
-          <ComparisonMode />
+
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={handleRun}
+                disabled={!canRun}
+                className={`w-full py-3 px-4 rounded-xl text-sm font-bold transition-all duration-300 ${
+                  canRun
+                    ? 'bg-cyan-600 hover:bg-cyan-500 text-white shadow-lg shadow-cyan-500/30 hover:scale-[1.02]'
+                    : 'bg-slate-800 text-slate-600 cursor-not-allowed border border-slate-700'
+                }`}
+              >
+                ▶ Run
+              </button>
+
+              <button
+                onClick={handleReset}
+                className="w-full py-3 px-4 rounded-xl text-sm font-bold bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 hover:text-white transition-all duration-300"
+              >
+                ↺ Reset
+              </button>
+            </div>
+
+            <MenuSelectAlgorithm
+              algorithm={algorithm}
+              setAlgorithm={setAlgorithm}
+            />
+            <MenuSelectNodeSearch node={node} setNode={setNode} nodeIds={nodeIds} />
+            <SpeedSlider value={speed} onChange={handleSpeedChange} />
+          </div>
         )}
+
+        <div className={`flex flex-col gap-6 ${mode === 'solo' ? 'w-full lg:w-3/4' : 'w-full'}`}>
+          {mode === 'solo' ? (
+            <>
+              <div className="rounded-xl border border-white/10 shadow-lg">
+                <CanvasSearching
+                  algorithm={algorithm}
+                  vertex={node}
+                  speed={speed}
+                  runKey={runKey}
+                  onGraphChange={handleGraphChange}
+                />
+              </div>
+
+              <ComplexityCard algorithm={algorithm} />
+
+              <div className="w-full">
+                <CodePanel
+                  title={
+                    algorithm
+                      ? `${algorithm.toUpperCase()} Implementation`
+                      : 'Code Viewer'
+                  }
+                  code={
+                    currentSource ||
+                    '// Select an algorithm and node to see implementation'
+                  }
+                  language={language}
+                  onLanguageChange={setLanguage}
+                />
+              </div>
+            </>
+          ) : (
+            <ComparisonMode />
+          )}
+        </div>
       </div>
     </motion.div>
   )

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { CanvasShortestPath } from './CanvasShortestPath'
 import GridVisualizer from './GridVisualizer'
 import GridComparisonMode from './GridComparisonMode'
@@ -14,6 +14,17 @@ import ComparisonMode from './ComparisonMode'
 import { useKeyboardShortcuts } from '../visualizer/useKeyboardShortcuts'
 
 export const ShortestPathPage = () => {
+  const readPersistedSpeed = () => {
+    try {
+      const stored = localStorage.getItem('algoscope_visualization_speed')
+      const parsed = Number.parseFloat(stored)
+      if (!Number.isFinite(parsed)) return 1.0
+      return Math.min(3, Math.max(0.5, parsed))
+    } catch {
+      return 1.0
+    }
+  }
+
   const [searchParams, setSearchParams] = useSearchParams()
 
   const mode = searchParams.get('mode') === 'compare' ? 'compare' : 'solo'
@@ -38,9 +49,7 @@ export const ShortestPathPage = () => {
   const [algorithm, setAlgorithm] = React.useState(null)
   const [source, setSource] = React.useState(null)
   const [target, setTarget] = React.useState(null)
-  const [speed, setSpeed] = React.useState(
-    () => parseFloat(localStorage.getItem('algoscope_visualization_speed')) || 1.0
-  )
+  const [speed, setSpeed] = React.useState(() => readPersistedSpeed())
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
   const [nodeIds, setNodeIds] = React.useState(
@@ -59,6 +68,14 @@ export const ShortestPathPage = () => {
   const handleSpeedChange = (_, newValue) => {
     setSpeed(newValue)
   }
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('algoscope_visualization_speed', String(speed))
+    } catch {
+      // Ignore storage failures in blocked environments.
+    }
+  }, [speed])
 
   const handleRun = () => {
     if (!algorithm) return

--- a/src/components/shortestPathAlgo/ShortestPathPage.jsx
+++ b/src/components/shortestPathAlgo/ShortestPathPage.jsx
@@ -38,7 +38,9 @@ export const ShortestPathPage = () => {
   const [algorithm, setAlgorithm] = React.useState(null)
   const [source, setSource] = React.useState(null)
   const [target, setTarget] = React.useState(null)
-  const [speed, setSpeed] = React.useState(1.0)
+  const [speed, setSpeed] = React.useState(
+    () => parseFloat(localStorage.getItem('algoscope_visualization_speed')) || 1.0
+  )
   const [language, setLanguage] = React.useState('javascript')
   const [runKey, setRunKey] = React.useState(null)
   const [nodeIds, setNodeIds] = React.useState(
@@ -130,7 +132,7 @@ export const ShortestPathPage = () => {
 
   return (
     <motion.div
-      className="w-full flex flex-col lg:flex-row p-4 sm:p-6 gap-4 sm:gap-6 bg-slate-950/50 min-h-screen rounded-2xl shadow-2xl border border-white/10 backdrop-blur-xl"
+      className="w-full bg-slate-950/50 min-h-screen rounded-2xl shadow-2xl border border-white/10 backdrop-blur-xl"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{
@@ -138,60 +140,29 @@ export const ShortestPathPage = () => {
         ease: 'easeInOut',
       }}
     >
-      <div className="w-full lg:w-1/4 p-4 flex flex-col gap-6 bg-slate-900/80 shadow-xl rounded-xl border border-white/5 backdrop-blur-sm overflow-y-auto">
-        <div className="border-b border-white/10 pb-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80 text-center mb-1">
-            Shortest Path Visualizer
-          </p>
-
-          <h2 className="text-xl font-bold text-center text-white tracking-tight">
-            Controls
-          </h2>
-        </div>
-
+      {/* Header */}
+      <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-2 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-cyan-400/80">
+          Shortest Path Visualizer
+        </p>
         <div className="flex gap-2">
           <button
-            onClick={() => setViewMode('network')}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
-              viewMode === 'network'
-                ? 'bg-cyan-600 text-white'
-                : 'bg-slate-800 text-slate-400'
-            }`}
-          >
-            Network View
-          </button>
-
-          <button
-            onClick={() => setViewMode('grid')}
+            onClick={() => setMode('solo')}
             disabled={algorithm === 'prim' || algorithm === 'kruskal'}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
-              viewMode === 'grid'
+            className={`px-3 py-1 rounded-lg text-xs font-bold transition-all ${
+              mode === 'solo'
                 ? 'bg-cyan-600 text-white'
                 : algorithm === 'prim' || algorithm === 'kruskal'
                   ? 'bg-slate-800/40 text-slate-600 cursor-not-allowed border border-white/5'
                   : 'bg-slate-800 text-slate-400'
             }`}
           >
-            Grid View
-          </button>
-        </div>
-
-        <div className="flex gap-2">
-          <button
-            onClick={() => setMode('solo')}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
-              mode === 'solo'
-                ? 'bg-cyan-600 text-white'
-                : 'bg-slate-800 text-slate-400'
-            }`}
-          >
             Solo
           </button>
-
           <button
             onClick={() => setMode('compare')}
             disabled={algorithm === 'prim' || algorithm === 'kruskal'}
-            className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+            className={`px-3 py-1 rounded-lg text-xs font-bold transition-all ${
               mode === 'compare'
                 ? 'bg-cyan-600 text-white'
                 : algorithm === 'prim' || algorithm === 'kruskal'
@@ -202,178 +173,218 @@ export const ShortestPathPage = () => {
             Compare
           </button>
         </div>
-
-        <div className="bg-slate-950/60 rounded-xl border border-white/5 p-3 space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
-            How to use
-          </p>
-
-          {[
-            ...(viewMode === 'network'
-              ? [{ step: '1', label: 'Build your graph (toolbar on canvas)' }]
-              : []),
-            {
-              step: viewMode === 'network' ? '2' : '1',
-              label: 'Pick an algorithm',
-            },
-            {
-              step: viewMode === 'network' ? '3' : '2',
-              label:
-                viewMode === 'grid'
-                  ? 'Build your grid'
-                  : 'Choose source & target',
-            },
-            {
-              step: viewMode === 'network' ? '4' : '3',
-              label: 'Press Run',
-            },
-          ].map(({ step, label }) => {
-            const done =
-              (viewMode === 'network' && step === '1' && nodeIds.length > 0) ||
-              ((viewMode === 'network' ? step === '2' : step === '1') &&
-                algorithm) ||
-              ((viewMode === 'network' ? step === '3' : step === '2') &&
-                (viewMode === 'grid' ? true : source && target)) ||
-              ((viewMode === 'network' ? step === '4' : step === '3') &&
-                runKey !== null)
-
-            return (
-              <div key={step} className="flex items-center gap-3">
-                <span
-                  className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold transition-colors duration-300 ${
-                    done
-                      ? 'bg-cyan-500 text-white'
-                      : 'bg-slate-700 text-slate-400'
-                  }`}
-                >
-                  {done ? '✓' : step}
-                </span>
-
-                <span
-                  className={`text-sm transition-colors duration-300 ${
-                    done ? 'text-slate-200' : 'text-slate-500'
-                  }`}
-                >
-                  {label}
-                </span>
-              </div>
-            )
-          })}
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <button
-            onClick={handleRun}
-            disabled={!canRun || mode === 'compare'}
-            className={`w-full py-3 px-4 rounded-xl text-sm font-bold transition-all duration-300 ${
-              canRun && mode !== 'compare'
-                ? 'bg-cyan-600 hover:bg-cyan-500 text-white shadow-lg shadow-cyan-500/30 hover:scale-[1.02]'
-                : 'bg-slate-800 text-slate-600 cursor-not-allowed border border-slate-700'
-            }`}
-          >
-            ▶ Run
-          </button>
-
-          <button
-            onClick={handleReset}
-            className="w-full py-3 px-4 rounded-xl text-sm font-bold bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 hover:text-white transition-all duration-300"
-          >
-            ↺ Reset
-          </button>
-        </div>
-
-        <MenuSetAlgoShortestPath
-          algorithm={algorithm}
-          setAlgorithm={setAlgorithm}
-        />
-
-        {viewMode === 'network' && (
-          <MenuSelectNodesShortestPath
-            source={source}
-            target={target}
-            setSource={setSource}
-            setTarget={setTarget}
-            algorithm={algorithm}
-            nodeIds={nodeIds}
-          />
-        )}
-
-        <SpeedSlider value={speed} onChange={handleSpeedChange} />
       </div>
 
-      <div className="w-full lg:w-3/4 flex flex-col gap-6">
-        {viewMode === 'network' ? (
-          <>
-            {mode === 'solo' ? (
-              <>
-                <div className="rounded-xl border border-white/10 shadow-lg">
-                  <CanvasShortestPath
-                    algorithm={algorithm}
-                    source={source}
-                    target={target}
-                    speed={speed}
-                    runKey={runKey}
-                    onGraphChange={handleGraphChange}
-                  />
-                </div>
+      {/* Content */}
+      <div className="flex flex-col lg:flex-row p-4 sm:p-6 gap-4 sm:gap-6">
+        {mode === 'solo' && (
+          <div className="w-full lg:w-1/4 p-4 flex flex-col gap-6 bg-slate-900/80 shadow-xl rounded-xl border border-white/5 backdrop-blur-sm overflow-y-auto">
+            <div className="border-b border-white/10 pb-4">
+              <h2 className="text-xl font-bold text-center text-white tracking-tight">
+                Controls
+              </h2>
+            </div>
 
-                <ComplexityCard algorithm={algorithm} />
+            <div className="flex gap-2">
+              <button
+                onClick={() => setViewMode('network')}
+                className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+                  viewMode === 'network'
+                    ? 'bg-cyan-600 text-white'
+                    : 'bg-slate-800 text-slate-400'
+                }`}
+              >
+                Network View
+              </button>
 
-                <div className="w-full">
-                  <CodePanel
-                    title={
-                      algorithm
-                        ? `${getAlgorithmName(algorithm)} Implementation`
-                        : 'Code Viewer'
-                    }
-                    code={
-                      currentSource ||
-                      '// Select an algorithm and nodes to see implementation'
-                    }
-                    language={language}
-                    onLanguageChange={setLanguage}
-                  />
-                </div>
-              </>
-            ) : (
-              <ComparisonMode />
+              <button
+                onClick={() => setViewMode('grid')}
+                disabled={algorithm === 'prim' || algorithm === 'kruskal'}
+                className={`w-1/2 py-2 rounded-lg text-xs font-bold transition-all ${
+                  viewMode === 'grid'
+                    ? 'bg-cyan-600 text-white'
+                    : algorithm === 'prim' || algorithm === 'kruskal'
+                      ? 'bg-slate-800/40 text-slate-600 cursor-not-allowed border border-white/5'
+                      : 'bg-slate-800 text-slate-400'
+                }`}
+              >
+                Grid View
+              </button>
+            </div>
+
+            <div className="bg-slate-950/60 rounded-xl border border-white/5 p-3 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 mb-2">
+                How to use
+              </p>
+
+              {[
+                ...(viewMode === 'network'
+                  ? [{ step: '1', label: 'Build your graph (toolbar on canvas)' }]
+                  : []),
+                {
+                  step: viewMode === 'network' ? '2' : '1',
+                  label: 'Pick an algorithm',
+                },
+                {
+                  step: viewMode === 'network' ? '3' : '2',
+                  label:
+                    viewMode === 'grid'
+                      ? 'Build your grid'
+                      : 'Choose source & target',
+                },
+                {
+                  step: viewMode === 'network' ? '4' : '3',
+                  label: 'Press Run',
+                },
+              ].map(({ step, label }) => {
+                const done =
+                  (viewMode === 'network' && step === '1' && nodeIds.length > 0) ||
+                  ((viewMode === 'network' ? step === '2' : step === '1') &&
+                    algorithm) ||
+                  ((viewMode === 'network' ? step === '3' : step === '2') &&
+                    (viewMode === 'grid' ? true : source && target)) ||
+                  ((viewMode === 'network' ? step === '4' : step === '3') &&
+                    runKey !== null)
+
+                return (
+                  <div key={step} className="flex items-center gap-3">
+                    <span
+                      className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-xs font-bold transition-colors duration-300 ${
+                        done
+                          ? 'bg-cyan-500 text-white'
+                          : 'bg-slate-700 text-slate-400'
+                      }`}
+                    >
+                      {done ? '✓' : step}
+                    </span>
+
+                    <span
+                      className={`text-sm transition-colors duration-300 ${
+                        done ? 'text-slate-200' : 'text-slate-500'
+                      }`}
+                    >
+                      {label}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={handleRun}
+                disabled={!canRun}
+                className={`w-full py-3 px-4 rounded-xl text-sm font-bold transition-all duration-300 ${
+                  canRun
+                    ? 'bg-cyan-600 hover:bg-cyan-500 text-white shadow-lg shadow-cyan-500/30 hover:scale-[1.02]'
+                    : 'bg-slate-800 text-slate-600 cursor-not-allowed border border-slate-700'
+                }`}
+              >
+                ▶ Run
+              </button>
+
+              <button
+                onClick={handleReset}
+                className="w-full py-3 px-4 rounded-xl text-sm font-bold bg-slate-800 text-slate-300 border border-slate-700 hover:bg-slate-700 hover:text-white transition-all duration-300"
+              >
+                ↺ Reset
+              </button>
+            </div>
+
+            <MenuSetAlgoShortestPath
+              algorithm={algorithm}
+              setAlgorithm={setAlgorithm}
+            />
+
+            {viewMode === 'network' && (
+              <MenuSelectNodesShortestPath
+                source={source}
+                target={target}
+                setSource={setSource}
+                setTarget={setTarget}
+                algorithm={algorithm}
+                nodeIds={nodeIds}
+              />
             )}
-          </>
-        ) : (
-          <>
-            {mode === 'solo' ? (
-              <>
-                <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
-                  <GridVisualizer
-                    algorithm={algorithm}
-                    speed={speed}
-                    runKey={runKey}
-                  />
-                </div>
 
-                <ComplexityCard algorithm={algorithm} />
-
-                <div className="w-full">
-                  <CodePanel
-                    title={
-                      algorithm
-                        ? `${getAlgorithmName(algorithm)} Grid Implementation`
-                        : 'Code Viewer'
-                    }
-                    code={
-                      currentSource ||
-                      '// Select an algorithm to see implementation'
-                    }
-                    language={language}
-                    onLanguageChange={setLanguage}
-                  />
-                </div>
-              </>
-            ) : (
-              <GridComparisonMode />
-            )}
-          </>
+            <SpeedSlider value={speed} onChange={handleSpeedChange} />
+          </div>
         )}
+
+        <div className={`flex flex-col gap-6 ${mode === 'solo' ? 'w-full lg:w-3/4' : 'w-full'}`}>
+          {viewMode === 'network' ? (
+            <>
+              {mode === 'solo' ? (
+                <>
+                  <div className="rounded-xl border border-white/10 shadow-lg">
+                    <CanvasShortestPath
+                      algorithm={algorithm}
+                      source={source}
+                      target={target}
+                      speed={speed}
+                      runKey={runKey}
+                      onGraphChange={handleGraphChange}
+                    />
+                  </div>
+
+                  <ComplexityCard algorithm={algorithm} />
+
+                  <div className="w-full">
+                    <CodePanel
+                      title={
+                        algorithm
+                          ? `${getAlgorithmName(algorithm)} Implementation`
+                          : 'Code Viewer'
+                      }
+                      code={
+                        currentSource ||
+                        '// Select an algorithm and nodes to see implementation'
+                      }
+                      language={language}
+                      onLanguageChange={setLanguage}
+                    />
+                  </div>
+                </>
+              ) : (
+                <ComparisonMode />
+              )}
+            </>
+          ) : (
+            <>
+              {mode === 'solo' ? (
+                <>
+                  <div className="rounded-xl overflow-hidden border border-white/10 shadow-lg">
+                    <GridVisualizer
+                      algorithm={algorithm}
+                      speed={speed}
+                      runKey={runKey}
+                    />
+                  </div>
+
+                  <ComplexityCard algorithm={algorithm} />
+
+                  <div className="w-full">
+                    <CodePanel
+                      title={
+                        algorithm
+                          ? `${getAlgorithmName(algorithm)} Grid Implementation`
+                          : 'Code Viewer'
+                      }
+                      code={
+                        currentSource ||
+                        '// Select an algorithm to see implementation'
+                      }
+                      language={language}
+                      onLanguageChange={setLanguage}
+                    />
+                  </div>
+                </>
+              ) : (
+                <GridComparisonMode />
+              )}
+            </>
+          )}
+        </div>
       </div>
     </motion.div>
   )


### PR DESCRIPTION
Closes #706, #385, #320, #312, #290

### Changes
**#706** — Persist visualization speed to localStorage
**#385** — Add execution lock to prevent overlapping Worker spawning
**#320** — Preserve custom editor code when switching Single/Compare modes
**#312** — Hide redundant solo-mode sidebar controls in Compare Mode
**#290** — Add early auth check to prevent Practice page flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent visualization speed, so your last speed setting is restored on return.
  * Reworked algorithm pages with clearer Solo/Compare mode toggles and a cleaner layout.
  * Improved practice access handling with a smoother loading state and automatic sign-in redirection.

* **Bug Fixes**
  * Prevented overlapping runs and profiler executions.
  * Preserved code when switching modes or languages, reducing unexpected resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->