### PR TITLE
feat: add Trie (Prefix Tree) visualizer to Abstract Data Types

### DIFF
--- a/src/components/dataStructures/DSLayout.jsx
+++ b/src/components/dataStructures/DSLayout.jsx
@@ -7,6 +7,7 @@ import TreeIV from './treeIV'
 import BinaryHeapIV from './binaryHeapIV'
 import PriorityQueueIV from './priorityQueueIV'
 import DSUIV from './dsuIV'
+import TrieIV from './TrieIV'
 import LinkedListIV from './LinkedListIV'
 import CodePanel from '../visualizer/CodePanel'
 import { adtSources } from './adtSources'
@@ -21,6 +22,7 @@ const tabs = [
   { id: 'dsu', label: 'Disjoint Set Union' },
   { id: 'linked-list', label: 'Linked List' },
   { id: 'graph', label: 'Graph Builder' },
+  { id: 'trie', label: 'Trie' },
 ]
 
 export const DSLayout = () => {
@@ -129,6 +131,9 @@ export const DSLayout = () => {
     if (activeTab === 'linked-list') {
       return adtSources.linkedList?.['singly linked list']?.[selectedLang] || ''
     }
+     if (activeTab === 'trie') {
+      return adtSources.trie?.['prefix tree']?.[selectedLang] || ''
+    }
 
     return ''
   }, [activeTab, selectedLang, stackMode, treeTraversal])
@@ -141,6 +146,7 @@ export const DSLayout = () => {
     if (activeTab === 'priority-queue') return 'Priority Queue'
     if (activeTab === 'dsu') return 'Disjoint Set Union'
     if (activeTab === 'linked-list') return 'Singly Linked List'
+    if (activeTab === 'trie') return 'Trie (Prefix Tree)'
     return 'Queue'
   }
 
@@ -221,6 +227,8 @@ export const DSLayout = () => {
         {activeTab === 'dsu' && mode === 'solo' && <DSUIV />}
 
         {activeTab === 'linked-list' && mode === 'solo' && <LinkedListIV />}
+
+        {activeTab === 'trie' && mode === 'solo' && <TrieIV />}
 
         {activeTab === 'graph' && (
           <div className="flex items-center justify-center min-h-[300px] text-slate-500">

--- a/src/components/dataStructures/DSLayout.jsx
+++ b/src/components/dataStructures/DSLayout.jsx
@@ -131,7 +131,7 @@ export const DSLayout = () => {
     if (activeTab === 'linked-list') {
       return adtSources.linkedList?.['singly linked list']?.[selectedLang] || ''
     }
-     if (activeTab === 'trie') {
+    if (activeTab === 'trie') {
       return adtSources.trie?.['prefix tree']?.[selectedLang] || ''
     }
 

--- a/src/components/dataStructures/TrieIV.jsx
+++ b/src/components/dataStructures/TrieIV.jsx
@@ -62,7 +62,6 @@ class Trie {
 
 function TrieNodeView({ node, highlightPath, depth = 0 }) {
   const isHighlighted = highlightPath.includes(node.fullPrefix)
-  
 
   return (
     <div className="flex flex-col items-center">
@@ -198,8 +197,6 @@ export default function TrieIV() {
       })
     }
   }
-
-  
 
   return (
     <div className="flex flex-col gap-4 text-slate-200 min-h-[400px]">

--- a/src/components/dataStructures/TrieIV.jsx
+++ b/src/components/dataStructures/TrieIV.jsx
@@ -62,7 +62,7 @@ class Trie {
 
 function TrieNodeView({ node, highlightPath, depth = 0 }) {
   const isHighlighted = highlightPath.includes(node.fullPrefix)
-  const isLeaf = node.children.length === 0
+  
 
   return (
     <div className="flex flex-col items-center">
@@ -108,14 +108,16 @@ function TrieNodeView({ node, highlightPath, depth = 0 }) {
 
 export default function TrieIV() {
   const trieRef = useRef(new Trie())
-  const [, forceUpdate] = useState(0)
+  const [trieJSON, setTrieJSON] = useState(() => new Trie().toJSON())
   const [inputWord, setInputWord] = useState('')
   const [operation, setOperation] = useState('insert')
   const [result, setResult] = useState(null)
   const [highlightPath, setHighlightPath] = useState([])
   const [words, setWords] = useState([])
 
-  const refresh = useCallback(() => forceUpdate((n) => n + 1), [])
+  const refresh = useCallback(() => {
+    setTrieJSON(trieRef.current.toJSON())
+  }, [])
 
   const handleReset = () => {
     trieRef.current = new Trie()
@@ -197,7 +199,7 @@ export default function TrieIV() {
     }
   }
 
-  const trieJSON = trieRef.current.toJSON()
+  
 
   return (
     <div className="flex flex-col gap-4 text-slate-200 min-h-[400px]">

--- a/src/components/dataStructures/TrieIV.jsx
+++ b/src/components/dataStructures/TrieIV.jsx
@@ -71,10 +71,10 @@ function TrieNodeView({ node, highlightPath, depth = 0 }) {
           isHighlighted
             ? 'bg-cyan-500 border-cyan-300 text-white shadow-[0_0_12px_rgba(6,182,212,0.6)]'
             : node.isEnd
-            ? 'bg-green-700 border-green-400 text-white'
-            : depth === 0
-            ? 'bg-slate-600 border-slate-400 text-slate-200'
-            : 'bg-slate-800 border-slate-600 text-slate-300'
+              ? 'bg-green-700 border-green-400 text-white'
+              : depth === 0
+                ? 'bg-slate-600 border-slate-400 text-slate-200'
+                : 'bg-slate-800 border-slate-600 text-slate-300'
         }`}
       >
         {node.label === 'root' ? '·' : node.label}
@@ -117,7 +117,7 @@ export default function TrieIV() {
 
   const refresh = useCallback(() => forceUpdate((n) => n + 1), [])
 
-const handleReset = () => {
+  const handleReset = () => {
     trieRef.current = new Trie()
     setWords([])
     setResult(null)
@@ -144,20 +144,30 @@ const handleReset = () => {
       const path = trieRef.current.insert(word)
       setWords((prev) => (prev.includes(word) ? prev : [...prev, word]))
       setHighlightPath(
-        path.reduce((acc, _, i) => {
-          acc.push(path.slice(1, i + 1).join(''))
-          return acc
-        }, [''])
+        path.reduce(
+          (acc, _, i) => {
+            acc.push(path.slice(1, i + 1).join(''))
+            return acc
+          },
+          ['']
+        )
       )
-      setResult({ type: 'insert', word, message: `"${word}" inserted into Trie` })
+      setResult({
+        type: 'insert',
+        word,
+        message: `"${word}" inserted into Trie`,
+      })
       refresh()
     } else if (operation === 'search') {
       const { found, path } = trieRef.current.search(word)
       setHighlightPath(
-        path.reduce((acc, _, i) => {
-          acc.push(path.slice(1, i + 1).join(''))
-          return acc
-        }, [''])
+        path.reduce(
+          (acc, _, i) => {
+            acc.push(path.slice(1, i + 1).join(''))
+            return acc
+          },
+          ['']
+        )
       )
       setResult({
         type: found ? 'success' : 'fail',
@@ -169,10 +179,13 @@ const handleReset = () => {
     } else if (operation === 'startsWith') {
       const { found, path } = trieRef.current.startsWith(word)
       setHighlightPath(
-        path.reduce((acc, _, i) => {
-          acc.push(path.slice(1, i + 1).join(''))
-          return acc
-        }, [''])
+        path.reduce(
+          (acc, _, i) => {
+            acc.push(path.slice(1, i + 1).join(''))
+            return acc
+          },
+          ['']
+        )
       )
       setResult({
         type: found ? 'success' : 'fail',
@@ -239,7 +252,9 @@ const handleReset = () => {
           {words.length === 0 ? (
             <div className="text-slate-400 text-center py-20">
               <p>Trie is empty</p>
-              <p className="text-sm mt-2">Insert a word or click Sample to begin</p>
+              <p className="text-sm mt-2">
+                Insert a word or click Sample to begin
+              </p>
             </div>
           ) : (
             <div className="flex justify-center pt-4">
@@ -255,15 +270,17 @@ const handleReset = () => {
         {/* Info Panel */}
         <div className="space-y-3">
           <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
-            <div className="text-cyan-400 font-bold text-xs mb-2">Last Result</div>
+            <div className="text-cyan-400 font-bold text-xs mb-2">
+              Last Result
+            </div>
             {result ? (
               <div
                 className={`font-mono text-xs whitespace-pre-wrap ${
                   result.type === 'insert'
                     ? 'text-cyan-400'
                     : result.type === 'success'
-                    ? 'text-green-400'
-                    : 'text-red-400'
+                      ? 'text-green-400'
+                      : 'text-red-400'
                 }`}
               >
                 {result.message}

--- a/src/components/dataStructures/TrieIV.jsx
+++ b/src/components/dataStructures/TrieIV.jsx
@@ -1,0 +1,317 @@
+import React, { useState, useCallback } from 'react'
+
+class TrieNode {
+  constructor() {
+    this.children = {}
+    this.isEnd = false
+  }
+}
+
+class Trie {
+  constructor() {
+    this.root = new TrieNode()
+  }
+
+  insert(word) {
+    let node = this.root
+    const path = ['']
+    for (const char of word) {
+      if (!node.children[char]) {
+        node.children[char] = new TrieNode()
+      }
+      node = node.children[char]
+      path.push(char)
+    }
+    node.isEnd = true
+    return path
+  }
+
+  search(word) {
+    let node = this.root
+    const path = ['']
+    for (const char of word) {
+      if (!node.children[char]) return { found: false, path }
+      node = node.children[char]
+      path.push(char)
+    }
+    return { found: node.isEnd, path }
+  }
+
+  startsWith(prefix) {
+    let node = this.root
+    const path = ['']
+    for (const char of prefix) {
+      if (!node.children[char]) return { found: false, path }
+      node = node.children[char]
+      path.push(char)
+    }
+    return { found: true, path }
+  }
+
+  toJSON(node = this.root, prefix = '') {
+    return {
+      label: prefix === '' ? 'root' : prefix[prefix.length - 1],
+      fullPrefix: prefix,
+      isEnd: node.isEnd,
+      children: Object.entries(node.children).map(([char, child]) =>
+        this.toJSON(child, prefix + char)
+      ),
+    }
+  }
+}
+
+function TrieNodeView({ node, highlightPath, depth = 0 }) {
+  const isHighlighted = highlightPath.includes(node.fullPrefix)
+  const isLeaf = node.children.length === 0
+
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className={`w-10 h-10 rounded-full flex items-center justify-center font-mono font-bold text-sm border-2 transition-all duration-300 ${
+          isHighlighted
+            ? 'bg-cyan-500 border-cyan-300 text-white shadow-[0_0_12px_rgba(6,182,212,0.6)]'
+            : node.isEnd
+            ? 'bg-green-700 border-green-400 text-white'
+            : depth === 0
+            ? 'bg-slate-600 border-slate-400 text-slate-200'
+            : 'bg-slate-800 border-slate-600 text-slate-300'
+        }`}
+      >
+        {node.label === 'root' ? '·' : node.label}
+      </div>
+
+      {node.isEnd && (
+        <div className="text-green-400 text-[9px] mt-0.5 font-mono">END</div>
+      )}
+
+      {node.children.length > 0 && (
+        <div className="flex gap-4 mt-4 relative">
+          <div
+            className="absolute top-0 left-0 right-0 h-px bg-slate-600"
+            style={{ top: '-8px' }}
+          />
+          {node.children.map((child) => (
+            <div key={child.fullPrefix} className="flex flex-col items-center">
+              <div className="w-px h-4 bg-slate-600" />
+              <TrieNodeView
+                node={child}
+                highlightPath={highlightPath}
+                depth={depth + 1}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function TrieIV() {
+  const [trie] = useState(() => new Trie())
+  const [, forceUpdate] = useState(0)
+  const [inputWord, setInputWord] = useState('')
+  const [operation, setOperation] = useState('insert')
+  const [result, setResult] = useState(null)
+  const [highlightPath, setHighlightPath] = useState([])
+  const [words, setWords] = useState([])
+
+  const refresh = useCallback(() => forceUpdate((n) => n + 1), [])
+
+  const handleReset = () => {
+    trie.root = new TrieNode()
+    setWords([])
+    setResult(null)
+    setHighlightPath([])
+    setInputWord('')
+    refresh()
+  }
+
+  const handleSample = () => {
+    trie.root = new TrieNode()
+    const sample = ['apple', 'app', 'apt', 'bat', 'ball', 'band']
+    sample.forEach((w) => trie.insert(w))
+    setWords(sample)
+    setResult(null)
+    setHighlightPath([])
+    refresh()
+  }
+
+  const handleRun = () => {
+    const word = inputWord.trim().toLowerCase()
+    if (!word) return
+
+    if (operation === 'insert') {
+      const path = trie.insert(word)
+      setWords((prev) => (prev.includes(word) ? prev : [...prev, word]))
+      setHighlightPath(
+        path.reduce((acc, _, i) => {
+          acc.push(path.slice(1, i + 1).join(''))
+          return acc
+        }, [''])
+      )
+      setResult({ type: 'insert', word, message: `"${word}" inserted into Trie` })
+      refresh()
+    } else if (operation === 'search') {
+      const { found, path } = trie.search(word)
+      setHighlightPath(
+        path.reduce((acc, _, i) => {
+          acc.push(path.slice(1, i + 1).join(''))
+          return acc
+        }, [''])
+      )
+      setResult({
+        type: found ? 'success' : 'fail',
+        word,
+        message: found
+          ? `"${word}" found in Trie ✓`
+          : `"${word}" not found in Trie ✗`,
+      })
+    } else if (operation === 'startsWith') {
+      const { found, path } = trie.startsWith(word)
+      setHighlightPath(
+        path.reduce((acc, _, i) => {
+          acc.push(path.slice(1, i + 1).join(''))
+          return acc
+        }, [''])
+      )
+      setResult({
+        type: found ? 'success' : 'fail',
+        word,
+        message: found
+          ? `Prefix "${word}" exists in Trie ✓`
+          : `Prefix "${word}" not found in Trie ✗`,
+      })
+    }
+  }
+
+  const trieJSON = trie.toJSON()
+
+  return (
+    <div className="flex flex-col gap-4 text-slate-200 min-h-[400px]">
+      {/* Controls */}
+      <div className="flex flex-wrap gap-2 items-center p-3 bg-slate-900/60 rounded-xl border border-slate-700">
+        <select
+          value={operation}
+          onChange={(e) => setOperation(e.target.value)}
+          className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-white text-sm outline-none focus:border-cyan-500"
+        >
+          <option value="insert">Insert</option>
+          <option value="search">Search</option>
+          <option value="startsWith">StartsWith</option>
+        </select>
+
+        <input
+          type="text"
+          value={inputWord}
+          onChange={(e) => setInputWord(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleRun()}
+          placeholder="Enter word..."
+          className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-white text-sm outline-none focus:border-cyan-500 w-36"
+        />
+
+        <button
+          onClick={handleRun}
+          className="px-3 py-1.5 bg-cyan-600 hover:bg-cyan-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Run
+        </button>
+
+        <div className="w-px h-6 bg-slate-600" />
+
+        <button
+          onClick={handleSample}
+          className="px-3 py-1.5 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Sample
+        </button>
+
+        <button
+          onClick={handleReset}
+          className="px-3 py-1.5 bg-red-600 hover:bg-red-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-3 flex-1 min-h-[350px]">
+        {/* Trie Visualization */}
+        <div className="lg:col-span-3 bg-slate-800/50 rounded-xl border border-slate-700 p-4 overflow-auto">
+          {words.length === 0 ? (
+            <div className="text-slate-400 text-center py-20">
+              <p>Trie is empty</p>
+              <p className="text-sm mt-2">Insert a word or click Sample to begin</p>
+            </div>
+          ) : (
+            <div className="flex justify-center pt-4">
+              <TrieNodeView
+                node={trieJSON}
+                highlightPath={highlightPath}
+                depth={0}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Info Panel */}
+        <div className="space-y-3">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">Last Result</div>
+            {result ? (
+              <div
+                className={`font-mono text-xs whitespace-pre-wrap ${
+                  result.type === 'insert'
+                    ? 'text-cyan-400'
+                    : result.type === 'success'
+                    ? 'text-green-400'
+                    : 'text-red-400'
+                }`}
+              >
+                {result.message}
+              </div>
+            ) : (
+              <div className="text-slate-500 text-xs">No operations yet</div>
+            )}
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">
+              Words Inserted ({words.length})
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {words.map((w) => (
+                <span
+                  key={w}
+                  className="text-xs bg-slate-700 text-slate-300 px-2 py-0.5 rounded font-mono"
+                >
+                  {w}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">Legend</div>
+            <div className="space-y-1.5 text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-slate-600 border-2 border-slate-400" />
+                <span className="text-slate-400">Root node</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-slate-800 border-2 border-slate-600" />
+                <span className="text-slate-400">Inner node</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-green-700 border-2 border-green-400" />
+                <span className="text-slate-400">End of word</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-full bg-cyan-500 border-2 border-cyan-300" />
+                <span className="text-slate-400">Highlighted path</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dataStructures/TrieIV.jsx
+++ b/src/components/dataStructures/TrieIV.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useRef } from 'react'
 
 class TrieNode {
   constructor() {
@@ -107,7 +107,7 @@ function TrieNodeView({ node, highlightPath, depth = 0 }) {
 }
 
 export default function TrieIV() {
-  const [trie] = useState(() => new Trie())
+  const trieRef = useRef(new Trie())
   const [, forceUpdate] = useState(0)
   const [inputWord, setInputWord] = useState('')
   const [operation, setOperation] = useState('insert')
@@ -117,8 +117,8 @@ export default function TrieIV() {
 
   const refresh = useCallback(() => forceUpdate((n) => n + 1), [])
 
-  const handleReset = () => {
-    trie.root = new TrieNode()
+const handleReset = () => {
+    trieRef.current = new Trie()
     setWords([])
     setResult(null)
     setHighlightPath([])
@@ -127,9 +127,9 @@ export default function TrieIV() {
   }
 
   const handleSample = () => {
-    trie.root = new TrieNode()
+    trieRef.current = new Trie()
     const sample = ['apple', 'app', 'apt', 'bat', 'ball', 'band']
-    sample.forEach((w) => trie.insert(w))
+    sample.forEach((w) => trieRef.current.insert(w))
     setWords(sample)
     setResult(null)
     setHighlightPath([])
@@ -141,7 +141,7 @@ export default function TrieIV() {
     if (!word) return
 
     if (operation === 'insert') {
-      const path = trie.insert(word)
+      const path = trieRef.current.insert(word)
       setWords((prev) => (prev.includes(word) ? prev : [...prev, word]))
       setHighlightPath(
         path.reduce((acc, _, i) => {
@@ -152,7 +152,7 @@ export default function TrieIV() {
       setResult({ type: 'insert', word, message: `"${word}" inserted into Trie` })
       refresh()
     } else if (operation === 'search') {
-      const { found, path } = trie.search(word)
+      const { found, path } = trieRef.current.search(word)
       setHighlightPath(
         path.reduce((acc, _, i) => {
           acc.push(path.slice(1, i + 1).join(''))
@@ -167,7 +167,7 @@ export default function TrieIV() {
           : `"${word}" not found in Trie ✗`,
       })
     } else if (operation === 'startsWith') {
-      const { found, path } = trie.startsWith(word)
+      const { found, path } = trieRef.current.startsWith(word)
       setHighlightPath(
         path.reduce((acc, _, i) => {
           acc.push(path.slice(1, i + 1).join(''))
@@ -184,7 +184,7 @@ export default function TrieIV() {
     }
   }
 
-  const trieJSON = trie.toJSON()
+  const trieJSON = trieRef.current.toJSON()
 
   return (
     <div className="flex flex-col gap-4 text-slate-200 min-h-[400px]">

--- a/src/components/dataStructures/adtSources.js
+++ b/src/components/dataStructures/adtSources.js
@@ -1611,10 +1611,16 @@ TrieNode* newNode() {
     return node;
 }
 
+static int charIndex(char c) {
+    int idx = c - 'a';
+    return (idx >= 0 && idx < ALPHA) ? idx : -1;
+}
+
 void insert(TrieNode* root, char* word) {
     TrieNode* node = root;
     for (int i = 0; word[i]; i++) {
-        int idx = word[i] - 'a';
+        int idx = charIndex(word[i]);
+        if (idx < 0) return;
         if (!node->children[idx])
             node->children[idx] = newNode();
         node = node->children[idx];
@@ -1625,11 +1631,21 @@ void insert(TrieNode* root, char* word) {
 int search(TrieNode* root, char* word) {
     TrieNode* node = root;
     for (int i = 0; word[i]; i++) {
-        int idx = word[i] - 'a';
-        if (!node->children[idx]) return 0;
+        int idx = charIndex(word[i]);
+        if (idx < 0 || !node->children[idx]) return 0;
         node = node->children[idx];
     }
     return node->isEnd;
+}
+
+int startsWith(TrieNode* root, char* prefix) {
+    TrieNode* node = root;
+    for (int i = 0; prefix[i]; i++) {
+        int idx = charIndex(prefix[i]);
+        if (idx < 0 || !node->children[idx]) return 0;
+        node = node->children[idx];
+    }
+    return 1;
 }`,
       rust: `use std::collections::HashMap;
 

--- a/src/components/dataStructures/adtSources.js
+++ b/src/components/dataStructures/adtSources.js
@@ -1442,4 +1442,287 @@ func (dsu *DisjointSetUnion) Union(x, y int) bool {
 }`,
     },
   },
+  trie: {
+    'prefix tree': {
+      javascript: `class TrieNode {
+  constructor() {
+    this.children = {};
+    this.isEnd = false;
+  }
+}
+
+class Trie {
+  constructor() {
+    this.root = new TrieNode();
+  }
+
+  insert(word) {
+    let node = this.root;
+    for (const char of word) {
+      if (!node.children[char])
+        node.children[char] = new TrieNode();
+      node = node.children[char];
+    }
+    node.isEnd = true;
+  }
+
+  search(word) {
+    let node = this.root;
+    for (const char of word) {
+      if (!node.children[char]) return false;
+      node = node.children[char];
+    }
+    return node.isEnd;
+  }
+
+  startsWith(prefix) {
+    let node = this.root;
+    for (const char of prefix) {
+      if (!node.children[char]) return false;
+      node = node.children[char];
+    }
+    return true;
+  }
+}`,
+      python: `class TrieNode:
+    def __init__(self):
+        self.children = {}
+        self.is_end = False
+
+class Trie:
+    def __init__(self):
+        self.root = TrieNode()
+
+    def insert(self, word):
+        node = self.root
+        for char in word:
+            if char not in node.children:
+                node.children[char] = TrieNode()
+            node = node.children[char]
+        node.is_end = True
+
+    def search(self, word):
+        node = self.root
+        for char in word:
+            if char not in node.children:
+                return False
+            node = node.children[char]
+        return node.is_end
+
+    def starts_with(self, prefix):
+        node = self.root
+        for char in prefix:
+            if char not in node.children:
+                return False
+            node = node.children[char]
+        return True`,
+      cpp: `#include <unordered_map>
+#include <string>
+
+struct TrieNode {
+    std::unordered_map<char, TrieNode*> children;
+    bool isEnd = false;
+};
+
+class Trie {
+    TrieNode* root;
+public:
+    Trie() { root = new TrieNode(); }
+
+    void insert(std::string word) {
+        TrieNode* node = root;
+        for (char c : word) {
+            if (!node->children.count(c))
+                node->children[c] = new TrieNode();
+            node = node->children[c];
+        }
+        node->isEnd = true;
+    }
+
+    bool search(std::string word) {
+        TrieNode* node = root;
+        for (char c : word) {
+            if (!node->children.count(c)) return false;
+            node = node->children[c];
+        }
+        return node->isEnd;
+    }
+
+    bool startsWith(std::string prefix) {
+        TrieNode* node = root;
+        for (char c : prefix) {
+            if (!node->children.count(c)) return false;
+            node = node->children[c];
+        }
+        return true;
+    }
+};`,
+      java: `import java.util.HashMap;
+
+class TrieNode {
+    HashMap<Character, TrieNode> children = new HashMap<>();
+    boolean isEnd = false;
+}
+
+class Trie {
+    TrieNode root = new TrieNode();
+
+    public void insert(String word) {
+        TrieNode node = root;
+        for (char c : word.toCharArray()) {
+            node.children.putIfAbsent(c, new TrieNode());
+            node = node.children.get(c);
+        }
+        node.isEnd = true;
+    }
+
+    public boolean search(String word) {
+        TrieNode node = root;
+        for (char c : word.toCharArray()) {
+            if (!node.children.containsKey(c)) return false;
+            node = node.children.get(c);
+        }
+        return node.isEnd;
+    }
+
+    public boolean startsWith(String prefix) {
+        TrieNode node = root;
+        for (char c : prefix.toCharArray()) {
+            if (!node.children.containsKey(c)) return false;
+            node = node.children.get(c);
+        }
+        return true;
+    }
+}`,
+      c: `#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ALPHA 26
+
+typedef struct TrieNode {
+    struct TrieNode* children[ALPHA];
+    int isEnd;
+} TrieNode;
+
+TrieNode* newNode() {
+    TrieNode* node = calloc(1, sizeof(TrieNode));
+    node->isEnd = 0;
+    return node;
+}
+
+void insert(TrieNode* root, char* word) {
+    TrieNode* node = root;
+    for (int i = 0; word[i]; i++) {
+        int idx = word[i] - 'a';
+        if (!node->children[idx])
+            node->children[idx] = newNode();
+        node = node->children[idx];
+    }
+    node->isEnd = 1;
+}
+
+int search(TrieNode* root, char* word) {
+    TrieNode* node = root;
+    for (int i = 0; word[i]; i++) {
+        int idx = word[i] - 'a';
+        if (!node->children[idx]) return 0;
+        node = node->children[idx];
+    }
+    return node->isEnd;
+}`,
+      rust: `use std::collections::HashMap;
+
+#[derive(Default)]
+struct TrieNode {
+    children: HashMap<char, TrieNode>,
+    is_end: bool,
+}
+
+struct Trie {
+    root: TrieNode,
+}
+
+impl Trie {
+    fn new() -> Self { Trie { root: TrieNode::default() } }
+
+    fn insert(&mut self, word: &str) {
+        let mut node = &mut self.root;
+        for c in word.chars() {
+            node = node.children.entry(c).or_default();
+        }
+        node.is_end = true;
+    }
+
+    fn search(&self, word: &str) -> bool {
+        let mut node = &self.root;
+        for c in word.chars() {
+            match node.children.get(&c) {
+                None => return false,
+                Some(n) => node = n,
+            }
+        }
+        node.is_end
+    }
+
+    fn starts_with(&self, prefix: &str) -> bool {
+        let mut node = &self.root;
+        for c in prefix.chars() {
+            match node.children.get(&c) {
+                None => return false,
+                Some(n) => node = n,
+            }
+        }
+        true
+    }
+}`,
+      go: `package main
+
+type TrieNode struct {
+    children map[rune]*TrieNode
+    isEnd    bool
+}
+
+func newTrieNode() *TrieNode {
+    return &TrieNode{children: make(map[rune]*TrieNode)}
+}
+
+type Trie struct{ root *TrieNode }
+
+func NewTrie() *Trie { return &Trie{root: newTrieNode()} }
+
+func (t *Trie) Insert(word string) {
+    node := t.root
+    for _, c := range word {
+        if _, ok := node.children[c]; !ok {
+            node.children[c] = newTrieNode()
+        }
+        node = node.children[c]
+    }
+    node.isEnd = true
+}
+
+func (t *Trie) Search(word string) bool {
+    node := t.root
+    for _, c := range word {
+        if _, ok := node.children[c]; !ok {
+            return false
+        }
+        node = node.children[c]
+    }
+    return node.isEnd
+}
+
+func (t *Trie) StartsWith(prefix string) bool {
+    node := t.root
+    for _, c := range prefix {
+        if _, ok := node.children[c]; !ok {
+            return false
+        }
+        node = node.children[c]
+    }
+    return true
+}`,
+    },
+  },
 }


### PR DESCRIPTION
What changed?

Added a new Trie (Prefix Tree) tab to the Abstract Data Types page, following the same pattern as the existing Disjoint Set Union visualizer. Three files were changed: a new TrieIV.jsx component with interactive insert, search, and startsWith visualization; a new trie entry in adtSources.js with reference implementations in JavaScript, Python, C++, Java, C, Rust, and Go; and DSLayout.jsx wired up with the new tab, activeCode case, title, and render.

Why is this needed?

The Abstract Data Types page was missing a Trie visualizer despite it being one of the most commonly taught data structures for autocomplete, spell-check, and prefix-search use cases. 

Closes #788

Type of Change

- [x]  feat - New user-facing feature or algorithm capability
- [ ]  fix - Bug fix or regression fix
- [ ]  docs - Documentation-only change
- [ ]  style - Formatting or styling change with no behavior change
- [ ]  refactor - Code restructuring with no feature or bug-fix behavior change
- [ ]  perf - Performance improvement
- [ ]  test - Test coverage or test infrastructure change
- [ ]  build - Build system, dependency, or packaging change
- [ ]  ci - GitHub Actions, Docker, Vercel, or release automation change
- [ ]  chore - Maintenance change that does not affect users
- [ ]  revert - Reverts a previous change

Release Notes

Release note category:

- [x]  Added
- [ ]  Changed
- [ ]  Fixed
- [ ]  Removed
- [ ]  Deprecated
- [ ]  Security
- [ ]  Not required

Release note entry:

Added Trie (Prefix Tree) visualizer to the Abstract Data Types page with interactive insert, search, and startsWith operations, animated path highlighting, and reference code in 7 languages

Testing and Verification

 

- [x] npm ci or npm install
- [ ]  npm run format:check
- [ ]  npm run lint
- [ ]  npm run build
- [ x]  Manual browser testing at http://localhost:5173
- [ x]  Responsive testing for affected views
- [ x]  No new console errors or warnings

Skipped or additional testing notes:
Skipped npm run format:check, npm run lint, and npm run build — will verify if CI flags anything.

UI Evidence

Before: No Trie tab existed on the Abstract Data Types page.
After:
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/43303f0c-deb1-4f31-a1f3-819e2675202d" />
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/0f23ffb1-262e-4dfa-9b23-cde93ae09413" />
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/6866bc67-d453-4104-abf7-c1bd186082d7" />
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/e73d7e14-c1a6-4409-89b3-7461dcb2af4a" />
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/0fe28fbe-11da-4400-b229-76c9295798e7" />
<img width="1686" height="967" alt="image" src="https://github.com/user-attachments/assets/238eefe2-a27b-4576-89f1-080309270447" />

The following screenshots demonstrate the complete Trie visualizer in action:

1. **Empty state** — Trie tab visible in the tab row with empty state message and dropdown showing all 3 operations (Insert, Search, StartsWith)
2. **StartsWith operation** — `startsWith("ba")` returning `Prefix "ba" exists in Trie ✓` with highlighted path
3. **Search — not found** — `search("xyz")` returning `"xyz" not found in Trie ✗` in red
4. **Search — empty state reset** — clean reset working correctly after operations
5. **Insert operation** — `insert("cat")` updating the tree with cyan highlighted path and `"cat" inserted into Trie` in the result panel
6. **Code panel** — `Trie (Prefix Tree) Implementation` showing correct JavaScript reference code with language switcher

CI/CD and Deployment Impact:

- [x]  No deployment impact expected
- [ ]  Updates GitHub Actions or release automation
- [ ]  Updates Docker build/runtime behavior
- [ ]  Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ]  Adds or changes environment variables
- [ ]  Adds, removes, or updates npm dependencies
- [ ]  Requires maintainer follow-up after merge

Reviewer Checklist

- [x]  PR title follows Conventional Commits and matches the selected change type
- [x]  Scope is focused and unrelated changes are excluded
- [x]  Release note category and entry are accurate
- [ ]  CI checks are expected to pass: format, lint, and build
- [x]  UI evidence is included when user-facing screens changed
- [ ]  Documentation is updated when behavior, setup, or deployment changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Trie (Prefix Tree)** visualization tab to the data structures layout.
  * Introduced an interactive Trie visualizer that lets users **insert words**, **search exact words**, and **check prefixes**, with node-level highlighting and an “END” marker.
  * Displays an empty-state before use, plus an info panel showing the **last result** and **inserted words**.
  * Added **multi-language** Trie reference code examples for the tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->