### PR TITLE
fix: correct Bubble Sort swap step message values

### DIFF
--- a/src/algorithms/sorting/bubbleSortSteps.js
+++ b/src/algorithms/sorting/bubbleSortSteps.js
@@ -233,6 +233,8 @@ export function generateBubbleSortSteps(inputArray) {
       )
 
       if (arr[j] > arr[j + 1]) {
+        const valA = arr[j]
+        const valB = arr[j + 1]
         ;[arr[j], arr[j + 1]] = [arr[j + 1], arr[j]]
 
         steps.push(
@@ -242,7 +244,7 @@ export function generateBubbleSortSteps(inputArray) {
             array: arr,
             indices: [j, j + 1],
             sortedIndices: [...sortedIndices],
-            message: `Swap ${arr[j + 1]} and ${arr[j]}.`,
+            message: `Swap ${valA} and ${valB}.`,
             variables: { i, j, n },
             duration: 850,
           })


### PR DESCRIPTION
Closes #773

Captured array values before the destructuring swap so the step message displays the original values being swapped instead of the already-mutated values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the clarity of bubble sort step messages by showing the values being swapped at the moment the swap occurs.
  * Kept the swap behavior unchanged while making the displayed step details more accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->