### PR TITLE
fix: add visible focus indicators for keyboard navigation (#721)

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -160,7 +160,7 @@ const Footer = () => {
                 rel="noreferrer"
                 title="Bratik Mukherjee on LinkedIn"
                 aria-label="Bratik Mukherjee on LinkedIn"
-                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:border-[#0A66C2]/20 transition-all"
+                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:border-[#0A66C2]/20 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 whileHover={{ scale: 1.05, y: -2 }}
               >
                 <svg

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -111,7 +111,7 @@ const Footer = () => {
                 href="https://github.com/algoscope-hq/AlgoScope.git"
                 target="_blank"
                 rel="noreferrer"
-                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:theme-text-strong transition-all"
+                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:theme-text-strong transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 whileHover={{ scale: 1.05, y: -2 }}
               >
                 <img
@@ -124,7 +124,7 @@ const Footer = () => {
                 href="https://discord.gg/Yj43j7YV9T"
                 target="_blank"
                 rel="noreferrer"
-                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#5865F2] hover:bg-[#5865F2]/10 hover:border-[#5865F2]/20 transition-all"
+                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#5865F2] hover:bg-[#5865F2]/10 hover:border-[#5865F2]/20 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 whileHover={{ scale: 1.05, y: -2 }}
               >
                 <svg
@@ -142,7 +142,7 @@ const Footer = () => {
                 rel="noreferrer"
                 title="Aditya Paul on LinkedIn"
                 aria-label="Aditya Paul on LinkedIn"
-                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:border-[#0A66C2]/20 transition-all"
+                className="w-9 h-9 theme-media-surface border theme-border rounded-lg flex items-center justify-center theme-text-muted hover:text-[#0A66C2] hover:bg-[#0A66C2]/10 hover:border-[#0A66C2]/20 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 whileHover={{ scale: 1.05, y: -2 }}
               >
                 <svg
@@ -176,7 +176,7 @@ const Footer = () => {
             <Link
               to="/about"
               onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-              className="text-xs theme-text-muted hover:theme-text-strong font-medium transition-colors"
+              className="text-xs theme-text-muted hover:theme-text-strong font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
             >
               About Project &rarr;
             </Link>
@@ -194,7 +194,7 @@ const Footer = () => {
                 key={i}
                 to={algo.path}
                 onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-                className={`group relative theme-media-surface border theme-border ${borderHoverClass} rounded-xl p-5 flex flex-col justify-between transition-all duration-300 transform hover:-translate-y-0.5`}
+                className={`group relative theme-media-surface border theme-border ${borderHoverClass} rounded-xl p-5 flex flex-col justify-between transition-all duration-300 transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900`}
               >
                 <div className="space-y-2">
                   <div className="flex justify-between items-start gap-2">
@@ -238,7 +238,7 @@ const Footer = () => {
           <div className="text-[11px] theme-text-subtle">
             Maintained by{' '}
             <a
-              className="font-semibold text-cyan-400 transition hover:text-cyan-300"
+              className="font-semibold text-cyan-400 transition hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               href="https://github.com/Bimbok"
               target="_blank"
               rel="noreferrer"
@@ -248,7 +248,7 @@ const Footer = () => {
             {' & '}
             <a
               target="_blank"
-              className="font-semibold text-cyan-400 transition hover:text-cyan-300"
+              className="font-semibold text-cyan-400 transition hover:text-cyan-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               href="https://github.com/adityapaul26"
               rel="noreferrer"
             >

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -56,7 +56,7 @@ const ThemeToggleButton = ({ compact = false, ...props }) => {
       onClick={toggleTheme}
       aria-label={label}
       title={label}
-      className={`theme-toggle inline-flex items-center justify-center rounded-xl border transition-all duration-300 active:scale-95 focus:outline-none focus:ring-2 focus:ring-cyan-400/40 ${
+      className={`theme-toggle inline-flex items-center justify-center rounded-xl border transition-all duration-300 active:scale-95 focus:outline-none focus:ring-2 focus:ring-cyan-400/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
         compact ? 'h-10 w-10' : 'h-10 w-10 md:h-10 md:w-10'
       }`}
       {...props}
@@ -223,7 +223,7 @@ export const Navbar = () => {
           <Link
             to="/"
             data-tour="logo-brand"
-            className="flex flex-row text-xl font-semibold tracking-tight group"
+            className="flex flex-row text-xl font-semibold tracking-tight group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
           >
             <div className="w-10 h-10 m-auto rounded flex items-center justify-center mr-3 transition-transform group-hover:scale-110">
               <img src={logo} alt="AlgoScope Logo" className="w-8 h-8" />
@@ -338,7 +338,7 @@ export const Navbar = () => {
                           to={matched?.href || '/'}
                           role="menuitem"
                           onClick={closeExploreMenu}
-                          className="block rounded-lg px-4 py-2 text-sm transition-all duration-200 border-l-2 border-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700"
+                          className="block rounded-lg px-4 py-2 text-sm transition-all duration-200 border-l-2 border-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                         >
                           {item}
                         </Link>
@@ -356,7 +356,7 @@ export const Navbar = () => {
                 <Link
                   to="/favorites"
                   data-tour="favorites-nav"
-                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     pathname === '/favorites'
                       ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
                       : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
@@ -382,7 +382,7 @@ export const Navbar = () => {
               >
                 <Link
                   to="/concepts"
-                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     pathname === '/concepts'
                       ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
                       : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
@@ -409,7 +409,7 @@ export const Navbar = () => {
                 <Link
                   to="/practice"
                   data-tour="practice-nav"
-                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     pathname === '/practice'
                       ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
                       : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
@@ -437,7 +437,7 @@ export const Navbar = () => {
                 <Link
                   to="/challenge"
                   data-tour="challenge-nav"
-                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 ${
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     pathname === '/challenge'
                       ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
                       : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
@@ -465,7 +465,7 @@ export const Navbar = () => {
               data-tour="github-btn"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 hover:bg-slate-100 dark:hover:bg-slate-800/80 text-slate-700 dark:text-slate-200 rounded-xl px-4 py-1.5 text-sm font-medium transition-all duration-300 shadow-md active:scale-95"
+              className="flex items-center gap-2 border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 hover:bg-slate-100 dark:hover:bg-slate-800/80 text-slate-700 dark:text-slate-200 rounded-xl px-4 py-1.5 text-sm font-medium transition-all duration-300 shadow-md active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
             >
               <img
                 src={githubIcon}
@@ -487,7 +487,7 @@ export const Navbar = () => {
                       mode="modal"
                       appearance={{ baseTheme: isDark ? dark : undefined }}
                     >
-                      <button className="theme-button-primary relative group overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 hover:bg-slate-100 dark:hover:bg-slate-800/80 text-slate-700 dark:text-slate-200 px-6 py-2 text-sm font-bold transition-all duration-300 shadow-md active:scale-95">
+                      <button className="theme-button-primary relative group overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 hover:bg-slate-100 dark:hover:bg-slate-800/80 text-slate-700 dark:text-slate-200 px-6 py-2 text-sm font-bold transition-all duration-300 shadow-md active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">
                         <span className="relative z-10">Sign In</span>
                         <div className="absolute inset-0 bg-gradient-to-r from-indigo-600/20 to-purple-600/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                       </button>
@@ -542,7 +542,7 @@ export const Navbar = () => {
               aria-expanded={open}
               onClick={() => setOpen((o) => !o)}
               animate={open ? 'open' : 'closed'}
-              className="inline-flex flex-col items-center justify-center gap-1 rounded-lg p-2 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-colors"
+              className="inline-flex flex-col items-center justify-center gap-1 rounded-lg p-2 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
             >
               <Line variants={topVariants} />
               <Line variants={middleVariants} />
@@ -578,7 +578,7 @@ export const Navbar = () => {
                 <Link
                   to="/"
                   onClick={() => setOpen(false)}
-                  className="flex items-center gap-2"
+                  className="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 >
                   <img src={logo} alt="AlgoScope Logo" className="w-8 h-8" />
                   <span className="text-xl font-bold tracking-tighter text-slate-900 dark:text-white logo-font">
@@ -588,7 +588,7 @@ export const Navbar = () => {
                 <button
                   type="button"
                   onClick={() => setOpen(false)}
-                  className="p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-900 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+                  className="p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-900 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 >
                   <X className="w-6 h-6" />
                 </button>
@@ -612,7 +612,7 @@ export const Navbar = () => {
                         <Link
                           to={link.href}
                           onClick={() => setOpen(false)}
-                          className={`block rounded-lg px-4 py-2.5 text-sm transition-all duration-200 border-l-2 ${
+                          className={`block rounded-lg px-4 py-2.5 text-sm transition-all duration-200 border-l-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                             pathname === link.href
                               ? 'bg-indigo-50/80 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 border-indigo-600 dark:border-indigo-500 font-semibold'
                               : 'text-slate-600 dark:text-slate-400 border-transparent hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700'
@@ -634,7 +634,7 @@ export const Navbar = () => {
                       mode="modal"
                       appearance={{ baseTheme: isDark ? dark : undefined }}
                     >
-                      <button className="w-full relative group overflow-hidden rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-300 active:scale-[0.98]">
+                      <button className="w-full relative group overflow-hidden rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-300 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900">
                         <span className="relative z-10">Sign In</span>
                         <div className="absolute inset-0 bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                       </button>
@@ -644,7 +644,7 @@ export const Navbar = () => {
                   <button
                     title="Auth not configured"
                     disabled
-                    className="w-full rounded-xl bg-slate-100 dark:bg-slate-900 px-4 py-2.5 text-sm font-semibold text-slate-500 border border-slate-200 dark:border-slate-800 transition-all duration-300 opacity-50 cursor-not-allowed"
+                    className="w-full rounded-xl bg-slate-100 dark:bg-slate-900 px-4 py-2.5 text-sm font-semibold text-slate-500 border border-slate-200 dark:border-slate-800 transition-all duration-300 opacity-50 cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                   >
                     Sign In
                   </button>
@@ -655,7 +655,7 @@ export const Navbar = () => {
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={() => setOpen(false)}
-                  className="flex items-center justify-center gap-2 w-full rounded-xl bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-4 py-2.5 text-sm font-semibold text-slate-700 dark:text-slate-200 transition-all duration-300 shadow-md active:scale-95"
+                  className="flex items-center justify-center gap-2 w-full rounded-xl bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-4 py-2.5 text-sm font-semibold text-slate-700 dark:text-slate-200 transition-all duration-300 shadow-md active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                 >
                   <img
                     src={githubIcon}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -272,7 +272,7 @@ export const Navbar = () => {
                     setHoveredTab('explore')
                   }}
                   onKeyDown={handleExploreKeyDown}
-                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 cursor-pointer ${
+                  className={`relative text-sm font-medium px-4 py-1.5 rounded-lg transition-all duration-300 z-10 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     isExploreActive
                       ? 'text-indigo-600 dark:text-indigo-300 font-semibold'
                       : 'text-slate-400 hover:text-slate-900 dark:hover:text-slate-100'
@@ -306,7 +306,7 @@ export const Navbar = () => {
                       to={link.href}
                       role="menuitem"
                       onClick={closeExploreMenu}
-                      className={`block rounded-lg px-4 py-2 text-sm transition-all duration-200 border-l-2 ${
+                      className={`block rounded-lg px-4 py-2 text-sm transition-all duration-200 border-l-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                         pathname === link.href
                           ? 'bg-indigo-50/80 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-300 border-indigo-600 dark:border-indigo-500 font-medium'
                           : 'text-slate-600 dark:text-slate-400 border-transparent hover:bg-slate-100 dark:hover:bg-slate-900 hover:text-slate-900 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-700'

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -32,7 +32,7 @@ const ScrollToTopButton = () => {
         <button
           onClick={scrollToTop}
           aria-label="Scroll to top"
-          className="w-10 h-10 rounded-full bg-violet-600 flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all duration-200"
+          className="w-10 h-10 rounded-full bg-violet-600 flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -54,7 +54,7 @@ const ScrollToTopButton = () => {
         <button
           onClick={scrollToBottom}
           aria-label="Scroll to bottom"
-          className="w-10 h-10 rounded-full bg-violet-600 flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all duration-200"
+          className="w-10 h-10 rounded-full bg-violet-600 flex items-center justify-center shadow-lg hover:scale-110 active:scale-95 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -627,7 +627,7 @@ const SearchBar = ({ onOpen }) => {
       <button
         ref={triggerRef}
         onClick={openModal}
-        className="flex items-center gap-2 px-3 py-1.5 bg-slate-900/40 border border-white/10 hover:border-cyan-500/50 rounded-xl text-slate-400 hover:text-cyan-400 transition-all group w-full lg:w-48"
+        className="flex items-center gap-2 px-3 py-1.5 bg-slate-900/40 border border-white/10 hover:border-cyan-500/50 rounded-xl text-slate-400 hover:text-cyan-400 transition-all group w-full lg:w-48 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
         aria-haspopup="dialog"
         aria-expanded={isModalOpen}
         aria-label="Search algorithms"
@@ -704,7 +704,7 @@ const SearchBar = ({ onOpen }) => {
                   type="text"
                   value={query}
                   onChange={handleSearch}
-                  className="w-full bg-transparent text-slate-200 text-lg block pl-12 pr-24 py-2 outline-none"
+                  className="w-full bg-transparent text-slate-200 text-lg block pl-12 pr-24 py-2 outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                   placeholder="Search algorithms..."
                 />
                 <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-3">
@@ -729,7 +729,7 @@ const SearchBar = ({ onOpen }) => {
                         )
                         setResults(sortedResults)
                       }}
-                      className="bg-slate-800 border border-slate-600 text-slate-300 text-xs px-2 py-1 rounded-lg cursor-pointer outline-none"
+                      className="bg-slate-800 border border-slate-600 text-slate-300 text-xs px-2 py-1 rounded-lg cursor-pointer outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                       aria-label="Sort results"
                     >
                       <option value="relevance">Relevance</option>
@@ -741,7 +741,7 @@ const SearchBar = ({ onOpen }) => {
                   {/* Close Button */}
                   <button
                     onClick={handleCloseModal}
-                    className="p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/10 transition-all duration-200"
+                    className="p-1.5 rounded-lg text-slate-500 hover:text-white hover:bg-white/10 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
                     aria-label="Close search"
                   >
                     <svg


### PR DESCRIPTION
## Description

### What does this PR do?
Adds visible keyboard focus indicators to interactive UI elements using `:focus-visible` styles to improve accessibility.

### Changes made
- Added visible focus rings to navigation controls
- Added focus indicators to search controls
- Added focus styles to footer links and social icons
- Added focus indicators to scroll-to-top buttons
- Preserved existing hover effects and UI design

Fixes #721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added consistent, visible keyboard-focus indicators to navigation links, footer links, menus, buttons, search controls, and scroll controls.
  * Improved focus styling across desktop and mobile interactive elements without changing their behavior or destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->