### PR TITLE
feat: add Hash Table (HashMap) visualizer to Abstract Data Types

### DIFF
--- a/src/components/dataStructures/DSLayout.jsx
+++ b/src/components/dataStructures/DSLayout.jsx
@@ -8,6 +8,7 @@ import BinaryHeapIV from './binaryHeapIV'
 import PriorityQueueIV from './priorityQueueIV'
 import DSUIV from './dsuIV'
 import TrieIV from './TrieIV'
+import HashTableIV from './HashTableIV'
 import LinkedListIV from './LinkedListIV'
 import CodePanel from '../visualizer/CodePanel'
 import { adtSources } from './adtSources'
@@ -23,6 +24,7 @@ const tabs = [
   { id: 'linked-list', label: 'Linked List' },
   { id: 'graph', label: 'Graph Builder' },
   { id: 'trie', label: 'Trie' },
+  { id: 'hash-table', label: 'Hash Table' },
 ]
 
 export const DSLayout = () => {
@@ -134,6 +136,9 @@ export const DSLayout = () => {
     if (activeTab === 'trie') {
       return adtSources.trie?.['prefix tree']?.[selectedLang] || ''
     }
+    if (activeTab === 'hash-table') {
+      return adtSources.hashTable?.['hash map']?.[selectedLang] || ''
+    }
 
     return ''
   }, [activeTab, selectedLang, stackMode, treeTraversal])
@@ -147,6 +152,7 @@ export const DSLayout = () => {
     if (activeTab === 'dsu') return 'Disjoint Set Union'
     if (activeTab === 'linked-list') return 'Singly Linked List'
     if (activeTab === 'trie') return 'Trie (Prefix Tree)'
+    if (activeTab === 'hash-table') return 'Hash Table (HashMap)'
     return 'Queue'
   }
 
@@ -229,6 +235,7 @@ export const DSLayout = () => {
         {activeTab === 'linked-list' && mode === 'solo' && <LinkedListIV />}
 
         {activeTab === 'trie' && mode === 'solo' && <TrieIV />}
+        {activeTab === 'hash-table' && mode === 'solo' && <HashTableIV />}
 
         {activeTab === 'graph' && (
           <div className="flex items-center justify-center min-h-[300px] text-slate-500">

--- a/src/components/dataStructures/HashTableIV.jsx
+++ b/src/components/dataStructures/HashTableIV.jsx
@@ -1,0 +1,375 @@
+import { useState, useCallback, useRef } from 'react'
+
+const TABLE_SIZE = 11
+
+class HashNode {
+  constructor(key, value) {
+    this.key = key
+    this.value = value
+    this.next = null
+  }
+}
+
+class HashTable {
+  constructor(size = TABLE_SIZE) {
+    this.size = size
+    this.buckets = Array(size).fill(null)
+    this.count = 0
+  }
+
+  hash(key) {
+    let hash = 0
+    for (let i = 0; i < key.length; i++) {
+      hash = (hash + key.charCodeAt(i)) % this.size
+    }
+    return hash
+  }
+
+  insert(key, value) {
+    const index = this.hash(key)
+    let node = this.buckets[index]
+    while (node) {
+      if (node.key === key) {
+        node.value = value
+        return { index, updated: true }
+      }
+      node = node.next
+    }
+    const newNode = new HashNode(key, value)
+    newNode.next = this.buckets[index]
+    this.buckets[index] = newNode
+    this.count++
+    return { index, updated: false }
+  }
+
+  search(key) {
+    const index = this.hash(key)
+    let node = this.buckets[index]
+    while (node) {
+      if (node.key === key) return { found: true, index, value: node.value }
+      node = node.next
+    }
+    return { found: false, index, value: null }
+  }
+
+  delete(key) {
+    const index = this.hash(key)
+    let node = this.buckets[index]
+    let prev = null
+    while (node) {
+      if (node.key === key) {
+        if (prev) prev.next = node.next
+        else this.buckets[index] = node.next
+        this.count--
+        return { deleted: true, index }
+      }
+      prev = node
+      node = node.next
+    }
+    return { deleted: false, index }
+  }
+
+  toJSON() {
+    return {
+      size: this.size,
+      count: this.count,
+      buckets: this.buckets.map((node) => {
+        const chain = []
+        let cur = node
+        while (cur) {
+          chain.push({ key: cur.key, value: cur.value })
+          cur = cur.next
+        }
+        return chain
+      }),
+    }
+  }
+}
+
+function getLoadFactorColor(lf) {
+  if (lf < 0.5) return 'text-green-400'
+  if (lf < 0.75) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+export default function HashTableIV() {
+  const tableRef = useRef(new HashTable())
+  const [snapshot, setSnapshot] = useState(() => new HashTable().toJSON())
+  const [keyInput, setKeyInput] = useState('')
+  const [valueInput, setValueInput] = useState('')
+  const [operation, setOperation] = useState('insert')
+  const [result, setResult] = useState(null)
+  const [highlightIndex, setHighlightIndex] = useState(null)
+
+  const refresh = useCallback(() => {
+    setSnapshot(tableRef.current.toJSON())
+  }, [])
+
+  const handleReset = () => {
+    tableRef.current = new HashTable()
+    setSnapshot(new HashTable().toJSON())
+    setResult(null)
+    setHighlightIndex(null)
+    setKeyInput('')
+    setValueInput('')
+  }
+
+  const handleSample = () => {
+    tableRef.current = new HashTable()
+    const samples = [
+      ['name', 'Alice'],
+      ['age', '25'],
+      ['city', 'Delhi'],
+      ['lang', 'JS'],
+      ['role', 'Dev'],
+    ]
+    samples.forEach(([k, v]) => tableRef.current.insert(k, v))
+    refresh()
+    setResult(null)
+    setHighlightIndex(null)
+  }
+
+  const handleRun = () => {
+    const key = keyInput.trim()
+    const value = valueInput.trim()
+    if (!key) return
+
+    if (operation === 'insert') {
+      if (!value) return
+      const { index, updated } = tableRef.current.insert(key, value)
+      refresh()
+      setHighlightIndex(index)
+      setResult({
+        type: 'insert',
+        message: updated
+          ? `"${key}" updated to "${value}" at bucket ${index}`
+          : `"${key}" → "${value}" inserted at bucket ${index}`,
+      })
+    } else if (operation === 'search') {
+      const { found, index, value: val } = tableRef.current.search(key)
+      setHighlightIndex(index)
+      setResult({
+        type: found ? 'success' : 'fail',
+        message: found
+          ? `"${key}" found at bucket ${index} → value: "${val}" ✓`
+          : `"${key}" not found in Hash Table ✗`,
+      })
+    } else if (operation === 'delete') {
+      const { deleted, index } = tableRef.current.delete(key)
+      refresh()
+      setHighlightIndex(index)
+      setResult({
+        type: deleted ? 'success' : 'fail',
+        message: deleted
+          ? `"${key}" deleted from bucket ${index} ✓`
+          : `"${key}" not found, nothing deleted ✗`,
+      })
+    }
+  }
+
+  const loadFactor = snapshot.count / snapshot.size
+  const loadFactorColor = getLoadFactorColor(loadFactor)
+
+  return (
+    <div className="flex flex-col gap-4 text-slate-200 min-h-[400px]">
+      {/* Controls */}
+      <div className="flex flex-wrap gap-2 items-center p-3 bg-slate-900/60 rounded-xl border border-slate-700">
+        <select
+          value={operation}
+          onChange={(e) => setOperation(e.target.value)}
+          className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-white text-sm outline-none focus:border-cyan-500"
+        >
+          <option value="insert">Insert</option>
+          <option value="search">Search</option>
+          <option value="delete">Delete</option>
+        </select>
+
+        <input
+          type="text"
+          value={keyInput}
+          onChange={(e) => setKeyInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleRun()}
+          placeholder="Key..."
+          className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-white text-sm outline-none focus:border-cyan-500 w-28"
+        />
+
+        {operation === 'insert' && (
+          <input
+            type="text"
+            value={valueInput}
+            onChange={(e) => setValueInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRun()}
+            placeholder="Value..."
+            className="bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-white text-sm outline-none focus:border-cyan-500 w-28"
+          />
+        )}
+
+        <button
+          onClick={handleRun}
+          className="px-3 py-1.5 bg-cyan-600 hover:bg-cyan-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Run
+        </button>
+
+        <div className="w-px h-6 bg-slate-600" />
+
+        <button
+          onClick={handleSample}
+          className="px-3 py-1.5 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Sample
+        </button>
+
+        <button
+          onClick={handleReset}
+          className="px-3 py-1.5 bg-red-600 hover:bg-red-500 text-white font-bold rounded-lg text-sm transition-colors"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-3 flex-1 min-h-[350px]">
+        {/* Hash Table Visualization */}
+        <div className="lg:col-span-3 bg-slate-800/50 rounded-xl border border-slate-700 p-4 overflow-auto">
+          {snapshot.count === 0 ? (
+            <div className="text-slate-400 text-center py-20">
+              <p>Hash Table is empty</p>
+              <p className="text-sm mt-2">
+                Insert a key-value pair or click Sample to begin
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {snapshot.buckets.map((chain, i) => (
+                <div
+                  key={i}
+                  className={`flex items-center gap-2 rounded-lg px-3 py-2 transition-all duration-300 ${
+                    highlightIndex === i
+                      ? 'bg-cyan-500/20 border border-cyan-500/50'
+                      : 'bg-slate-900/40 border border-slate-700/50'
+                  }`}
+                >
+                  {/* Index */}
+                  <div
+                    className={`w-7 h-7 rounded-md flex items-center justify-center font-mono font-bold text-xs flex-shrink-0 ${
+                      highlightIndex === i
+                        ? 'bg-cyan-500 text-white'
+                        : 'bg-slate-700 text-slate-300'
+                    }`}
+                  >
+                    {i}
+                  </div>
+
+                  {/* Bucket arrow */}
+                  <div className="text-slate-500 text-xs font-mono">→</div>
+
+                  {/* Chain */}
+                  {chain.length === 0 ? (
+                    <div className="text-slate-600 text-xs font-mono">null</div>
+                  ) : (
+                    <div className="flex items-center gap-1 flex-wrap">
+                      {chain.map((node, j) => (
+                        <div key={j} className="flex items-center gap-1">
+                          <div className="flex items-center gap-1 bg-slate-700 border border-slate-600 rounded-lg px-2 py-1">
+                            <span className="text-cyan-400 font-mono text-xs font-bold">
+                              {node.key}
+                            </span>
+                            <span className="text-slate-500 text-xs">:</span>
+                            <span className="text-green-400 font-mono text-xs">
+                              {node.value}
+                            </span>
+                          </div>
+                          {j < chain.length - 1 && (
+                            <span className="text-slate-500 text-xs font-mono">
+                              →
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                      <span className="text-slate-600 text-xs font-mono">
+                        → null
+                      </span>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Info Panel */}
+        <div className="space-y-3">
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">
+              Last Result
+            </div>
+            {result ? (
+              <div
+                className={`font-mono text-xs whitespace-pre-wrap ${
+                  result.type === 'insert'
+                    ? 'text-cyan-400'
+                    : result.type === 'success'
+                      ? 'text-green-400'
+                      : 'text-red-400'
+                }`}
+              >
+                {result.message}
+              </div>
+            ) : (
+              <div className="text-slate-500 text-xs">No operations yet</div>
+            )}
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">Stats</div>
+            <div className="space-y-1 text-xs">
+              <div className="flex justify-between">
+                <span className="text-slate-400">Table Size</span>
+                <span className="text-white font-mono">{snapshot.size}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-slate-400">Items</span>
+                <span className="text-white font-mono">{snapshot.count}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-slate-400">Load Factor</span>
+                <span className={`font-mono font-bold ${loadFactorColor}`}>
+                  {loadFactor.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">
+              Hash Function
+            </div>
+            <div className="font-mono text-xs text-slate-300 bg-slate-900/60 rounded p-2">
+              {`hash(key) =\nΣ charCode(c)\n% ${snapshot.size}`}
+            </div>
+          </div>
+
+          <div className="bg-slate-800/50 rounded-xl border border-slate-700 p-3">
+            <div className="text-cyan-400 font-bold text-xs mb-2">Legend</div>
+            <div className="space-y-1.5 text-xs">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-slate-700 border border-slate-600" />
+                <span className="text-slate-400">Empty bucket</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-slate-700 border border-slate-600 flex items-center justify-center">
+                  <div className="w-2 h-2 rounded-sm bg-green-400" />
+                </div>
+                <span className="text-slate-400">Occupied bucket</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-cyan-500/20 border border-cyan-500/50" />
+                <span className="text-slate-400">Active bucket</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dataStructures/adtSources.js
+++ b/src/components/dataStructures/adtSources.js
@@ -1737,7 +1737,418 @@ func (t *Trie) StartsWith(prefix string) bool {
         }
         node = node.children[c]
     }
-    return true
+ return true
+}`,
+    },
+  },
+  hashTable: {
+    'hash map': {
+      javascript: `class HashNode {
+  constructor(key, value) {
+    this.key = key;
+    this.value = value;
+    this.next = null;
+  }
+}
+
+class HashTable {
+  constructor(size = 11) {
+    this.size = size;
+    this.buckets = Array(size).fill(null);
+    this.count = 0;
+  }
+
+  hash(key) {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+      hash = (hash + key.charCodeAt(i)) % this.size;
+    }
+    return hash;
+  }
+
+  insert(key, value) {
+    const index = this.hash(key);
+    let node = this.buckets[index];
+    while (node) {
+      if (node.key === key) { node.value = value; return; }
+      node = node.next;
+    }
+    const newNode = new HashNode(key, value);
+    newNode.next = this.buckets[index];
+    this.buckets[index] = newNode;
+    this.count++;
+  }
+
+  search(key) {
+    const index = this.hash(key);
+    let node = this.buckets[index];
+    while (node) {
+      if (node.key === key) return node.value;
+      node = node.next;
+    }
+    return null;
+  }
+
+  delete(key) {
+    const index = this.hash(key);
+    let node = this.buckets[index], prev = null;
+    while (node) {
+      if (node.key === key) {
+        if (prev) prev.next = node.next;
+        else this.buckets[index] = node.next;
+        this.count--;
+        return true;
+      }
+      prev = node;
+      node = node.next;
+    }
+    return false;
+  }
+}`,
+      python: `class HashNode:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self.next = None
+
+class HashTable:
+    def __init__(self, size=11):
+        self.size = size
+        self.buckets = [None] * size
+        self.count = 0
+
+    def _hash(self, key):
+        return sum(ord(c) for c in key) % self.size
+
+    def insert(self, key, value):
+        index = self._hash(key)
+        node = self.buckets[index]
+        while node:
+            if node.key == key:
+                node.value = value
+                return
+            node = node.next
+        new_node = HashNode(key, value)
+        new_node.next = self.buckets[index]
+        self.buckets[index] = new_node
+        self.count += 1
+
+    def search(self, key):
+        index = self._hash(key)
+        node = self.buckets[index]
+        while node:
+            if node.key == key:
+                return node.value
+            node = node.next
+        return None
+
+    def delete(self, key):
+        index = self._hash(key)
+        node = self.buckets[index]
+        prev = None
+        while node:
+            if node.key == key:
+                if prev:
+                    prev.next = node.next
+                else:
+                    self.buckets[index] = node.next
+                self.count -= 1
+                return True
+            prev = node
+            node = node.next
+        return False`,
+      cpp: `#include <string>
+using namespace std;
+
+struct HashNode {
+    string key, value;
+    HashNode* next;
+    HashNode(string k, string v) : key(k), value(v), next(nullptr) {}
+};
+
+class HashTable {
+    int size;
+    HashNode** buckets;
+    int count;
+
+    int hash(const string& key) {
+        int h = 0;
+        for (char c : key) h = (h + c) % size;
+        return h;
+    }
+
+public:
+    HashTable(int size = 11) : size(size), count(0) {
+        buckets = new HashNode*[size]();
+    }
+
+    void insert(const string& key, const string& value) {
+        int idx = hash(key);
+        HashNode* node = buckets[idx];
+        while (node) {
+            if (node->key == key) { node->value = value; return; }
+            node = node->next;
+        }
+        HashNode* newNode = new HashNode(key, value);
+        newNode->next = buckets[idx];
+        buckets[idx] = newNode;
+        count++;
+    }
+
+    string search(const string& key) {
+        int idx = hash(key);
+        HashNode* node = buckets[idx];
+        while (node) {
+            if (node->key == key) return node->value;
+            node = node->next;
+        }
+        return "";
+    }
+
+    bool deleteKey(const string& key) {
+        int idx = hash(key);
+        HashNode* node = buckets[idx];
+        HashNode* prev = nullptr;
+        while (node) {
+            if (node->key == key) {
+                if (prev) prev->next = node->next;
+                else buckets[idx] = node->next;
+                delete node;
+                count--;
+                return true;
+            }
+            prev = node;
+            node = node->next;
+        }
+        return false;
+    }
+};`,
+      java: `import java.util.LinkedList;
+
+class HashTable<K, V> {
+    private static class Entry<K, V> {
+        K key; V value;
+        Entry(K k, V v) { key = k; value = v; }
+    }
+
+    private final int size;
+    private final LinkedList<Entry<K, V>>[] buckets;
+    private int count;
+
+    @SuppressWarnings("unchecked")
+    public HashTable(int size) {
+        this.size = size;
+        buckets = new LinkedList[size];
+        for (int i = 0; i < size; i++)
+            buckets[i] = new LinkedList<>();
+    }
+
+    private int hash(K key) {
+        int h = 0;
+        for (char c : key.toString().toCharArray())
+            h = (h + c) % size;
+        return h;
+    }
+
+    public void insert(K key, V value) {
+        int idx = hash(key);
+        for (Entry<K, V> e : buckets[idx]) {
+            if (e.key.equals(key)) { e.value = value; return; }
+        }
+        buckets[idx].addFirst(new Entry<>(key, value));
+        count++;
+    }
+
+    public V search(K key) {
+        for (Entry<K, V> e : buckets[hash(key)])
+            if (e.key.equals(key)) return e.value;
+        return null;
+    }
+
+    public boolean delete(K key) {
+        int idx = hash(key);
+        for (Entry<K, V> e : buckets[idx]) {
+            if (e.key.equals(key)) {
+                buckets[idx].remove(e);
+                count--;
+                return true;
+            }
+        }
+        return false;
+    }
+}`,
+      c: `#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SIZE 11
+
+typedef struct HashNode {
+    char key[64];
+    char value[64];
+    struct HashNode* next;
+} HashNode;
+
+typedef struct {
+    HashNode* buckets[SIZE];
+    int count;
+} HashTable;
+
+static int hash(const char* key) {
+    int h = 0;
+    for (int i = 0; key[i]; i++)
+        h = (h + (unsigned char)key[i]) % SIZE;
+    return h;
+}
+
+void insert(HashTable* ht, const char* key, const char* value) {
+    int idx = hash(key);
+    HashNode* node = ht->buckets[idx];
+    while (node) {
+        if (strcmp(node->key, key) == 0) {
+            strncpy(node->value, value, 63);
+            return;
+        }
+        node = node->next;
+    }
+    HashNode* newNode = calloc(1, sizeof(HashNode));
+    strncpy(newNode->key, key, 63);
+    strncpy(newNode->value, value, 63);
+    newNode->next = ht->buckets[idx];
+    ht->buckets[idx] = newNode;
+    ht->count++;
+}
+
+const char* search(HashTable* ht, const char* key) {
+    int idx = hash(key);
+    HashNode* node = ht->buckets[idx];
+    while (node) {
+        if (strcmp(node->key, key) == 0) return node->value;
+        node = node->next;
+    }
+    return NULL;
+}
+
+int deleteKey(HashTable* ht, const char* key) {
+    int idx = hash(key);
+    HashNode* node = ht->buckets[idx];
+    HashNode* prev = NULL;
+    while (node) {
+        if (strcmp(node->key, key) == 0) {
+            if (prev) prev->next = node->next;
+            else ht->buckets[idx] = node->next;
+            free(node);
+            ht->count--;
+            return 1;
+        }
+        prev = node;
+        node = node->next;
+    }
+    return 0;
+}`,
+      rust: `use std::collections::LinkedList;
+
+struct Entry {
+    key: String,
+    value: String,
+}
+
+struct HashTable {
+    size: usize,
+    buckets: Vec<LinkedList<Entry>>,
+    count: usize,
+}
+
+impl HashTable {
+    fn new(size: usize) -> Self {
+        let mut buckets = Vec::with_capacity(size);
+        for _ in 0..size { buckets.push(LinkedList::new()); }
+        HashTable { size, buckets, count: 0 }
+    }
+
+    fn hash(&self, key: &str) -> usize {
+        key.chars().fold(0usize, |acc, c| (acc + c as usize) % self.size)
+    }
+
+    fn insert(&mut self, key: String, value: String) {
+        let idx = self.hash(&key);
+        for entry in &mut self.buckets[idx] {
+            if entry.key == key { entry.value = value; return; }
+        }
+        self.buckets[idx].push_front(Entry { key, value });
+        self.count += 1;
+    }
+
+    fn search(&self, key: &str) -> Option<&str> {
+        let idx = self.hash(key);
+        for entry in &self.buckets[idx] {
+            if entry.key == key { return Some(&entry.value); }
+        }
+        None
+    }
+
+    fn delete(&mut self, key: &str) -> bool {
+        let idx = self.hash(key);
+        let before = self.buckets[idx].len();
+        self.buckets[idx].retain(|e| e.key != key);
+        let deleted = self.buckets[idx].len() < before;
+        if deleted { self.count -= 1; }
+        deleted
+    }
+}`,
+      go: `package main
+
+type Entry struct {
+    key, value string
+    next       *Entry
+}
+
+type HashTable struct {
+    size    int
+    buckets []*Entry
+    count   int
+}
+
+func NewHashTable(size int) *HashTable {
+    return &HashTable{size: size, buckets: make([]*Entry, size)}
+}
+
+func (ht *HashTable) hash(key string) int {
+    h := 0
+    for _, c := range key {
+        h = (h + int(c)) % ht.size
+    }
+    return h
+}
+
+func (ht *HashTable) Insert(key, value string) {
+    idx := ht.hash(key)
+    for node := ht.buckets[idx]; node != nil; node = node.next {
+        if node.key == key { node.value = value; return }
+    }
+    ht.buckets[idx] = &Entry{key, value, ht.buckets[idx]}
+    ht.count++
+}
+
+func (ht *HashTable) Search(key string) (string, bool) {
+    for node := ht.buckets[ht.hash(key)]; node != nil; node = node.next {
+        if node.key == key { return node.value, true }
+    }
+    return "", false
+}
+
+func (ht *HashTable) Delete(key string) bool {
+    idx := ht.hash(key)
+    var prev *Entry
+    for node := ht.buckets[idx]; node != nil; node = node.next {
+        if node.key == key {
+            if prev != nil { prev.next = node.next } else { ht.buckets[idx] = node.next }
+            ht.count--
+            return true
+        }
+        prev = node
+    }
+    return false
 }`,
     },
   },


### PR DESCRIPTION
### What changed?
Added a new **Hash Table (HashMap)** tab to the Abstract Data Types page following the same pattern as the existing Trie and DSU visualizers. Three files were changed: a new `HashTableIV.jsx` component with interactive Insert, Search, and Delete operations with chaining collision handling; a new `hashTable` entry in `adtSources.js` with reference implementations in 7 languages (JavaScript, Python, C++, Java, C, Rust, Go); and `DSLayout.jsx` wired up with the new tab, activeCode case, title, and render.

### Why is this needed?
Closes #792

## Type of Change
- [x] `feat` - New user-facing feature or algorithm capability
- [ ] `fix` - Bug fix or regression fix
- [ ] `docs` - Documentation-only change
- [ ] `style` - Formatting or styling change with no behavior change
- [ ] `refactor` - Code restructuring with no feature or bug-fix behavior change
- [ ] `perf` - Performance improvement
- [ ] `test` - Test coverage or test infrastructure change
- [ ] `build` - Build system, dependency, or packaging change
- [ ] `ci` - GitHub Actions, Docker, Vercel, or release automation change
- [ ] `chore` - Maintenance change that does not affect users
- [ ] `revert` - Reverts a previous change

## Release Notes

Release note category:
- [x] Added
- [ ] Changed
- [ ] Fixed
- [ ] Removed
- [ ] Deprecated
- [ ] Security
- [ ] Not required

Release note entry:
- Added Hash Table (HashMap) visualizer to the Abstract Data Types page with interactive Insert, Search, and Delete operations, chaining collision handling, real-time load factor tracking, and reference code in 7 languages

## Testing and Verification
- [x] `npm ci` or `npm install`
- [ ] `npm run format:check`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Manual browser testing at `http://localhost:5173`
- [x] Responsive testing for affected views
- [x] No new console errors or warnings

Skipped or additional testing notes:
Ran `npx prettier --write .`, `npm run format:check`, and `npm run lint` locally — all passed with zero errors before committing.

## UI Evidence

**Before:** No Hash Table tab existed on the Abstract Data Types page.

**After:** 
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 49 19 PM" src="https://github.com/user-attachments/assets/7269db8b-363b-4515-ba43-4be0d9f0b959" />
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 48 33 PM" src="https://github.com/user-attachments/assets/0883259b-2a0c-4546-bed9-62ef32232918" />
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 48 23 PM" src="https://github.com/user-attachments/assets/f84ec6f8-9cff-4a91-9a4f-9d3b0ea05b62" />
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 48 12 PM" src="https://github.com/user-attachments/assets/773b3cd9-8be6-4c1b-a1d7-b9daadbb5b93" />
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 47 33 PM" src="https://github.com/user-attachments/assets/aeeb61ce-39c9-4ec9-968e-5155ed9fc749" />
<img width="1691" height="1023" alt="Screenshot 2026-07-26 at 12 47 22 PM" src="https://github.com/user-attachments/assets/2d217007-a4f3-460a-9217-789bf7543556" />


## CI/CD and Deployment Impact
- [x] No deployment impact expected
- [ ] Updates GitHub Actions or release automation
- [ ] Updates Docker build/runtime behavior
- [ ] Updates Vercel, Nginx, redirects, or client-side routing behavior
- [ ] Adds or changes environment variables
- [ ] Adds, removes, or updates npm dependencies
- [ ] Requires maintainer follow-up after merge

## Reviewer Checklist
- [x] PR title follows Conventional Commits and matches the selected change type
- [x] Scope is focused and unrelated changes are excluded
- [x] Release note category and entry are accurate
- [ ] CI checks are expected to pass: format, lint, and build
- [x] UI evidence is included when user-facing screens changed
- [ ] Documentation is updated when behavior, setup, or deployment changed