### PR TITLE
fix: remove duplicate LinkedIn icon from footer (#746)

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -154,24 +154,7 @@ const Footer = () => {
                   <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
                 </svg>
               </motion.a>
-              <motion.a
-                href="https://linkedin.com/in/bratik-mukherjee"
-                target="_blank"
-                rel="noreferrer"
-                title="Bratik Mukherjee on LinkedIn"
-                aria-label="Bratik Mukherjee on LinkedIn"
-                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:border-[#0A66C2]/20 transition-all"
-                whileHover={{ scale: 1.05, y: -2 }}
-              >
-                <svg
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                  className="h-4 w-4"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                </svg>
-              </motion.a>
+
             </div>
             <Link
               to="/about"


### PR DESCRIPTION
## Summary

Fixes #746

The footer displayed two identical LinkedIn icons (one for each maintainer). Removed the duplicate icon while keeping the first one. Individual LinkedIn profiles are still accessible via the About page.\n\n## Change\n- Removed Bratik Mukherjee's LinkedIn icon from the footer social links section