### PR TITLE
feat: Remember last selected CPU scheduling algorithm across page refreshes (#777)

### DIFF
--- a/src/components/operatingSystems/CPUSchedulingPage.jsx
+++ b/src/components/operatingSystems/CPUSchedulingPage.jsx
@@ -21,9 +21,20 @@ export default function CPUSchedulingPage() {
     DEFAULT_PROCESSES.map((p) => ({ ...p }))
   )
 
-  const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
-  return localStorage.getItem('cpu-selected-algorithm') || 'fcfs'
+  const VALID_ALGORITHMS = [
+  'fcfs',
+  'sjf',
+  'srtf',
+  'priority',
+  'roundRobin',
+  'multilevelQueue',
+]
+
+const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
+  const saved = localStorage.getItem('cpu-selected-algorithm')
+  return VALID_ALGORITHMS.includes(saved) ? saved : 'fcfs'
 })
+
   const [simulationStatus, setSimulationStatus] = useState('Not Started')
   const [ganttData, setGanttData] = useState([])
   const [statistics, setStatistics] = useState([])

--- a/src/components/operatingSystems/CPUSchedulingPage.jsx
+++ b/src/components/operatingSystems/CPUSchedulingPage.jsx
@@ -20,7 +20,10 @@ export default function CPUSchedulingPage() {
   const [processes, setProcesses] = useState(() =>
     DEFAULT_PROCESSES.map((p) => ({ ...p }))
   )
-  const [selectedAlgorithm, setSelectedAlgorithm] = useState('fcfs')
+
+  const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
+  return localStorage.getItem('cpu-selected-algorithm') || 'fcfs'
+})
   const [simulationStatus, setSimulationStatus] = useState('Not Started')
   const [ganttData, setGanttData] = useState([])
   const [statistics, setStatistics] = useState([])
@@ -44,6 +47,10 @@ export default function CPUSchedulingPage() {
   const [step3Completed, setStep3Completed] = useState(false)
   const [step4Completed, setStep4Completed] = useState(false)
   const [algorithmChanged, setAlgorithmChanged] = useState(false)
+
+  useEffect(() => {
+  localStorage.setItem('cpu-selected-algorithm', selectedAlgorithm)
+  }, [selectedAlgorithm])
 
   const playbackTimerRef = useRef(null)
   const remainingTimeRef = useRef(new Map())

--- a/src/components/operatingSystems/CPUSchedulingPage.jsx
+++ b/src/components/operatingSystems/CPUSchedulingPage.jsx
@@ -22,18 +22,18 @@ export default function CPUSchedulingPage() {
   )
 
   const VALID_ALGORITHMS = [
-  'fcfs',
-  'sjf',
-  'srtf',
-  'priority',
-  'roundRobin',
-  'multilevelQueue',
-]
+    'fcfs',
+    'sjf',
+    'srtf',
+    'priority',
+    'roundRobin',
+    'multilevelQueue',
+  ]
 
-const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
-  const saved = localStorage.getItem('cpu-selected-algorithm')
-  return VALID_ALGORITHMS.includes(saved) ? saved : 'fcfs'
-})
+  const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
+    const saved = localStorage.getItem('cpu-selected-algorithm')
+    return VALID_ALGORITHMS.includes(saved) ? saved : 'fcfs'
+  })
 
   const [simulationStatus, setSimulationStatus] = useState('Not Started')
   const [ganttData, setGanttData] = useState([])
@@ -60,7 +60,7 @@ const [selectedAlgorithm, setSelectedAlgorithm] = useState(() => {
   const [algorithmChanged, setAlgorithmChanged] = useState(false)
 
   useEffect(() => {
-  localStorage.setItem('cpu-selected-algorithm', selectedAlgorithm)
+    localStorage.setItem('cpu-selected-algorithm', selectedAlgorithm)
   }, [selectedAlgorithm])
 
   const playbackTimerRef = useRef(null)


### PR DESCRIPTION
## Pull Request Summary

This PR implements persistence for the selected CPU Scheduling algorithm using `localStorage`.

### Changes Made

* Stores the selected CPU scheduling algorithm in `localStorage`.
* Restores the previously selected algorithm when the page reloads.
* Falls back to the default `FCFS` algorithm if no saved preference exists.
* Preserves the existing application behavior without affecting other features.

### Testing

* ✅ Selected different CPU scheduling algorithms.
* ✅ Refreshed the page and verified the last selected algorithm was restored.
* ✅ Verified that the default algorithm is used for first-time visitors.
* ✅ Confirmed that all existing CPU scheduling functionality continues to work as expected.

Fixes #777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * The CPU scheduling simulator now persists your selected scheduling algorithm between visits.
  * When you reopen the page, the previously selected algorithm is restored (falling back to a default if the saved value is not recognized).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->